### PR TITLE
fix(onboarding): wire the tracker to where the master actually stands

### DIFF
--- a/master-ops/ONBOARDING.md
+++ b/master-ops/ONBOARDING.md
@@ -174,20 +174,40 @@ Operational note: in production, a path selector for an unregistered folder fail
 - seed only load-bearing memory pointers and rules
 
 The second item is the one that gets missed. The master's working directory is
-`{{WORKSPACE_ROOT}}`, not the ops repository. A tracker that finds its database
-by looking in the current directory will find nothing there, or find a product
-repository's database and use that instead. Beads behaves this way: it checks
-the current directory only and does not walk upward.
+`{{WORKSPACE_ROOT}}`, or an orchestrator root the user approved instead. Either
+way it is not the ops repository, and the ops repository sits below it.
 
-For that class of tracker, place a link at the workspace root pointing at the
-database inside the ops repository, so the master resolves to the right one
-from where it actually stands.
+Beads resolves from the current directory upward, and stops at a git repository
+root. It never looks downward. Measured on 1.1.0:
+
+| From | Result |
+| --- | --- |
+| two levels below a directory holding `.beads` | resolves to it |
+| a workspace root whose ops repository holds `.beads` | finds nothing |
+| a workspace root with `.beads` one level above it | resolves to the one above |
+| below a git root that has no `.beads` | stops, finds nothing |
+
+So the failure at the workspace root is an empty resolution, not a wrong one,
+unless something above the workspace happens to hold a database. That second
+case is the quiet one, because it answers.
+
+Place a link at the workspace root pointing at the database inside the ops
+repository, so the master resolves to the intended one from where it stands.
+Expand `{{OPS_REPO}}` to an absolute path first; it may be a bare repository
+name, and a relative link breaks as soon as the ops repository is not a direct
+child of the workspace root.
 
 ```console
-$ ln -s "{{OPS_REPO}}/.beads" "{{WORKSPACE_ROOT}}/.beads"
+$ [ -e "{{WORKSPACE_ROOT}}/.beads" ] && echo "already exists, inspect before linking" \
+    || ln -s "$(cd "{{OPS_REPO}}" && pwd)/.beads" "{{WORKSPACE_ROOT}}/.beads"
 ```
 
-Adjust the name for the tracker in use. Ask the user before creating it.
+The guard matters. `ln -s` against an existing directory succeeds silently and
+creates the link inside it, so the resolution does not change and nothing says
+so.
+
+Adjust the name for the tracker in use, and confirm its own resolution rule
+rather than assuming it matches this one. Ask the user before creating the link.
 
 (d) Verification:
 
@@ -196,6 +216,7 @@ from inside the ops repository proves nothing about where the master will look.
 
 - `bd where`, or the selected equivalent, resolves to the ops repository
 - the workspace tracker database is a different database from the one in any product repository
+- no tracker database sits above `{{WORKSPACE_ROOT}}` on the path to the filesystem root, since an upward search would reach it first
 - a global environment variable does not override the resolution. If your
   tracker reads one, print it from the same shell the agent's tool calls use.
   A value read in a different shell can be a different value, and the check

--- a/master-ops/ONBOARDING.md
+++ b/master-ops/ONBOARDING.md
@@ -195,7 +195,7 @@ Run the checks from `{{WORKSPACE_ROOT}}`, not from the ops repository. Passing
 from inside the ops repository proves nothing about where the master will look.
 
 - `bd where`, or the selected equivalent, resolves to the ops repository
-- the workspace tracker database is separate from every product repository's
+- the workspace tracker database is a different database from the one in any product repository
 - a global environment variable does not override the resolution. If your
   tracker reads one, print it from the same shell the agent's tool calls use.
   A value read in a different shell can be a different value, and the check

--- a/master-ops/ONBOARDING.md
+++ b/master-ops/ONBOARDING.md
@@ -173,7 +173,7 @@ Operational note: in production, a path selector for an unregistered folder fail
 - record active work there, not in markdown TODO files
 - seed only load-bearing memory pointers and rules
 
-The second item is the one that gets missed. The master's working directory is
+Reaching the tracker from the workspace root is the step that gets missed. The master's working directory is
 `{{WORKSPACE_ROOT}}`, or an orchestrator root the user approved instead. Either
 way it is not the ops repository, and the ops repository sits below it.
 
@@ -198,7 +198,8 @@ name, and a relative link breaks as soon as the ops repository is not a direct
 child of the workspace root.
 
 ```console
-$ [ -e "{{WORKSPACE_ROOT}}/.beads" ] && echo "already exists, inspect before linking" \
+$ { [ -e "{{WORKSPACE_ROOT}}/.beads" ] || [ -L "{{WORKSPACE_ROOT}}/.beads" ]; } \
+    && echo "already exists, inspect before linking" \
     || ln -s "$(cd "{{OPS_REPO}}" && pwd)/.beads" "{{WORKSPACE_ROOT}}/.beads"
 ```
 
@@ -225,8 +226,9 @@ from inside the ops repository proves nothing about where the master will look.
 Warning: Beads and similar local trackers can keep per-repo databases. Do not
 reuse a product repository's database for workspace-level orchestration.
 
-Nothing fails loudly when this is wrong. The tracker reports no database, or it
-reports someone else's, and boot continues either way. Consider a session-start
+The tracker itself does fail loudly. Beads returns `No active beads workspace
+found.` and exits 1. What is quiet is the boot path, which does not read that
+exit code, so boot continues on an empty tracker. Consider a session-start
 check that prints a warning when the workspace root has no reachable tracker
 database, or when an environment variable points outside the workspace.
 

--- a/master-ops/ONBOARDING.md
+++ b/master-ops/ONBOARDING.md
@@ -169,16 +169,45 @@ Operational note: in production, a path selector for an unregistered folder fail
 (c) Agent action:
 
 - initialize the selected tracker only in the ops repository
+- reach the tracker from the workspace root, since that is where the master runs
 - record active work there, not in markdown TODO files
 - seed only load-bearing memory pointers and rules
 
+The second item is the one that gets missed. The master's working directory is
+`{{WORKSPACE_ROOT}}`, not the ops repository. A tracker that finds its database
+by looking in the current directory will find nothing there, or find a product
+repository's database and use that instead. Beads behaves this way: it checks
+the current directory only and does not walk upward.
+
+For that class of tracker, place a link at the workspace root pointing at the
+database inside the ops repository, so the master resolves to the right one
+from where it actually stands.
+
+```console
+$ ln -s "{{OPS_REPO}}/.beads" "{{WORKSPACE_ROOT}}/.beads"
+```
+
+Adjust the name for the tracker in use. Ask the user before creating it.
+
 (d) Verification:
 
-- tracker commands run from `{{OPS_REPO}}`
-- the workspace tracker database is separate from every product repository tracker database
-- `bd where` or the selected equivalent points to the ops repository, not a product repo
+Run the checks from `{{WORKSPACE_ROOT}}`, not from the ops repository. Passing
+from inside the ops repository proves nothing about where the master will look.
 
-Warning: Beads and similar local trackers can keep per-repo databases. Do not reuse a product repository's database for workspace-level orchestration.
+- `bd where`, or the selected equivalent, resolves to the ops repository
+- the workspace tracker database is separate from every product repository's
+- a global environment variable does not override the resolution. If your
+  tracker reads one, print it from the same shell the agent's tool calls use.
+  A value read in a different shell can be a different value, and the check
+  passes while the real path is wrong
+
+Warning: Beads and similar local trackers can keep per-repo databases. Do not
+reuse a product repository's database for workspace-level orchestration.
+
+Nothing fails loudly when this is wrong. The tracker reports no database, or it
+reports someone else's, and boot continues either way. Consider a session-start
+check that prints a warning when the workspace root has no reachable tracker
+database, or when an environment variable points outside the workspace.
 
 ## Step 6. Seed Universal User Rules
 

--- a/master-ops/docs/MASTER-OPERATIONS.md
+++ b/master-ops/docs/MASTER-OPERATIONS.md
@@ -19,7 +19,7 @@ This document is the workspace master-operations SSOT.
 - Field cards: `docs/runbooks/succession-boot-card.md`
 - Role state SSOT: `docs/runbooks/role-state.md`
 - Observability suite: `docs/observability/README.md` — attribution legend, integrity rules, and the retro / travelog / field-notes / agent-journey genres
-- Execution state SSOT: the issue tracker selected during onboarding
+- Execution state SSOT: the issue tracker selected during onboarding, reachable from `{{WORKSPACE_ROOT}}`
 - Long-term planning and design SSOT: Git documents
 
 Issue-tracker memory should contain only load-bearing rules and pointers. Keep it curated; do not turn it into a second copy of this document.
@@ -196,6 +196,14 @@ Recommended hook spec:
 - UserPromptSubmit: inject the current role-state line from `docs/runbooks/role-state.md`
 - PreToolUse: warn when supervised dispatch is bypassed
 - PostToolUse: collect non-sensitive audit markers when locally approved
+- SessionStart: warn when the issue tracker is not reachable from `{{WORKSPACE_ROOT}}`, or when an environment variable points its database outside the workspace
+
+The last one covers a failure that is otherwise silent. The master runs at the
+workspace root, and a tracker that resolves its database from the current
+directory finds nothing there, or finds a product repository's database. Boot
+continues either way. Measure the environment variable in the same shell the
+agent's tool calls use; a login shell can define a different value, and reading
+the wrong one turns the check into a pass.
 
 Context-quality monitor namespace: `{{MONITOR_NS}}`
 


### PR DESCRIPTION
## Summary

Step 5 verified the issue tracker with "tracker commands run from `{{OPS_REPO}}`". The master's working directory is `{{WORKSPACE_ROOT}}`. Those are different places, and the check was run in the one that does not matter.

A tracker that resolves its database from the current directory finds nothing at the workspace root, or finds a product repository's database and uses that. Beads works exactly this way: it checks the current directory and does not walk upward. The onboarding guide never says to bridge the gap, so every installation that picks such a tracker starts with it broken.

It fails silently. The tracker reports no database, or reports someone else's, and boot continues either way.

## What changed

- Step 5 gains the wiring step: a link at the workspace root pointing at the database inside the ops repository. The agent asks before creating it.
- Verification moved to the workspace root. Passing from inside the ops repository proves nothing about where the master will look.
- An environment-variable check, measured in the same shell the agent's tool calls use. A login shell can define a different value, and reading the wrong one turns the check into a pass. That is how one misplacement stayed unnoticed until a later audit.
- Section 7 hook spec gains a session-start warning for an unreachable tracker or a database pointed outside the workspace.

No script ships with this. Section 7 is a specification and hook implementation belongs to the operator, which this change leaves alone.

## Testing

- [x] `PYTHONPATH=src python3 -m pytest tests -q` — 295 passed, 1 skipped
- [x] `redaction-scan.sh --require-extra` — 0 findings, 124 files
- [x] `redaction-inventory` — 0 uncovered candidates
- [x] No test. Template and guide text only; no code path changes.

## Review

Not reviewed by anyone else yet.

## Template impact

Touches `master-ops/`. Generated operations repositories are copies and do not receive this. An existing installation has to add the link itself and re-run the verification from its workspace root. Worth checking on any install where the tracker has behaved oddly, since the symptom is an empty or wrong database rather than an error.

## Notes

The reference installation hit this during its first boot and fixed it locally. The fix never made it back into the template, so it has been reproducible for every install since. Same shape as the role-boundary rule in #1: the workaround lived in one machine's configuration and the doctrine that would have carried it never got written down.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix onboarding so the issue tracker is reachable and verified from `{{WORKSPACE_ROOT}}`, where the master actually runs. Corrects Beads resolution, adds a safe symlink wiring (including dangling-link guard), and surfaces silent miswires.

- **New Features**
  - Add wiring step: create a symlink at `{{WORKSPACE_ROOT}}` to the tracker DB in `{{OPS_REPO}}` (ask before creating), use an absolute path, and guard if a target exists or is a dangling link.
  - Correct Beads resolution rule (searches upward, stops at a git root; never downward); verify no tracker DB exists above `{{WORKSPACE_ROOT}}`.
  - Run verification from `{{WORKSPACE_ROOT}}`; confirm `bd where` points to the ops repo and not any product repo; check env vars in the same shell the agent’s tools use; note Beads exits non-zero when missing, but boot ignores it; extend hook spec with `SessionStart` warning; fix a cut-off verification sentence.

- **Migration**
  - Create the symlink at `{{WORKSPACE_ROOT}}` to the ops tracker DB (absolute path; do not overwrite or nest; handle existing or broken links).
  - Re-run verification from `{{WORKSPACE_ROOT}}`; ensure nothing above it resolves first and any tracker env var points inside the workspace.

<sup>Written for commit 53f6b6387274b7eb94560100152135df8bc3ede4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/baksohyeon/mogui-ADE-orchestrator/pull/4?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated onboarding guidance to ensure issue tracking is resolved from the workspace root.
  - Added confirmation and verification steps for tracker location, isolation, and configuration.
  - Documented safeguards against incorrect or silent tracker resolution.
  - Added session-start guidance to warn when the tracker is unavailable or resolved outside the workspace while allowing startup to continue.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->