### PR TITLE
docs(readme): refresh status

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,9 +201,21 @@ Documentation in this repository is English. `master-ops/` is a template that ge
 
 ## Status
 
-Working and exercised: 271 unit tests pass (1 skipped, as of 2026-08-01), every unit listed below exists in `src/master_runtime/core/`, and the succession, dispatch-gate, acceptance, and compaction paths have all run against real workspaces.
+Working and exercised, as of 2026-08-01: 295 unit tests pass, 1 skipped. Every
+unit listed below exists in `src/master_runtime/core/`. The succession,
+dispatch-gate, acceptance, and compaction paths have run against real
+workspaces, and onboarding has been run start to finish by someone other than
+its author.
 
-Moving fast: interfaces, CLI flags, and file formats still change without notice. Pin a commit if you build on it.
+No version tag yet. No CI: tests and the redaction scanners run locally before
+a push, so a passing count in a pull request is the author's word. Interfaces,
+CLI flags, and file formats still change without notice. Pin a commit if you
+build on it.
+
+The template that onboarding copies is versioned separately at
+`master-ops/TEMPLATE-VERSION`, currently 1. A generated operations repository
+does not update when the template does, so that number is how an installation
+says where it came from.
 
 ## Core concepts
 


### PR DESCRIPTION
## Summary

The Status section said 271 tests. It is 295. It also omitted two things a reader should know before depending on the repository: there is no version tag, and there is no CI, so a passing count in a pull request is the author's word.

Adds that onboarding has been run start to finish by someone other than its author, and that the template carries its own version at `master-ops/TEMPLATE-VERSION` because a generated operations repository does not update when the template does.

## Testing

- [x] `redaction-scan.sh --require-extra` — 0 findings
- [x] `redaction-inventory` — 0 uncovered candidates
- [x] No test. One documentation section.

## Review

Not reviewed by anyone else. Counts verified against a run on this branch.

## Template impact

None.

## Notes

The CI line becomes wrong the moment CI lands, which is the next thing worth doing.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refreshes the README Status section to reflect the current state and set expectations for users. Updates the test count to 295 (1 skipped), notes there’s no version tag or CI yet, confirms onboarding was run end-to-end by someone other than the author, and documents the template version at `master-ops/TEMPLATE-VERSION`.

<sup>Written for commit c09eede5f159d8beb989ac78e581b54372a61899. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/baksohyeon/mogui-ADE-orchestrator/pull/7?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

