### PR TITLE
fix(preflight): SIGPIPE false negative on large captured output

### DIFF
--- a/scripts/onboarding-preflight.sh
+++ b/scripts/onboarding-preflight.sh
@@ -74,7 +74,7 @@ elif [[ "$orca_basename" != "orca" \
 else
   status_output=""
   if status_output=$("$orca_command" status --json 2>&1); then
-    if printf '%s\n' "$status_output" | grep -Eq '"ok"[[:space:]]*:[[:space:]]*true'; then
+    if grep -Eq '"ok"[[:space:]]*:[[:space:]]*true' <<<"$status_output"; then
       pass "orca" "$orca_command status --json returned ok:true"
       orca_ready=true
     else
@@ -90,9 +90,8 @@ if [[ "$orca_ready" == true ]]; then
   orchestration_status=0
   orchestration_output=$("$orca_command" orchestration task-list --json 2>&1) || orchestration_status=$?
   if { [[ $orchestration_status -eq 0 ]] \
-    && printf '%s\n' "$orchestration_output" \
-      | grep -Eq '"ok"[[:space:]]*:[[:space:]]*true'; } \
-    || printf '%s\n' "$orchestration_output" | grep -Eq '"code"[[:space:]]*:[[:space:]]*"run_required"'; then
+    && grep -Eq '"ok"[[:space:]]*:[[:space:]]*true' <<<"$orchestration_output"; } \
+    || grep -Eq '"code"[[:space:]]*:[[:space:]]*"run_required"' <<<"$orchestration_output"; then
     pass "orchestration" "RPC reachable (run_required is expected before a Run is bound)"
   else
     fail "orchestration" "RPC unavailable; enable Orca orchestration and retry"
@@ -130,8 +129,8 @@ if [[ ${#skills_command[@]} -eq 0 ]]; then
 else
   skills_output=$("${skills_command[@]}" list -g 2>&1 | strip_ansi) || skills_status=$?
   if [[ $skills_status -eq 0 ]] \
-    && printf '%s\n' "$skills_output" | grep -Eq '(^|[[:space:]])orca-cli([[:space:]]|$)' \
-    && printf '%s\n' "$skills_output" | grep -Eq '(^|[[:space:]])orchestration([[:space:]]|$)'; then
+    && grep -Eq '(^|[[:space:]])orca-cli([[:space:]]|$)' <<<"$skills_output" \
+    && grep -Eq '(^|[[:space:]])orchestration([[:space:]]|$)' <<<"$skills_output"; then
     pass "skills" "global orca-cli and orchestration skills are present"
   else
     skills_status=1
@@ -148,8 +147,8 @@ elif [[ "$fix" == true && ${#skills_command[@]} -gt 0 ]]; then
     "${skills_command[@]}" update orchestration -g || fix_status=$?
     skills_output=$("${skills_command[@]}" list -g 2>&1 | strip_ansi) || fix_status=$?
     if [[ $fix_status -eq 0 ]] \
-      && printf '%s\n' "$skills_output" | grep -Eq '(^|[[:space:]])orca-cli([[:space:]]|$)' \
-      && printf '%s\n' "$skills_output" | grep -Eq '(^|[[:space:]])orchestration([[:space:]]|$)'; then
+      && grep -Eq '(^|[[:space:]])orca-cli([[:space:]]|$)' <<<"$skills_output" \
+      && grep -Eq '(^|[[:space:]])orchestration([[:space:]]|$)' <<<"$skills_output"; then
       pass "skills" "installed global orca-cli and orchestration skills"
     else
       fail "skills" "required skills still missing after --fix"


### PR DESCRIPTION
Found while dogfooding the v5 upgrade minutes after #16 merged: the orchestration check reported `FAIL RPC unavailable` on a healthy runtime.

Mechanism: the script runs under `set -euo pipefail`, and checks shaped as `printf '%s\n' "$captured" | grep -Eq PATTERN` race once the captured output exceeds the pipe buffer (orchestration `task-list` is 74KB on this workspace today and grows with history). grep matches on line 3 and exits; printf's remaining write takes SIGPIPE; the pipeline exits 141; a healthy subsystem reads as FAIL. Nondeterministic by scheduling — a `bash -x` trace of a failing run shows `"ok": true` inside the very value the grep rejected.

Fix: replace all seven captured-variable `printf | grep` pipelines with here-string greps (no writer process, no SIGPIPE). Check semantics and messages unchanged.

Verification: full suite 342 passed / 1 skipped; five consecutive runs of the orchestration check PASS against an 80KB task-list response.

Note for #17: the same pattern appears in its new checks; rebasing onto this lands the fix there too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a false FAIL in preflight checks caused by SIGPIPE when parsing large outputs. Replaces `printf | grep` pipelines with here-string `grep` to remove the race, keeping check semantics and messages unchanged.

- **Bug Fixes**
  - Use here-strings with `grep` to avoid SIGPIPE on large captured output (e.g., 80KB orchestration task-list).
  - Verified: full suite passed; orchestration check now consistently reports PASS on healthy runtimes.

<sup>Written for commit d3eb59f5ed3fb5afe46006de89bf9bedb6cc42ba. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/baksohyeon/mogui-ADE-orchestrator/pull/18?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of onboarding preflight checks when validating service status, orchestration responses, and available skills.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->