### PR TITLE
feat(preflight): gate the whole harness tool surface, and measure capability over reachability

### DIFF
--- a/master-ops/CHANGELOG.md
+++ b/master-ops/CHANGELOG.md
@@ -49,13 +49,34 @@ re-running `bash scripts/onboarding-preflight.sh`, and raising the installed
 
 Onboarding now requires Orca infrastructure and uses Orca orchestration for all
 supervised dispatch. A new read-only-by-default `scripts/onboarding-preflight.sh`
-checks Orca status, the orchestration RPC, the global `orca-cli` and
+checks Orca status, orchestration capability, the `orca-cli` and
 `orchestration` skills, Beads resolution when an ops repository exists, and
-Python before onboarding proceeds. `ONBOARDING.md` is rewritten as a token-lean
-script-and-command flow while retaining its questions, safeguards, and
-verification gates; `--fix` may add or refresh only the required global skills.
-Template v5 also adds the append-only `scripts/codex-worker-pretrust` helper so
-every Orca Codex account trusts a worker worktree before dispatch.
+Python before onboarding proceeds. It also gates the rest of the tool surface a
+master and its workers actually invoke: the named agent CLI, the worker runtimes
+dispatch targets, Git, an authenticated `gh`, a runnable test entry point, a
+writable dispatch ledger directory, and the organization rules file.
+`ONBOARDING.md` is rewritten as a token-lean script-and-command flow while
+retaining its questions, safeguards, and verification gates; `--fix` may add or
+refresh only the required global skills. Template v5 also adds the append-only
+`scripts/codex-worker-pretrust` helper so every Orca Codex account trusts a
+worker worktree before dispatch.
+
+Two of those checks measure differently than a first reading suggests, because
+both were wrong in the first cut. Orchestration is judged by capability, not
+reachability: a retained legacy coordinator answers reads and drops writes with
+`effectsApplied:false`, so `run-current` must report a bound non-legacy Run.
+Skills are judged by the artifact, not the installer: the required skills can
+resolve on a host that has no `skills` package manager at all, and an installer
+listing that cannot run is not evidence of absence.
+
+The organization rules file moves from optional to required, since two of the
+three publish gates refuse to run without it. The preflight validates its format
+and reports counts only. It never prints a rule, an identifier, or a match,
+because that file's contents are what the scanner protects. The format is one
+rule per line as `id|description|regex`, `#` comments and blank lines skipped,
+split on the first two pipes only so the regex may contain `|`, and every regex
+must compile: the inventory drops uncompilable rules without reporting them, so
+a malformed rule narrows coverage while the file still looks populated.
 
 The minimum Python version is now 3.11 because the pre-trust helper uses the
 standard-library `tomllib` parser to make config edits safely.
@@ -73,7 +94,8 @@ Upgrade an existing installation in this order:
 2. Run `bash scripts/onboarding-preflight.sh` from that clone and fix every FAIL;
    re-collect and confirm the workspace facts before routing work.
 3. Before each Codex worker attach, run `scripts/codex-worker-pretrust <worktree-path>` from the orchestrator clone.
-4. Enable Orca orchestration, then verify the preflight reports its RPC reachable.
+4. Enable Orca orchestration and bind a Run with `orca orchestration run-create`,
+   then verify the preflight reports a non-legacy Run bound to this terminal.
 5. Select or create the approved ops repository, then verify `bd where` from the
    workspace root resolves to it and no tracker root is selected above it.
 6. Replace all template placeholders, verify `CLAUDE.md` and `AGENTS.md` are

--- a/master-ops/ONBOARDING.md
+++ b/master-ops/ONBOARDING.md
@@ -33,7 +33,7 @@ Use only these template placeholders: `{{WORKSPACE_NAME}}`, `{{WORKSPACE_ROOT}}`
 
 **Position and action:** Step 0 starts after orientation, with no workspace state changed: run `bash scripts/onboarding-preflight.sh` from `{{RUNTIME_ROOT}}` and fix every FAIL before continuing.
 
-**Why/caution:** Orca, orchestration, the Orca skills, Beads, and Python are required; do not offer a non-Orca fallback.
+**Why/caution:** Orca, an orchestration Run bound to this terminal, the Orca skills, Beads, Python, the named agent CLI, the worker runtimes it dispatches to, Git, `gh`, and the organization rules file are all required; do not offer a non-Orca fallback. Orchestration is measured by capability rather than reachability: a retained legacy coordinator answers reads and drops writes with `effectsApplied:false`, so a dispatch record can survive while the worker receives nothing. If the preflight reports that, bind a fresh Run with `orca orchestration run-create` and measure again; restarting the app does not clear it.
 
 Ask whether the user is ready for local read-only checks and which agent CLI they expect to use, such as `claude`.
 
@@ -50,9 +50,11 @@ Use `bash scripts/onboarding-preflight.sh --fix` only with approval; it may add 
 
 Verify:
 
-- the preflight exits zero, Orca status was measured, orchestration RPC is reachable, required skills are present, `bd` is present and resolves to the ops repo when one exists, and Python is present
-- the named agent CLI is measured or explicitly unresolved
-- Git is measured
+- the preflight exits zero, Orca status was measured, a non-legacy orchestration Run is bound to this terminal, required skills resolve, `bd` is present and resolves to the ops repo when one exists, and Python is present
+- the named agent CLI is set and resolves on `PATH`; an unset selection is a FAIL, because it silently downgrades the agent-specific checks to INFO
+- the worker runtimes this master dispatches to resolve on `PATH`
+- Git and `gh` are present, `gh` is authenticated, and a missing `workflow` scope was reported
+- the organization rules file loads at least one rule and no rule is malformed; the preflight reports counts only and never the file's contents
 
 ## Step 1. Collect Workspace Facts
 

--- a/scripts/onboarding-preflight.sh
+++ b/scripts/onboarding-preflight.sh
@@ -85,16 +85,26 @@ else
   fi
 fi
 
+# A reachable RPC does not mean a dispatch will land. Measure the capability
+# the master actually depends on: a non-legacy Run bound to this terminal.
+# Observed failure this check exists for: a retained legacy coordinator answers
+# reads normally and drops writes with effectsApplied:false, so the dispatch
+# record survives while the worker receives nothing.
 if [[ "$orca_ready" == true ]]; then
   orchestration_output=""
   orchestration_status=0
-  orchestration_output=$("$orca_command" orchestration task-list --json 2>&1) || orchestration_status=$?
-  if { [[ $orchestration_status -eq 0 ]] \
-    && grep -Eq '"ok"[[:space:]]*:[[:space:]]*true' <<<"$orchestration_output"; } \
-    || grep -Eq '"code"[[:space:]]*:[[:space:]]*"run_required"' <<<"$orchestration_output"; then
-    pass "orchestration" "RPC reachable (run_required is expected before a Run is bound)"
-  else
+  orchestration_output=$("$orca_command" orchestration run-current --json 2>&1) || orchestration_status=$?
+  if grep -Eq '"code"[[:space:]]*:[[:space:]]*"legacy_read_only"' <<<"$orchestration_output"; then
+    fail "orchestration" "retained legacy coordinator: calls answer and writes are dropped (effectsApplied:false); bind a fresh Run with '$orca_command orchestration run-create', then re-run this preflight; restarting the app does not clear it"
+  elif [[ $orchestration_status -ne 0 ]] \
+    || ! grep -Eq '"ok"[[:space:]]*:[[:space:]]*true' <<<"$orchestration_output"; then
     fail "orchestration" "RPC unavailable; enable Orca orchestration and retry"
+  elif grep -Eq '"run"[[:space:]]*:[[:space:]]*null' <<<"$orchestration_output"; then
+    fail "orchestration" "RPC reachable but no Run is bound to this terminal, so dispatch effects have nowhere to land; run: $orca_command orchestration run-create"
+  elif grep -Eq '"legacy"[[:space:]]*:[[:space:]]*1' <<<"$orchestration_output"; then
+    fail "orchestration" "the bound Run is legacy and inspect-only; create a fresh one: $orca_command orchestration run-create"
+  else
+    pass "orchestration" "RPC reachable and a non-legacy Run is bound to this terminal"
   fi
 else
   fail "orchestration" "not checked because Orca status failed"
@@ -103,6 +113,37 @@ fi
 skills_output=""
 skills_status=0
 runtime_root=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd -P)
+
+# Measure the artifact before the installer. The required skills can be present
+# without the `skills` package manager being installed at all, and an installer
+# listing that cannot run is not evidence that the skills are missing.
+# ORCA_SKILLS_DIRS overrides the search for agent layouts not listed here.
+skills_artifact_ok=false
+skills_roots=()
+if [[ -n "${ORCA_SKILLS_DIRS:-}" ]]; then
+  IFS=':' read -r -a skills_roots <<<"$ORCA_SKILLS_DIRS"
+else
+  skills_roots=(
+    "$HOME/.claude/skills"
+    "$HOME/.agents/skills"
+    "$HOME/.codex/skills"
+    "$HOME/.config/skills"
+    "$HOME/.local/share/skills"
+  )
+fi
+skills_found_root=""
+for skills_root in "${skills_roots[@]}"; do
+  [[ -d "$skills_root" ]] || continue
+  if [[ -e "$skills_root/orca-cli" && -e "$skills_root/orchestration" ]]; then
+    skills_artifact_ok=true
+    skills_found_root="$skills_root"
+    break
+  fi
+done
+if [[ "$skills_artifact_ok" == true ]]; then
+  pass "skills" "orca-cli and orchestration resolve under $skills_found_root"
+fi
+
 skills_command=()
 skills_display=""
 skills_candidate=$(command -v skills 2>/dev/null || true)
@@ -124,7 +165,9 @@ if [[ ${#skills_command[@]} -eq 0 ]] && command -v npx >/dev/null 2>&1; then
   skills_display="npx --no-install skills"
 fi
 
-if [[ ${#skills_command[@]} -eq 0 ]]; then
+if [[ "$skills_artifact_ok" == true ]]; then
+  skills_status=0
+elif [[ ${#skills_command[@]} -eq 0 ]]; then
   skills_status=127
 else
   skills_output=$("${skills_command[@]}" list -g 2>&1 | strip_ansi) || skills_status=$?
@@ -175,11 +218,54 @@ else
   printf 'INFO %-14s %s\n' "codex-plugin" "skipped because Claude Code is not the selected agent"
 fi
 
-redaction_extra="${HOME}/.config/redaction-extra.txt"
-if [[ -f "$redaction_extra" ]]; then
-  pass "redaction-extra" "optional organization-specific rules file present: $redaction_extra"
+# Required, not optional: REDACTION_REQUIRE_EXTRA=1 scanning exits 2 with no
+# rules loaded, and redaction-inventory exits 2 when this file is unset or
+# yields no readable rule. A missing file is a blocked publish path.
+# Honor the variable both consumers read before falling back to the default path.
+redaction_extra="${REDACTION_EXTRA_PATTERNS:-${HOME}/.config/redaction-extra.txt}"
+redaction_format='format: one rule per line as "id|description|regex"; blank lines and lines beginning with # are skipped; only the first two pipes separate fields, so the regex may contain "|"; the regex must compile, because redaction-inventory drops uncompilable rules without reporting them; keep the file out of version control'
+if [[ ! -f "$redaction_extra" ]]; then
+  fail "redaction-extra" "organization rules file missing: $redaction_extra; two of the three publish gates refuse to run without it; $redaction_format"
 else
-  warn "redaction-extra" "optional organization-specific rules file missing: $redaction_extra; create with: mkdir -p ~/.config && touch ~/.config/redaction-extra.txt"
+  # Counts only. This file's contents are what the scanner protects, so the
+  # check must never print a rule, an identifier, or a match.
+  redaction_counts=""
+  redaction_counts=$(python3 - "$redaction_extra" <<'PY' 2>/dev/null || true
+import re
+import sys
+
+total = valid = malformed = 0
+with open(sys.argv[1], encoding="utf-8") as handle:
+    for line in handle:
+        line = line.strip()
+        if not line or line.startswith("#"):
+            continue
+        total += 1
+        parts = line.split("|", 2)
+        if len(parts) != 3:
+            malformed += 1
+            continue
+        try:
+            re.compile(parts[2])
+        except re.error:
+            malformed += 1
+            continue
+        valid += 1
+print(total, valid, malformed)
+PY
+  )
+  if [[ -z "$redaction_counts" ]]; then
+    fail "redaction-extra" "could not read $redaction_extra; $redaction_format"
+  else
+    read -r rx_total rx_valid rx_malformed <<<"$redaction_counts"
+    if [[ "$rx_valid" -eq 0 ]]; then
+      fail "redaction-extra" "$redaction_extra yields no usable rule out of $rx_total non-comment lines; $redaction_format"
+    elif [[ "$rx_malformed" -gt 0 ]]; then
+      fail "redaction-extra" "$rx_malformed of $rx_total rules in $redaction_extra are malformed or do not compile, so coverage is narrower than the file looks; $redaction_format"
+    else
+      pass "redaction-extra" "$rx_valid rules load from $redaction_extra"
+    fi
+  fi
 fi
 
 if command -v bd >/dev/null 2>&1; then
@@ -215,11 +301,92 @@ else
 fi
 
 test_hint='PYTHONPATH=src uv run --with pytest --no-project python3 -m pytest tests -q'
-if command -v python3 >/dev/null 2>&1 \
-  && python3 -c 'import sys; raise SystemExit(0 if sys.version_info >= (3, 11) else 1)' >/dev/null 2>&1; then
+python_floor_ok=false
+if ! command -v python3 >/dev/null 2>&1; then
+  fail "python3" "missing; install Python 3.11+ because codex-worker-pretrust uses tomllib for safe TOML editing; test suite: $test_hint"
+elif python3 -c 'import sys; raise SystemExit(0 if sys.version_info >= (3, 11) else 1)' >/dev/null 2>&1; then
+  python_floor_ok=true
   pass "python3" "Python 3.11+ present; codex-worker-pretrust uses tomllib for safe TOML editing; test suite: $test_hint"
 else
-  fail "python3" "missing or too old; install Python 3.11+ because codex-worker-pretrust uses tomllib for safe TOML editing; test suite: $test_hint"
+  # Present but below the floor. Reporting an old interpreter as "missing" sends
+  # the operator looking for the wrong thing.
+  fail "python3" "present but $(python3 -c 'import sys; print(".".join(map(str, sys.version_info[:3])))' 2>/dev/null) is below the required 3.11, which codex-worker-pretrust needs for tomllib; install Python 3.11+ or run the suite through uv: $test_hint"
+fi
+
+# --- harness and worker tool surface --------------------------------------
+# Every entry below is a tool the master or a dispatched worker invokes during
+# normal operation. The template ships prose and scripts; the parts that make a
+# master work live in host configuration, so onboarding measures them instead of
+# assuming them. Trim the lists if your routing policy uses different executors.
+
+agent_cli="${ORCA_AGENT_CLI:-}"
+if [[ -z "$agent_cli" ]]; then
+  fail "agent-cli" "ORCA_AGENT_CLI is unset; name the agent CLI this master runs so agent-specific checks are measured instead of skipped"
+elif ! command -v "$agent_cli" >/dev/null 2>&1; then
+  fail "agent-cli" "ORCA_AGENT_CLI=$agent_cli is not on PATH; install it or correct the value"
+else
+  pass "agent-cli" "$agent_cli resolves on PATH"
+fi
+
+worker_runtimes=(codex cursor-agent)
+for worker_runtime in "${worker_runtimes[@]}"; do
+  if command -v "$worker_runtime" >/dev/null 2>&1; then
+    pass "worker-runtime" "$worker_runtime present"
+  else
+    fail "worker-runtime" "$worker_runtime is not on PATH; a master that cannot reach its executors cannot delegate"
+  fi
+done
+
+for repo_tool in git gh; do
+  if command -v "$repo_tool" >/dev/null 2>&1; then
+    pass "$repo_tool" "present"
+  else
+    fail "$repo_tool" "$repo_tool is required; this repository is managed through pull requests"
+  fi
+done
+
+if command -v gh >/dev/null 2>&1; then
+  gh_status=$(gh auth status 2>&1) || true
+  if printf '%s\n' "$gh_status" | grep -q 'Logged in'; then
+    if printf '%s\n' "$gh_status" | grep -q 'workflow'; then
+      pass "gh-auth" "authenticated with workflow scope"
+    else
+      # Not fatal for ordinary PR work; fatal the moment a workflow file moves.
+      warn "gh-auth" "authenticated without the workflow scope; pushing or editing GitHub Actions workflows will fail; run: gh auth refresh -h github.com -s workflow"
+    fi
+  else
+    fail "gh-auth" "gh is not authenticated; run: gh auth login"
+  fi
+fi
+
+# pytest resolving is not the same as the suite running: below the floor,
+# collection fails on tomllib before a single test executes, so an interpreter
+# under 3.11 has to reach the suite through uv.
+if [[ "$python_floor_ok" == true ]] && python3 -m pytest --version >/dev/null 2>&1; then
+  pass "pytest" "python3 -m pytest is runnable at the required interpreter version"
+elif command -v uv >/dev/null 2>&1; then
+  pass "pytest" "uv present; the suite runs through: $test_hint"
+else
+  fail "pytest" "no way to run the test gate: pytest is not available on a 3.11+ interpreter and uv is missing; install either"
+fi
+
+# The gate writes its ledger outside the repository. Check writability without
+# creating anything: this script must not change state before --fix.
+gate_ledger="${DISPATCH_GATE_LEDGER:-.mogui/dispatch-ledger.jsonl}"
+gate_ledger_dir=$(dirname "$gate_ledger")
+if [[ -d "$gate_ledger_dir" ]]; then
+  if [[ -w "$gate_ledger_dir" ]]; then
+    pass "gate-ledger" "dispatch ledger directory is writable: $gate_ledger_dir"
+  else
+    fail "gate-ledger" "dispatch ledger directory is not writable: $gate_ledger_dir; set DISPATCH_GATE_LEDGER to a writable path"
+  fi
+else
+  gate_ledger_parent=$(dirname "$gate_ledger_dir")
+  if [[ -d "$gate_ledger_parent" && -w "$gate_ledger_parent" ]]; then
+    pass "gate-ledger" "dispatch ledger directory will be created under $(cd "$gate_ledger_parent" && pwd -P)"
+  else
+    fail "gate-ledger" "cannot create the dispatch ledger directory under $gate_ledger_parent; set DISPATCH_GATE_LEDGER to a writable path"
+  fi
 fi
 
 printf '\nPreflight summary\n'

--- a/tests/test_onboarding_preflight.py
+++ b/tests/test_onboarding_preflight.py
@@ -1,0 +1,204 @@
+"""Tests for scripts/onboarding-preflight.sh.
+
+The script had no test of its own, which is the same defect class it exists to
+prevent: a gate whose green light is indistinguishable from silence. These
+tests drive it against a stubbed host so each verdict is measured, not assumed.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import subprocess
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+PREFLIGHT = REPO_ROOT / "scripts" / "onboarding-preflight.sh"
+
+ORCA_STUB = """#!/usr/bin/env bash
+case "$*" in
+  "status --json") printf '%s\\n' '{"ok":true}' ;;
+  "orchestration run-current --json") printf '%s\\n' "$STUB_RUN_CURRENT" ;;
+  *) printf '%s\\n' '{"ok":false}' ; exit 1 ;;
+esac
+"""
+
+BD_STUB = """#!/usr/bin/env bash
+case "$1" in
+  where) printf '%s\\n' "$STUB_OPS_REPO/.beads" ;;
+  *) exit 1 ;;
+esac
+"""
+
+GH_STUB = """#!/usr/bin/env bash
+if [[ "$1" == "auth" && "$2" == "status" ]]; then
+  printf '%s\\n' "  Logged in to github.com account tester"
+  printf '%s\\n' "  - Token scopes: 'gist', 'read:org', 'repo', 'workflow'"
+  exit 0
+fi
+exit 0
+"""
+
+TRUE_STUB = "#!/usr/bin/env bash\nexit 0\n"
+
+RUN_BOUND = '{"ok":true,"result":{"run":{"id":"run_test","legacy":0}}}'
+RUN_NULL = '{"ok":true,"result":{"run":null}}'
+RUN_LEGACY_READ_ONLY = (
+    '{"ok":false,"error":{"code":"legacy_read_only",'
+    '"message":"retained legacy coordinator","data":{"effectsApplied":false}}}'
+)
+RUN_BOUND_LEGACY = '{"ok":true,"result":{"run":{"id":"run_old","legacy":1}}}'
+
+
+def _write_stub(path: Path, body: str) -> None:
+    path.write_text(body, encoding="utf-8")
+    path.chmod(0o755)
+
+
+def _host(tmp_path: Path, *, rules: str | None = "id|description|abc[0-9]+") -> dict:
+    """Provision a stub host and return the env for running the preflight."""
+
+    home = tmp_path / "home"
+    bin_dir = tmp_path / "bin"
+    ops_repo = tmp_path / "ops"
+    (home / ".claude" / "skills" / "orca-cli").mkdir(parents=True)
+    (home / ".claude" / "skills" / "orchestration").mkdir(parents=True)
+    (home / ".claude" / "plugins").mkdir(parents=True)
+    (home / ".claude" / "plugins" / "installed_plugins.json").write_text(
+        '{"plugins":{"codex@openai-codex":[{"scope":"user"}]}}', encoding="utf-8"
+    )
+    (home / ".config").mkdir(parents=True)
+    if rules is not None:
+        (home / ".config" / "redaction-extra.txt").write_text(
+            rules + "\n", encoding="utf-8"
+        )
+    (ops_repo / "docs").mkdir(parents=True)
+    (ops_repo / "docs" / "MASTER-OPERATIONS.md").write_text("ops\n", encoding="utf-8")
+    (ops_repo / ".beads").mkdir()
+
+    bin_dir.mkdir()
+    _write_stub(bin_dir / "orca", ORCA_STUB)
+    _write_stub(bin_dir / "bd", BD_STUB)
+    _write_stub(bin_dir / "gh", GH_STUB)
+    for name in ("codex", "cursor-agent", "claude", "git"):
+        _write_stub(bin_dir / name, TRUE_STUB)
+
+    env = dict(os.environ)
+    env.update(
+        {
+            "HOME": str(home),
+            "PATH": f"{bin_dir}:{env['PATH']}",
+            "ORCA_AGENT_CLI": "claude",
+            "ORCA_CLI_COMMAND": "",
+            "ORCA_DEV_REPO_ROOT": "",
+            "STUB_RUN_CURRENT": RUN_BOUND,
+            "STUB_OPS_REPO": str(ops_repo),
+            "DISPATCH_GATE_LEDGER": str(tmp_path / "ledger" / "dispatch.jsonl"),
+            "REDACTION_EXTRA_PATTERNS": str(
+                home / ".config" / "redaction-extra.txt"
+            ),
+        }
+    )
+    env.pop("ORCA_SKILLS_DIRS", None)
+    return env
+
+
+def _run(env: dict, tmp_path: Path) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        ["bash", str(PREFLIGHT)],
+        env=env,
+        cwd=str(tmp_path),
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+def _labels(output: str, verdict: str) -> set[str]:
+    return set(re.findall(rf"^{verdict} +(\S+)", output, re.MULTILINE))
+
+
+def test_provisioned_host_reports_no_failure_it_can_act_on(tmp_path: Path) -> None:
+    """A correctly provisioned host must be able to pass.
+
+    python3 is exempted from the assertion because the interpreter running the
+    suite is not under this test's control, and the check compares it against
+    the floor README declares.
+    """
+
+    result = _run(_host(tmp_path), tmp_path)
+    assert _labels(result.stdout, "FAIL") <= {"python3"}, result.stdout
+    assert {
+        "orchestration",
+        "skills",
+        "redaction-extra",
+        "agent-cli",
+        "gate-ledger",
+        "bd",
+    } <= _labels(result.stdout, "PASS"), result.stdout
+
+
+def test_skills_pass_without_the_installer_cli(tmp_path: Path) -> None:
+    """The artifact is the subject; the installer listing is only a fallback."""
+
+    env = _host(tmp_path)
+    result = _run(env, tmp_path)
+    assert "skills" in _labels(result.stdout, "PASS"), result.stdout
+    assert "skills" not in _labels(result.stdout, "FAIL"), result.stdout
+
+
+def test_legacy_read_only_coordinator_is_named(tmp_path: Path) -> None:
+    env = _host(tmp_path)
+    env["STUB_RUN_CURRENT"] = RUN_LEGACY_READ_ONLY
+    result = _run(env, tmp_path)
+    assert "orchestration" in _labels(result.stdout, "FAIL"), result.stdout
+    assert "retained legacy coordinator" in result.stdout
+    assert "run-create" in result.stdout
+
+
+def test_unbound_run_fails_even_though_rpc_answers(tmp_path: Path) -> None:
+    env = _host(tmp_path)
+    env["STUB_RUN_CURRENT"] = RUN_NULL
+    result = _run(env, tmp_path)
+    assert "orchestration" in _labels(result.stdout, "FAIL"), result.stdout
+    assert "no Run is bound" in result.stdout
+
+
+def test_bound_legacy_run_fails(tmp_path: Path) -> None:
+    env = _host(tmp_path)
+    env["STUB_RUN_CURRENT"] = RUN_BOUND_LEGACY
+    result = _run(env, tmp_path)
+    assert "orchestration" in _labels(result.stdout, "FAIL"), result.stdout
+    assert "inspect-only" in result.stdout
+
+
+def test_missing_agent_cli_selection_fails(tmp_path: Path) -> None:
+    env = _host(tmp_path)
+    env["ORCA_AGENT_CLI"] = ""
+    result = _run(env, tmp_path)
+    assert "agent-cli" in _labels(result.stdout, "FAIL"), result.stdout
+
+
+def test_missing_rules_file_blocks_instead_of_warning(tmp_path: Path) -> None:
+    env = _host(tmp_path, rules=None)
+    result = _run(env, tmp_path)
+    assert "redaction-extra" in _labels(result.stdout, "FAIL"), result.stdout
+    assert "redaction-extra" not in _labels(result.stdout, "WARN"), result.stdout
+    assert result.returncode == 1
+
+
+def test_malformed_rule_fails_and_nothing_from_the_file_is_printed(
+    tmp_path: Path,
+) -> None:
+    """Report counts, never content: the file is what the scanner protects."""
+
+    env = _host(
+        tmp_path,
+        rules="canary|canary description|abc(unclosed\ngood|good description|xyz[0-9]",
+    )
+    result = _run(env, tmp_path)
+    output = result.stdout + result.stderr
+    assert "redaction-extra" in _labels(result.stdout, "FAIL"), output
+    assert "1 of 2" in output, output
+    for leaked in ("canary", "abc(unclosed", "xyz[0-9]"):
+        assert leaked not in output, output


### PR DESCRIPTION
Stacked on #16, based on that branch's head at the time of writing and rebased onto `720d056`. Base is `feat/mao-n1w-gate-orchestration`, not `main`, because `scripts/onboarding-preflight.sh` does not exist on `main` yet.

## Why

Running #16's preflight on a host where the master harness had been operating all day returned `exit 1`, `BLOCKED`, with 3 FAIL. Two were false. Details and evidence are in https://github.com/baksohyeon/mogui-ADE-orchestrator/pull/16#issuecomment-5157166690.

A gate that cannot pass on a correctly provisioned machine teaches the operator to skip it, so this fixes the two false negatives, extends the checks to the rest of the tool surface a master and its workers actually invoke, and gives the script its first test.

## Orchestration is now judged by capability, not reachability

The old check read `orchestration task-list` and accepted `run_required` as expected. On the host above the real state was neither reachable-and-fine nor unreachable:

```
code: legacy_read_only
"retained legacy coordinator could not prove its original process identity"
data.effectsApplied: false

run-current  ->  run: null
run-list     ->  two Runs from one state migration, both unbound,
                 one of them inspect-only
```

Reads answer normally the whole time and writes are dropped. After binding a fresh Run, scoped calls apply and unscoped calls still resolve to the retained coordinator. That is how a dispatch record survives with no heartbeat and an empty worker terminal, which is what another session hit today during worker boot.

The check now reads `run-current` and requires a bound non-legacy Run, and names `legacy_read_only` separately because its remedy differs: `run-create` plus the knowledge that restarting the app does not clear it.

## Skills are now judged by the artifact, not the installer

Both required skills resolved on that host, as entries under the agent's skills directory. What was missing was the `skills` package manager, and the `npx --no-install` fallback cancels when the package is not cached. The artifact is probed first, with `ORCA_SKILLS_DIRS` for layouts not in the default list; the installer path stays for `--fix`.

## New hard gates

Each one is a tool the master or a dispatched worker invokes in normal operation, and none of them were checked:

- the named agent CLI. Leaving `ORCA_AGENT_CLI` unset previously downgraded the codex plugin check to INFO, so a dispatch dependency went unverified while the summary stayed clean
- the worker runtimes dispatch targets, as an editable list at the top of that block
- `git`, and `gh` with authentication measured; a missing `workflow` scope is reported as a WARN rather than a block, since ordinary PR work does not need it
- a runnable test entry point. Note that `python3 -m pytest --version` succeeding is not the same as the suite running: below 3.11, collection now fails on `tomllib` before any test executes, so an older interpreter must reach the suite through `uv`
- a writable dispatch ledger directory, checked without creating anything, because this script must not change state before `--fix`

A present-but-old `python3` is no longer reported as `missing`. It names the version it found and the floor it failed.

## The organization rules file moves from optional to required

Two of the three publish gates refuse to run without it: `REDACTION_REQUIRE_EXTRA=1` scanning exits 2 with no rules loaded, and the inventory exits 2 when the variable is unset or nothing readable comes back. A missing file is a blocked publish path, so WARN was the wrong verdict. The check also honors `REDACTION_EXTRA_PATTERNS`, which is the variable both consumers read.

It validates the format and reports counts only. It never prints a rule, an identifier, or a match, because that file's contents are what the scanner protects. What it does state, because a new installation has no other way to learn it:

- one rule per line, `id|description|regex`
- `#` comments and blank lines are skipped
- the line is split on the first two pipes only, so the regex may contain `|`
- the regex must compile, since the inventory drops uncompilable rules without reporting them; a malformed rule narrows coverage while the file still looks populated

## Tests

`scripts/onboarding-preflight.sh` had none. `tests/test_onboarding_preflight.py` drives it against a stubbed host: a provisioned host reports no failure it can act on, skills pass without the installer CLI, `legacy_read_only` is named, an unbound Run fails, a bound legacy Run fails, an unset agent CLI fails, a missing rules file blocks instead of warning, and a malformed rule fails while nothing from the file appears in the output.

Two mutations confirmed the tests bite rather than merely pass: turning the rules-file FAIL back into a WARN fails `test_missing_rules_file_blocks_instead_of_warning`, and accepting a bound legacy Run fails `test_bound_legacy_run_fails`.

## Gates

- `PYTHONPATH=src uv run --with pytest --no-project python3 -m pytest tests -q` : 350 passed, 1 skipped, 13 subtests passed. The suite has to go through `uv` on this host, because its `python3` is below the 3.11 floor #16 introduced
- `REDACTION_REQUIRE_EXTRA=1 REDACTION_EXTRA_PATTERNS=... ./scripts/redaction-scan.sh` : exit 0, 0 findings, 125 files
- `REDACTION_EXTRA_PATTERNS=... ./scripts/redaction-inventory` : exit 1 with 110 uncovered candidates. Pre-existing and measured: the same command on the base commit alone reports 104. The 6 added by this branch are ordinary kebab-case words from the new prose and checks. The inventory's exit 1 is a triage list, not a secret.

## Notes for review

`TEMPLATE-VERSION` is not raised. #16 already moves it to 5 and that version has not shipped, so this extends the v5 entry rather than inventing a v6 for the same unreleased template. Say the word if you would rather have the bump.

The worker runtime list and the rules-file requirement encode one operator's routing policy. A public installer with different executors, or a workspace with no organization-specific identifiers to cover, will want to trim that list. It is a single array and one block, deliberately, but it is a hard gate now and that is a product decision worth confirming.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Expands the onboarding preflight to gate the full harness tool surface and measure orchestration by capability (requires a bound, non-legacy Run) instead of reachability. Fixes prior false negatives, prevents silent dispatch drops, and adds tests.

- **New Features**
  - Orchestration measured via `orca orchestration run-current`; requires a bound non-legacy Run; names `legacy_read_only` with a clear remedy; bound legacy Runs fail.
  - Skills checked by artifact first (search `ORCA_SKILLS_DIRS`), with the `skills` installer path kept for `--fix`.
  - Hard gates: `ORCA_AGENT_CLI` set and resolves on `PATH`; worker runtimes (`codex`, `cursor-agent`); `git`; `gh` with auth measured (warn if `workflow` scope is missing); runnable tests (`python3 -m pytest` on 3.11+ or via `uv`); writable dispatch ledger dir (`DISPATCH_GATE_LEDGER`).
  - Organization rules file required (`REDACTION_EXTRA_PATTERNS` or `~/.config/redaction-extra.txt`); validates format, compiles regexes, and reports counts only (never prints contents).
  - `python3` below 3.11 is reported as present-but-old, with version and a hint to run tests via `uv`; added `tests/test_onboarding_preflight.py` to exercise these checks and ensure rules content never leaks.

- **Migration**
  - Bind a fresh Run: `orca orchestration run-create`, then re-run preflight.
  - Create and validate the org rules file; at least one usable rule, format: `id|description|regex`.
  - Set `ORCA_AGENT_CLI` and ensure the CLI is on `PATH`; install worker runtimes (`codex`, `cursor-agent`).
  - Ensure `git` and `gh` are installed; `gh auth login`, and optionally add `workflow` scope.
  - Use Python 3.11+ or install `uv` for running tests.
  - Point `DISPATCH_GATE_LEDGER` to a writable location if needed.

<sup>Written for commit 8a777bafb2b426edec54e94d3a65f163e05e0daf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/baksohyeon/mogui-ADE-orchestrator/pull/17?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

