### PR TITLE
chore: add contribution scaffolding

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,32 @@
+name: Bug report
+description: Something behaved differently from what the docs say
+labels: ["bug"]
+body:
+  - type: textarea
+    id: what
+    attributes:
+      label: What happened
+      description: Command run, output, exit code. Paste rather than summarise.
+      render: shell
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: What you expected
+    validations:
+      required: true
+  - type: input
+    id: version
+    attributes:
+      label: Commit
+      description: Output of `git rev-parse --short HEAD`
+    validations:
+      required: true
+  - type: input
+    id: env
+    attributes:
+      label: OS, Python, agent host
+      placeholder: macOS 15.2, Python 3.11.9, Claude Code
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: true

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,20 @@
+name: Feature request
+description: Something the harness should do and does not
+labels: ["enhancement"]
+body:
+  - type: textarea
+    id: problem
+    attributes:
+      label: The problem
+      description: What you were trying to do when you hit this. Skip the solution for now.
+    validations:
+      required: true
+  - type: textarea
+    id: idea
+    attributes:
+      label: What you have in mind
+      description: Optional. A rough shape is fine.
+  - type: textarea
+    id: workaround
+    attributes:
+      label: What you do instead today

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,21 @@
+## Summary
+
+What changed, and what made it necessary.
+
+## Testing
+
+- [ ] `PYTHONPATH=src python3 -m pytest tests -q` — paste the count
+- [ ] A test that fails without this change, or a note on why none was needed
+- [ ] New files staged before running any scan. The scanners read tracked files, so an unstaged addition is invisible to them and the run comes back green without having looked at it.
+
+## Review
+
+If you ran a review, automated or otherwise, say what it flagged and what you did. Say which findings you reproduced yourself. A review is a claim until it is measured.
+
+## Template impact
+
+Does this touch `master-ops/`? Generated operations repositories are copies made at onboarding and do not pick up template changes. Say what an existing install has to do. Otherwise write `none`.
+
+## Notes
+
+Platform, follow-up work, anything a reviewer should know.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -16,6 +16,8 @@ If you ran a review, automated or otherwise, say what it flagged and what you di
 
 Does this touch `master-ops/`? Generated operations repositories are copies made at onboarding and do not pick up template changes. Say what an existing install has to do. Otherwise write `none`.
 
+If it does touch `master-ops/`, raise `master-ops/TEMPLATE-VERSION` and add an entry to `master-ops/CHANGELOG.md`. Without that, installs on different template states all report the same version and the version stops meaning anything.
+
 ## Notes
 
 Platform, follow-up work, anything a reviewer should know.

--- a/.redaction-inventory-baseline
+++ b/.redaction-inventory-baseline
@@ -175,7 +175,6 @@ long-term
 longest-path
 ls-files
 machine-readable
-macos-latest
 master-bootstrap-live
 master-dispatched
 master-lifecycle
@@ -290,7 +289,6 @@ pty-u8-shadow
 pty-u9
 public-release
 pytest
-python-version
 python3
 re-admitted
 re-admitting
@@ -336,7 +334,6 @@ rows
 rule-a
 rules
 runner
-runs-on
 runtime-issued
 same-marker
 same-session

--- a/.redaction-inventory-baseline
+++ b/.redaction-inventory-baseline
@@ -175,6 +175,7 @@ long-term
 longest-path
 ls-files
 machine-readable
+macos-latest
 master-bootstrap-live
 master-dispatched
 master-lifecycle
@@ -289,6 +290,7 @@ pty-u8-shadow
 pty-u9
 public-release
 pytest
+python-version
 python3
 re-admitted
 re-admitting
@@ -334,6 +336,7 @@ rows
 rule-a
 rules
 runner
+runs-on
 runtime-issued
 same-marker
 same-session

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,7 +8,7 @@ Small repository, one maintainer. Issues and pull requests are both welcome.
 $ PYTHONPATH=src python3 -m pytest tests -q
 ```
 
-Standard library only. Nothing to install. CI runs the same command on macOS.
+Standard library only. Nothing to install. There is no CI yet, so run this before opening a pull request and paste the count.
 
 ## What gets merged
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,52 @@
+# Contributing
+
+Small repository, one maintainer. Issues and pull requests are both welcome.
+
+## Running it
+
+```console
+$ PYTHONPATH=src python3 -m pytest tests -q
+```
+
+Standard library only. Nothing to install. CI runs the same command on macOS.
+
+## What gets merged
+
+A change with a test that fails without it. If a test does not make sense for
+the change, say so in the pull request and why.
+
+Documentation changes need no test. Say what was wrong with the old wording.
+
+## Things worth knowing before you start
+
+**Exit codes carry meaning here.** Several scripts use 0 for a clean result, 1
+for a finding, and 2 for "could not decide". An unhandled exception exits 1,
+which reads as a finding, so a crash and a verdict look the same to a caller.
+When you add a failure path, make sure it lands on 2. Most of the review
+findings on this repository so far have been instances of that one mistake.
+
+**The redaction scanners read tracked files.** An unstaged new file is
+invisible to them, and the run comes back green without having looked at it.
+Stage first, then scan. These run locally before publishing, not in CI.
+
+**`master-ops/` is a template**, copied into a user's own operations repository
+during onboarding. It is not documentation about this repository. Changes there
+reach new installations only. Existing ones are copies and do not update.
+
+**Capture exit codes directly.** `out=$(cmd 2>&1); rc=$?` rather than through a
+pipe, where `$?` belongs to the last command in the pipeline.
+
+## Scope
+
+This repository owns workspace-level orchestration: roles, succession, worker
+dispatch, lineage. Repository-local rules, hooks, and runbooks belong to
+[mogui-agent-harness](https://github.com/baksohyeon/mogui-agent-harness).
+
+Supported platform is macOS. The master has only been run under Claude Code.
+Other hosts and platforms should work and have not been tried, so reports from
+anyone who does are useful.
+
+## Commits
+
+Conventional commits, English. `feat(scope):`, `fix(scope):`, `docs(scope):`.
+Say what changed and what made it necessary. Pull requests are squashed.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,7 +8,9 @@ Small repository, one maintainer. Issues and pull requests are both welcome.
 $ PYTHONPATH=src python3 -m pytest tests -q
 ```
 
-Standard library only. Nothing to install. There is no CI yet, so run this before opening a pull request and paste the count.
+The runtime is standard library only. The test run needs pytest (`python3 -m pip install pytest`).
+
+There is no CI yet, so run this before opening a pull request. Name the test that fails without your change, or say why none was needed. A passing count on its own says nothing: it is the same number on every branch that adds no test.
 
 ## What gets merged
 
@@ -22,12 +24,19 @@ Documentation changes need no test. Say what was wrong with the old wording.
 **Exit codes carry meaning here.** Several scripts use 0 for a clean result, 1
 for a finding, and 2 for "could not decide". An unhandled exception exits 1,
 which reads as a finding, so a crash and a verdict look the same to a caller.
-When you add a failure path, make sure it lands on 2. Most of the review
-findings on this repository so far have been instances of that one mistake.
+When you add a failure path, make sure it lands on 2. That single mistake is
+the largest class of review findings this repository has had.
+
+`redaction-scan.sh` is an exception it declares in its own header: it folds a
+usage or tool error into 1. Read each script's codes rather than assuming.
 
 **The redaction scanners read tracked files.** An unstaged new file is
 invisible to them, and the run comes back green without having looked at it.
 Stage first, then scan. These run locally before publishing, not in CI.
+
+`redaction-inventory` also skips binary files, judged by a NUL byte in the
+first 8 KB. That is a heuristic and it is silent: the output still says the
+scope was every tracked file.
 
 **`master-ops/` is a template**, copied into a user's own operations repository
 during onboarding. It is not documentation about this repository. Changes there


### PR DESCRIPTION
## Summary

The repository started taking pull requests without anything to receive them with. This borrows the shape from projects that do it well and cuts it to what a one-maintainer repository actually uses.

- `.github/pull_request_template.md`
- `.github/ISSUE_TEMPLATE/` with a bug form and a feature form
- `CONTRIBUTING.md`

Three things in the templates exist because they cost time today rather than because a checklist wanted them.

The staging reminder: both scanners read tracked files, so an unstaged addition is invisible and the run comes back green without having looked at it. That happened twice while writing the specs this repository now ships.

The exit-code note in CONTRIBUTING: 0 clean, 1 finding, 2 undecidable, and an uncaught exception exits 1 into the finding slot. Five of the review findings on the previous pull request were instances of that single mistake.

The template-impact section: `master-ops/` is copied into a user's operations repository at onboarding, so changes there reach new installations only. A contributor has no way to know that.

## Testing

- [x] `PYTHONPATH=src python3 -m pytest tests -q` — 295 passed, 1 skipped
- [x] `redaction-scan.sh --require-extra` — 0 findings, 129 files
- [x] `redaction-inventory` — 0 uncovered candidates
- [x] No test needed. No code path changes.

## Review

Not reviewed by anyone else yet. Text and YAML forms only.

## Template impact

None. Nothing under `master-ops/` changes.

## Notes

**A CI job is missing from this and should follow.** One workflow running pytest on macOS. Pushing `.github/workflows` needs a token scope this account does not currently grant, so it was dropped from the branch rather than blocking it. The reason to add it: a test count in a pull request body is a self-report, and this project's own rule is not to accept those.

The redaction scanners stay out of CI either way. Strict mode needs an organization rules file that does not exist there, and the generic mode emits a warning that makes a green run mean less than it looks.

No CODEOWNERS. One maintainer, so it would only add noise.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add contribution scaffolding to standardize PRs and issues and clarify contributor expectations. Tightens guidance on local testing, scanner behavior, and `master-ops/` versioning; removes CI-only tokens from the redaction baseline.

- **New Features**
  - Added `.github/pull_request_template.md` with Testing, Review, Template impact, and Notes; includes a staging reminder and requires bumping `master-ops/TEMPLATE-VERSION` and `master-ops/CHANGELOG.md` when `master-ops/` changes.
  - Added issue forms in `.github/ISSUE_TEMPLATE/` for bugs and features; bug form requires commit and environment; blank issues allowed.
  - Added `CONTRIBUTING.md` documenting exit codes (0 clean, 1 finding, 2 undecidable; uncaught exceptions exit 1), scanner scope (tracked files only; `redaction-inventory` skips binaries), and that `master-ops/` is a template for new installs.

- **Bug Fixes**
  - Corrected CONTRIBUTING: no CI yet; install `pytest`; ask for the failing test name (or why none); noted `redaction-scan.sh` folds tool errors into exit 1.
  - Trimmed `.redaction-inventory-baseline` to drop CI-only tokens (`macos-latest`, `python-version`, `runs-on`) not present in this branch.

<sup>Written for commit 9bec8f4ae10f02a688fc6dbcd491993e4f4c086a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/baksohyeon/mogui-ADE-orchestrator/pull/3?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

