### PR TITLE
docs(release): add CHANGELOG, CODE_OF_CONDUCT, and SECURITY for 0.1.0

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -12,6 +12,13 @@ What changed, and what made it necessary.
 
 If you ran a review, automated or otherwise, say what it flagged and what you did. Say which findings you reproduced yourself. A review is a claim until it is measured.
 
+## Changelog
+
+There are two, and they are not interchangeable.
+
+- Changes to the orchestrator go under `[Unreleased]` in the root `CHANGELOG.md`, if a user would notice them. Internal refactors and test-only changes need no entry.
+- Changes to `master-ops/` go in `master-ops/CHANGELOG.md`, covered below.
+
 ## Template impact
 
 Does this touch `master-ops/`? Generated operations repositories are copies made at onboarding and do not pick up template changes. Say what an existing install has to do. Otherwise write `none`.

--- a/.redaction-inventory-baseline
+++ b/.redaction-inventory-baseline
@@ -1,6 +1,7 @@
-# 심은 시점: 2026-08-01, 룰 9개 기준
+# 심은 시점: 2026-08-01, 룰 10개 기준
 # 갱신: 새 후보를 검토한 뒤 이 파일에 추가한다. 지우면 다시 보고된다.
 # redaction-inventory 기준선. 검토 완료해 무해 판정한 후보.
+# 2026-08-01 추가: CODE_OF_CONDUCT.md(Contributor Covenant 원문)와 SECURITY.md의 일반 영어 하이픈 단어 6건. 식별자가 아니다.
 a-z
 a-z0-9
 acceptance-loop
@@ -48,6 +49,7 @@ code-fact
 code-review-graph
 coding-agent
 command-line
+compaction-resilience
 compaction-specific
 config
 context-limit
@@ -75,6 +77,7 @@ drift-monitor
 dual-instance
 duplicate-session
 dz-bwh-demo
+e-mail
 echo-agent
 encoding
 end-to-end
@@ -127,6 +130,7 @@ grok
 hand-maintained
 handoff
 hands-on
+harassment-free
 hard-restricts
 headless-browser
 held-out
@@ -358,8 +362,10 @@ session-start
 shared-state
 shell-interpolated
 short-lived
+single-maintainer
 single-sourced
 sk-ant-api03-test
+socio-economic
 source-of-truth
 source-tree
 special-cases
@@ -387,6 +393,7 @@ term-u8
 term-u8-shadow
 term-u9
 test-framework
+test-only
 third-party
 three-branch
 three-lens

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,47 @@
+# Changelog
+
+Changes to the orchestrator. The template under `master-ops/` has its own
+changelog at `master-ops/CHANGELOG.md` and its own version number; the two move
+independently.
+
+Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
+Versions follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+While the major version is 0, the public surface is unstable: CLI flags, file
+formats, and module interfaces can change in a minor release. Pin a version if
+you build on it.
+
+## [Unreleased]
+
+## [0.1.0] - 2026-08-01
+
+First tagged version. The repository was already public and usable before this
+tag. What the tag adds is a point you can pin and a place to record what
+changed after it, not a change in what the code does.
+
+### Added
+
+- `CHANGELOG.md` and versioned releases. Before this, "which version" had no
+  answer other than a commit SHA.
+- `CODE_OF_CONDUCT.md`, adopting the Contributor Covenant.
+- `SECURITY.md`, stating where to report a vulnerability and what response to
+  expect from a single-maintainer project.
+
+### Changed
+
+- README no longer says there is no version tag.
+- The pull request template distinguishes the two changelogs. A change to the
+  orchestrator and a change to the template are recorded in different files.
+
+### Notes on what 0.1.0 contains
+
+Everything in the repository at this tag, which the README describes in full.
+The pieces exercised against real workspaces are succession, contract-gated
+dispatch, the acceptance loop, and the compaction-resilience probe. 295 unit
+tests pass, 1 skipped.
+
+There is no CI at this tag. Tests and the redaction scanners run locally before
+a push, so a passing count in a pull request is the author's word.
+
+[Unreleased]: https://github.com/baksohyeon/mogui-ADE-orchestrator/compare/v0.1.0...HEAD
+[0.1.0]: https://github.com/baksohyeon/mogui-ADE-orchestrator/releases/tag/v0.1.0

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,84 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our community a harassment-free experience for everyone, regardless of age, body size, visible or invisible disability, ethnicity, sex characteristics, gender identity and expression, level of experience, education, socio-economic status, nationality, personal appearance, race, caste, color, religion, or sexual identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming, diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our community include:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes, and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the overall community
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention or advances of any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or email address, without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of acceptable behavior and will take appropriate and fair corrective action in response to any behavior that they deem inappropriate, threatening, offensive, or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct, and will communicate reasons for moderation decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when an individual is officially representing the community in public spaces. Examples of representing our community include using an official e-mail address, posting via an official social media account, or acting as an appointed representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the community leaders responsible for enforcement at [GitHub's private reporting form](https://github.com/baksohyeon/mogui-ADE-orchestrator/security/advisories/new), which opens a private thread with the maintainer. All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing clarity around the nature of the violation and an explanation of why the behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of actions.
+
+**Consequence**: A warning with consequences for continued behavior. No interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, for a specified period of time. This includes avoiding interactions in community spaces as well as external channels like social media. Violating these terms may lead to a temporary or permanent ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public communication with the community for a specified period of time. No public or private interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, is allowed during this period. Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community standards, including sustained inappropriate behavior, harassment of an individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within the community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 2.1, available at [https://www.contributor-covenant.org/version/2/1/code_of_conduct.html][v2.1].
+
+Community Impact Guidelines were inspired by [Mozilla's code of conduct enforcement ladder][Mozilla CoC].
+
+For answers to common questions about this code of conduct, see the FAQ at [https://www.contributor-covenant.org/faq][FAQ]. Translations are available at [https://www.contributor-covenant.org/translations][translations].
+
+[homepage]: https://www.contributor-covenant.org
+[v2.1]: https://www.contributor-covenant.org/version/2/1/code_of_conduct.html
+[Mozilla CoC]: https://github.com/mozilla/diversity
+[FAQ]: https://www.contributor-covenant.org/faq
+[translations]: https://www.contributor-covenant.org/translations
+

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -59,3 +59,8 @@ anyone who does are useful.
 
 Conventional commits, English. `feat(scope):`, `fix(scope):`, `docs(scope):`.
 Say what changed and what made it necessary. Pull requests are squashed.
+
+Much of this repository is written by an AI agent under a maintainer's
+direction. Where that is true the commit carries a `Co-Authored-By` trailer
+naming the model. Commits before this convention was adopted do not have one,
+so absence means "written earlier", not "written by hand".

--- a/README.md
+++ b/README.md
@@ -207,10 +207,11 @@ dispatch-gate, acceptance, and compaction paths have run against real
 workspaces, and onboarding has been run start to finish by someone other than
 its author.
 
-No version tag yet. No CI: tests and the redaction scanners run locally before
-a push, so a passing count in a pull request is the author's word. Interfaces,
-CLI flags, and file formats still change without notice. Pin a commit if you
-build on it.
+Released as 0.1.0, the first tagged version. `CHANGELOG.md` records what changes
+after it. No CI: tests and the redaction scanners run locally before a push, so
+a passing count in a pull request is the author's word. While the major version
+is 0, interfaces, CLI flags, and file formats can change in a minor release.
+Pin a version if you build on it.
 
 The template that onboarding copies is versioned separately at
 `master-ops/TEMPLATE-VERSION`, currently 1. A generated operations repository

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,67 @@
+# Security Policy
+
+One maintainer, no company behind it. This document says what that means for a
+vulnerability report so you can decide whether to send one here or handle it
+another way.
+
+## Reporting
+
+Use [private vulnerability
+reporting](https://github.com/baksohyeon/mogui-ADE-orchestrator/security/advisories/new).
+It opens a private thread with the maintainer and does not disclose anything
+until an advisory is published.
+
+Do not open a public issue for a vulnerability. Public issues are the right
+place for everything else, including a bug that merely looks alarming.
+
+## What to expect
+
+Best effort, no service level agreement. A realistic expectation is
+acknowledgement within a week and a fix or a decision within a month. If a
+month passes with no reply, treat the report as unread and disclose on whatever
+timeline you think is right. Silence here means the maintainer missed it, not
+that disclosure is unwelcome.
+
+Fixes land on `main` and in the next release. There are no backports: while the
+major version is 0, only the latest release is supported.
+
+| Version | Supported |
+| --- | --- |
+| latest release | yes |
+| anything earlier | no |
+
+## Scope
+
+This is an orchestrator that runs coding agents on your machine, under your
+account, against your repositories. It runs with whatever the shell it launched
+from can reach.
+
+In scope:
+
+- The runtime under `src/master_runtime/` and the scripts under `scripts/`
+- Anything that causes the orchestrator to run a command, read a path, or
+  dispatch a worker outside what the caller asked for
+- The redaction scanners reporting clean when they did not read what they
+  claimed to read
+
+Out of scope:
+
+- The agent runtimes it dispatches to. Report those to their own projects.
+- The template under `master-ops/`, which is copied into your repository and
+  becomes yours to review before you run it
+- A model producing wrong or harmful output. That is a property of the model,
+  and this project's answer to it is verification before acceptance rather than
+  trust.
+
+## Known limits, already public
+
+These are documented rather than fixed, so they are not vulnerabilities:
+
+- No CI at 0.1.0. The scanners and tests run locally before a push, so a green
+  result in a pull request is the author's word.
+- The redaction scanners read tracked files only. An unstaged new file is
+  invisible to them and the run still reports clean.
+- `redaction-inventory` skips binary files, judged by a NUL byte in the first
+  8 KB, and does not say so in its output.
+
+If you find that one of these is worse than described, that is worth a report.


### PR DESCRIPTION
## Summary

The repository has been public and usable with no version, so "which one are you running" had no answer other than a commit SHA. This adds the three files a consumer looks for, plus the two document changes that follow from having a version at all.

Prepares the `0.1.0` tag. The tag and the GitHub Release are not part of this pull request.

- `CHANGELOG.md` — Keep a Changelog, SemVer. Covers the orchestrator only; `master-ops/CHANGELOG.md` keeps covering the template.
- `CODE_OF_CONDUCT.md` — Contributor Covenant 2.1, byte-identical to the published text except the contact line. Verified with `diff` against the upstream `.md`.
- `SECURITY.md` — where to report, what response to expect from a single-maintainer project, and what is out of scope. States the limits already documented elsewhere rather than letting a reporter discover them: no CI at this tag, scanners that read tracked files only, an inventory that silently skips binaries.
- `README.md` — no longer says there is no version tag. "Pin a commit" becomes "pin a version".
- `.github/pull_request_template.md` — names both changelogs. The old text named one and there are two now.
- `.redaction-inventory-baseline` — six reviewed candidates added.

One repository setting changed outside this diff: private vulnerability reporting was enabled, because `SECURITY.md` links to it and the link was dead without it.

## Testing

- [x] `PYTHONPATH=src python3 -m pytest tests -q` — 295 passed, 1 skipped
- [x] A test that fails without this change, or a note on why none was needed — none. Documentation and one baseline file, no runtime code touched.
- [x] New files staged before running any scan. Staged first, then scanned; the strict scan reports 134 files against 131 before this change, which is the three additions accounted for.

Strict scan: `REDACTION_REQUIRE_EXTRA=1` with organization rules loaded, 0 findings over 134 files.
Inventory: 0 uncovered.

The first inventory run returned six uncovered candidates: `compaction-resilience`, `e-mail`, `harassment-free`, `single-maintainer`, `socio-economic`, `test-only`. All are ordinary hyphenated English from the Covenant text and `SECURITY.md`, none are identifiers. Reviewed and added to the baseline, which is what took the run to 0.

## Review

No automated review on this one. Two things were caught by running the gates rather than by reading:

`redaction-scan.sh --strict` is not a flag. It fell into the usage path, which the script folds into exit 1 by its own declared exception, so it looked like a finding. Strict mode is `REDACTION_REQUIRE_EXTRA=1`. Read from the script header, then re-run.

`redaction-inventory` exits 2 with no `REDACTION_EXTRA_PATTERNS`, which is correct behavior and worth saying out loud: it refuses to measure blind spots with no rules rather than reporting a clean zero.

## Changelog

Root `CHANGELOG.md`, `[0.1.0]`. This pull request creates the file.

## Template impact

`none`. Nothing under `master-ops/` changes, so `TEMPLATE-VERSION` stays at 1.

## Notes

The baseline header said nine rules; there are ten. Corrected in the same change.

Branch is `feat/` because Orca names worktree branches that way. The change is documentation; the commit type carries the accurate label and the merge is squashed.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prepares the 0.1.0 release with versioning and policy docs, aligned project docs, and private vulnerability reporting. Also documents the `Co-Authored-By` convention and updates the redaction baseline.

- **New Features**
  - Add `CHANGELOG.md` for the orchestrator; the `master-ops/` template keeps its own changelog.
  - Add `CODE_OF_CONDUCT.md` (Contributor Covenant 2.1).
  - Add `SECURITY.md` with private reporting and clear scope/limits; enabled GitHub private vulnerability reporting.
  - Update `README.md` to reference 0.1.0 and advise pinning by version.
  - Update PR template to reference both changelogs.
  - Update `CONTRIBUTING.md` to document the `Co-Authored-By` trailer convention for model-written commits.
  - Update `.redaction-inventory-baseline` with six reviewed terms and correct rule count.

<sup>Written for commit b476a550f49700b273ed5d49419bbebb3bbe4417. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/baksohyeon/mogui-ADE-orchestrator/pull/8?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

