### PR TITLE
docs: install steps for every platform, and the CLI registration step

### DIFF
--- a/.redaction-inventory-baseline
+++ b/.redaction-inventory-baseline
@@ -238,6 +238,7 @@ one-shot
 one-to-one
 open-ended
 operations
+orca-ide
 organization-specific
 other-backend
 owner-prompt
@@ -369,6 +370,7 @@ source-of-truth
 source-tree
 special-cases
 src-layout
+stably-orca-bin
 standard-library-only
 state-changing
 stdout

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -51,9 +51,10 @@ This repository owns workspace-level orchestration: roles, succession, worker
 dispatch, lineage. Repository-local rules, hooks, and runbooks belong to
 [mogui-agent-harness](https://github.com/baksohyeon/mogui-agent-harness).
 
-Supported platform is macOS. The master has only been run under Claude Code.
-Other hosts and platforms should work and have not been tried, so reports from
-anyone who does are useful.
+Developed and run on macOS, under Claude Code. Orca ships Linux and Windows
+builds and one user has reported the Linux install working, but nothing here is
+exercised on either. Other hosts and platforms should work and have not been
+tried, so reports from anyone who does are useful.
 
 ## Commits
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Anyone running more than two agents at once hits this. Dorito hit it, got tired 
 
 Nothing to configure and nothing to read first. Clone it, start an agent inside the clone, tell it to wake up. The agent takes it from there and explains as it goes.
 
-It runs the fleet on [Orca](https://www.onorca.dev/download). A session has to outlive its window and be addressable by handle before anything can orchestrate it. macOS only for now. Python 3.10+, stdlib-only core, MIT. No API key.
+It runs the fleet on [Orca](https://www.onorca.dev/download). A session has to outlive its window and be addressable by handle before anything can orchestrate it. Built and run on macOS; Orca also ships Linux and Windows. Python 3.10+, stdlib-only core, MIT. No API key.
 
 The orchestrating session is called the master, for lack of a better word. It has no name yet. Suggestions welcome.
 
@@ -19,6 +19,10 @@ $ brew install --cask stablyai/orca/orca
 $ git clone https://github.com/baksohyeon/mogui-ADE-orchestrator
 $ cd mogui-ADE-orchestrator
 ```
+
+Not on macOS? Orca has Linux and Windows builds on its [download page](https://www.onorca.dev/download). `--cask` is macOS-only, so Homebrew is not the route there.
+
+Then open Orca once and turn on **Settings → Orca CLI → Shell command**. The runtime calls `orca` to spawn and retire master sessions. `orca status` should answer.
 
 Open that directory in Orca, start any coding agent inside it, and say:
 
@@ -125,7 +129,7 @@ Local only.
 - **Master starts under Claude Code out of the box.** The spawn path in `core/succession.py` calls `claude`. Nothing in the design depends on that, and pointing the line at another CLI is a small change. Claude Code is what has been run, so it is what is recommended.
 - **Workers can be any CLI.** A worker is a terminal session in an Orca pane, so it is whatever binary starts there. Claude, Codex, Cursor, Grok, Gemini have all run this way under contract. No plugin for any of them. The typed `adapter dispatch` path is narrower and takes `codex` only.
 - **Codex as master should work, and nobody has tried it.** Untested rather than unsupported. If you run it, a report or a patch is welcome.
-- **macOS only.** Other platforms planned, untested.
+- **macOS is what this has been run on.** Orca itself ships Linux and Windows builds, and one user has reported the install working on Linux. Neither is exercised here, so reports are useful.
 - **Orca required** for live sessions. Pure functions run without it.
 
 ## Alternatives

--- a/docs/public/getting-started.md
+++ b/docs/public/getting-started.md
@@ -4,17 +4,45 @@ The shortest path from a clone to a running master session. There is nothing to 
 
 ## What you need
 
-- macOS. That is the only platform this has been built and run on. Other platforms are planned, not supported yet.
-- [Orca](https://www.onorca.dev/download). The master lives in an Orca pane, which is what lets it outlive a window.
+- [Orca](https://www.onorca.dev/download). The master lives in an Orca pane, which is what lets it outlive a window. Orca ships macOS, Linux, and Windows builds.
+- The `orca` shell command. The runtime calls it to spawn, list, and retire master sessions, so succession does not work without it. Registering it is a step in Orca's settings, covered below.
 - A coding-agent CLI you already pay for: Claude Code, Codex, Grok CLI, or another one. Any single one is enough.
+- macOS is what this project has been developed and run on. One user has reported the install working on Linux. Windows is untested.
 
 ## Install and clone
 
+macOS:
+
 ```console
-$ brew install --cask stablyai/orca/orca      # or download: https://www.onorca.dev/download
+$ brew install --cask stablyai/orca/orca
+```
+
+Linux: an AppImage or `.deb` from Orca's releases, or `yay -S stably-orca-bin` on Arch. Homebrew does not help here, because `--cask` only works on macOS. Note the executable is named `orca-ide` rather than `orca`, to avoid colliding with the GNOME screen reader of the same name.
+
+Windows: `orca-windows-setup.exe` from releases.
+
+All three are also on the [download page](https://www.onorca.dev/download).
+
+Then clone:
+
+```console
 $ git clone https://github.com/baksohyeon/mogui-ADE-orchestrator
 $ cd mogui-ADE-orchestrator
 ```
+
+## Register the shell command
+
+Open Orca, go to **Settings → Orca CLI**, and turn on **Shell command**. The app writes a launcher for the CLI it already bundles: a symlink under `/usr/local/bin` on macOS (it may ask for admin), a symlink under `~/.local/bin` on Linux, a batch wrapper plus a PATH entry on Windows.
+
+Check it before going further:
+
+```console
+$ orca status
+appRunning: true
+runtimeState: ready
+```
+
+Skipping this is the failure that looks like a bug much later: onboarding reads fine, and then the founding spawn has nothing to call.
 
 ## Wake the master
 


### PR DESCRIPTION
## Summary

Three gaps, all found by watching someone install this for the first time.

**The quickstart started with a macOS-only command.** `brew install --cask` fails on Linux even where Homebrew itself is installed, because casks are macOS artifacts. A Linux reader hit line one and concluded the project did not support them. Orca ships AppImage, `.deb`, AUR, and Windows builds; the docs now say so. The Linux executable is `orca-ide` rather than `orca`, to avoid colliding with the GNOME screen reader, which is worth knowing before someone goes looking for a missing binary.

**Registering the shell command was documented nowhere.** The runtime calls `orca` to spawn, list, and retire master sessions:

```
succession.py:262   orca terminal list --json
succession.py:338   orca terminal close ...
succession.py:406   orca ... (spawn)
```

Without it succession cannot work, and the failure surfaces long after the step that caused it: onboarding reads fine, and then the founding spawn has nothing to call. It is a toggle in Settings, and `orca status` answers whether it took.

**The platform claim was out of date.** A user reported the install working on Linux. That is one report and not a support claim, so the docs say what happened rather than promoting it to a supported platform.

## Testing

- [x] `PYTHONPATH=src python3 -m pytest tests -q` — 297 passed, 1 skipped
- [x] A test that fails without this change — none. Documentation only; no runtime code is touched.
- [x] New files staged before running any scan. 125 files, unchanged from `main`.

Strict scan: 0 findings over 125 files. Inventory: 0 uncovered after baselining `stably-orca-bin` and `orca-ide`, both public package and binary names from Orca's own docs.

## Review

Swept the claim rather than the instance. "macOS only" appeared in four places — the README intro, the README limitations list, `CONTRIBUTING.md`, and `docs/public/getting-started.md` — and fixing only the one that had been noticed would have left three readers with the old answer.

Install details come from Orca's documentation. The CLI registration behaviour was checked locally rather than taken on faith: `/opt/homebrew/bin/orca` is a symlink into `/Applications/Orca.app/Contents/Resources/bin/orca`, so the app ships the binary and the settings toggle only puts it on PATH. That is why the docs say "register" instead of "install" — nothing is downloaded at that step.

`orca --version` prints only `orca` with no version string, so it is a presence check and not much else. `orca status` reports `appRunning` and `runtimeState`, which is what a reader actually needs to know at that point, so that is what the docs tell them to run.

## Changelog

Root `CHANGELOG.md`, `[Unreleased]` — not added. Documentation only.

## Template impact

`none`. Nothing under `master-ops/` changes, so `TEMPLATE-VERSION` stays at 1.

## Notes

The Linux line is deliberately weak: one user, one report, and no idea how far they got past the install. If they confirm a founding spawn completed, that sentence can get stronger.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added platform-specific install steps for Orca (macOS `brew install --cask stablyai/orca/orca`, Linux AppImage/`.deb` or AUR `stably-orca-bin` with `orca-ide`, and Windows) and documented the missing step to register the `orca` shell command. Clarified platform claims: developed and run on macOS; Linux/Windows builds exist but are untested here.

- **Migration**
  - In Orca, enable Settings → Orca CLI → Shell command, then run `orca status` to confirm.

<sup>Written for commit c6016d06f9e6ec690e7fa7ff8c0326d76a9ac498. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/baksohyeon/mogui-ADE-orchestrator/pull/12?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

