### PR TITLE
fix(gate): casefold tier matching and record which policy decided

### DIFF
--- a/master-ops/CHANGELOG.md
+++ b/master-ops/CHANGELOG.md
@@ -32,6 +32,15 @@ ledger, and provides a stable plain-text `report` rollup for model use, cost
 proxy, denials, overrides, and time span. Existing installations should copy
 and customize the policy file before adopting this gate version.
 
+Model identifiers are matched casefolded, because exact-string membership let a
+case variant of a denied tier miss the denied set and pass as a warning wherever
+`unknown_model` is `warn`. Every check entry also records `tier_policy_path` and
+`tier_policy_sha256`, and `report` lists each policy a span was judged against:
+the policy path is caller-supplied through `--tier-policy` or
+`DISPATCH_TIER_POLICY`, so without that identity an allowed top-tier dispatch
+cannot be told apart from one a substituted policy allowed. More than one policy
+row in a day's rollup is the signal.
+
 Upgrade an existing installation by copying `master-ops/model-tier-policy.json`,
 re-running `bash scripts/onboarding-preflight.sh`, and raising the installed
 `Template version` line to 6.

--- a/master-ops/docs/MASTER-OPERATIONS.md
+++ b/master-ops/docs/MASTER-OPERATIONS.md
@@ -164,7 +164,7 @@ L=~/.mogui/dispatch-ledger.jsonl
 "$G" --ledger "$L" register --job-id <job-id> --probe-cmd "<command proving the job-id appears in an artifact>" --orchestration-task <task-id>
 ```
 
-The gate enforces `model-tier-policy.json`; an exceptional denied-tier dispatch requires `--tier-override "<reason>"`, and every accepted override is recorded in the ledger.
+The gate enforces `model-tier-policy.json`; an exceptional denied-tier dispatch requires `--tier-override "<reason>"`, and every accepted override is recorded in the ledger. Model identifiers match casefolded, so a denied tier spelled in another case is the same tier. Each decision records the policy path and its `sha256`, because that path is caller-supplied; `dispatch-gate report` lists every policy a span was judged against, and more than one row means the span was not judged against one policy.
 
 Before attaching a Codex worker, run `scripts/codex-worker-pretrust <worktree-path>` so startup never blocks on the trust prompt.
 

--- a/scripts/dispatch-gate
+++ b/scripts/dispatch-gate
@@ -200,8 +200,18 @@ def _report(args: argparse.Namespace) -> int:
     model_stats: dict[str, list[int]] = {}
     denial_counts: Counter[str] = Counter()
     override_counts: Counter[tuple[str, str]] = Counter()
+    policy_counts: Counter[tuple[str, str]] = Counter()
     timestamps: list[float] = []
     for entry in entries:
+        policy_path = entry.get("tier_policy_path")
+        policy_digest = entry.get("tier_policy_sha256")
+        if isinstance(policy_path, str) and policy_path:
+            policy_counts[
+                (
+                    policy_path,
+                    policy_digest if isinstance(policy_digest, str) else "",
+                )
+            ] += 1
         timestamp = _timestamp(entry.get("ts"))
         if timestamp is not None:
             timestamps.append(timestamp)
@@ -254,6 +264,18 @@ def _report(args: argparse.Namespace) -> int:
     if denial_counts:
         for reason in sorted(denial_counts):
             print(f"  {reason}: {denial_counts[reason]}")
+    else:
+        print("  <none>")
+
+    # More than one row here means the day was not judged against one policy.
+    print("Tier policies:")
+    if policy_counts:
+        for policy_path, policy_digest in sorted(policy_counts):
+            digest_label = policy_digest[:12] if policy_digest else "<unrecorded>"
+            print(
+                f"  {policy_path}: sha256={digest_label} "
+                f"decisions={policy_counts[(policy_path, policy_digest)]}"
+            )
     else:
         print("  <none>")
 

--- a/src/master_runtime/core/dispatch_gate.py
+++ b/src/master_runtime/core/dispatch_gate.py
@@ -135,11 +135,18 @@ class DispatchTicket:
 
 @dataclass(frozen=True)
 class ModelTierPolicy:
-    """Validated per-installation worker model policy."""
+    """Validated per-installation worker model policy.
+
+    Model sets are casefolded. Exact-string membership let a case variant of a
+    denied tier miss the denied set, fall into the unknown branch, and pass as a
+    warning wherever `unknown_model` is `warn`. `digest` identifies the file the
+    decision was made against, because the path is caller-supplied.
+    """
 
     worker_allowed: frozenset[str]
     worker_denied_tiers: frozenset[str]
     unknown_model: str
+    digest: str = ""
 
 
 class DispatchGate:
@@ -155,6 +162,11 @@ class DispatchGate:
 
     def check(self, request: DispatchRequest) -> GateDecision:
         """Return a gate decision and append it to the ledger."""
+
+        # Per-call, reset before anything can append: entries written before the
+        # policy loads must not inherit a digest from an earlier check. One gate
+        # instance per process is the assumption here, same as the ticket lock.
+        self._tier_policy_digest = ""
 
         # None is the fail-closed sentinel for an input whose size could not be
         # measured. Handle it before every other validation or budget check so
@@ -183,12 +195,15 @@ class DispatchGate:
             self._append_decision(request, decision)
             return decision
 
+        self._tier_policy_digest = tier_policy.digest
         tier_policy_warning = False
         tier_override: str | None = None
         model = request.model.strip() if request.model is not None else ""
-        if model not in tier_policy.worker_allowed:
+        # Casefolded: a denied tier spelled in another case is the same tier.
+        model_key = model.casefold()
+        if model_key not in tier_policy.worker_allowed:
             policy_denies = (
-                model in tier_policy.worker_denied_tiers
+                model_key in tier_policy.worker_denied_tiers
                 or tier_policy.unknown_model == "deny"
             )
             if policy_denies:
@@ -451,6 +466,12 @@ class DispatchGate:
             entry["warnings"] = [warning.value for warning in decision.warnings]
         if decision.tier_override is not None:
             entry["tier_override"] = decision.tier_override
+        # Which policy decided. The path is caller-supplied through --tier-policy
+        # or DISPATCH_TIER_POLICY, so an ALLOW that names neither path nor digest
+        # cannot be told apart from one a substituted policy allowed.
+        entry["tier_policy_path"] = str(self.config.tier_policy_path)
+        if getattr(self, "_tier_policy_digest", ""):
+            entry["tier_policy_sha256"] = self._tier_policy_digest
         self._append_entry(entry)
 
     def _append_entry(self, entry: Mapping[str, object]) -> None:
@@ -652,7 +673,8 @@ def _validate_request(request: DispatchRequest) -> ReasonCode | None:
 
 
 def _load_tier_policy(path: Path) -> ModelTierPolicy:
-    payload = json.loads(path.read_text(encoding="utf-8"))
+    raw = path.read_bytes()
+    payload = json.loads(raw.decode("utf-8"))
     if (
         not isinstance(payload, dict)
         or isinstance(payload.get("version"), bool)
@@ -671,6 +693,7 @@ def _load_tier_policy(path: Path) -> ModelTierPolicy:
         worker_allowed=worker_allowed,
         worker_denied_tiers=worker_denied_tiers,
         unknown_model=unknown_model,
+        digest=hashlib.sha256(raw).hexdigest(),
     )
 
 
@@ -681,7 +704,7 @@ def _model_list(value: object) -> frozenset[str]:
         raise ValueError("model identifiers must be non-empty strings")
     if any(model != model.strip() for model in value):
         raise ValueError("model identifiers must not have surrounding whitespace")
-    return frozenset(value)
+    return frozenset(model.casefold() for model in value)
 
 
 def _dispatch_ticket_path(

--- a/tests/test_dispatch_gate.py
+++ b/tests/test_dispatch_gate.py
@@ -1575,6 +1575,39 @@ def test_cli_report_rolls_up_models_denials_and_overrides(
     )
 
 
+def test_cli_report_shows_every_policy_a_day_was_judged_against(
+    tmp_path: Path,
+    capsys,
+) -> None:
+    """Two rows here mean the day was not judged against one policy."""
+
+    script = runpy.run_path(str(_script()), run_name="dispatch_gate_test")
+    ledger = tmp_path / "policy-report-ledger.jsonl"
+    rows = (
+        {"tier_policy_path": "/policies/installation.json", "tier_policy_sha256": "a" * 64},
+        {"tier_policy_path": "/policies/installation.json", "tier_policy_sha256": "a" * 64},
+        {"tier_policy_path": "/tmp/substituted.json", "tier_policy_sha256": "b" * 64},
+        {"tier_policy_path": "/policies/legacy-entry.json"},
+    )
+    with ledger.open("w", encoding="utf-8") as handle:
+        for index, row in enumerate(rows):
+            entry = {
+                "ts": 1_785_000_000 + index,
+                "decision": "ALLOW",
+                "reason": "OK",
+                "model": "gpt-5.6-luna",
+                "cost_proxy": 10,
+                **row,
+            }
+            handle.write(json.dumps(entry) + "\n")
+
+    assert script["main"](["--ledger", str(ledger), "report"]) == 0
+    output = capsys.readouterr().out
+    assert f"/policies/installation.json: sha256={'a' * 12} decisions=2" in output
+    assert f"/tmp/substituted.json: sha256={'b' * 12} decisions=1" in output
+    assert "/policies/legacy-entry.json: sha256=<unrecorded> decisions=1" in output
+
+
 def test_cli_report_uses_stored_cost_and_labels_legacy_computation(
     tmp_path: Path,
     capsys,
@@ -1833,6 +1866,114 @@ class _MutableClock:
 
     def __call__(self) -> float:
         return self.value
+
+
+def test_case_variant_of_denied_tier_is_denied_under_warn(tmp_path: Path) -> None:
+    """Exact-string membership let a case variant reach the unknown branch."""
+
+    contract = _contract(tmp_path, "case variant of a denied tier")
+    gate = _gate(
+        tmp_path,
+        now=1_000,
+        tier_policy_path=_tier_policy(tmp_path, unknown_model="warn"),
+    )
+
+    decision = gate.check(
+        DispatchRequest(
+            runtime="codex",
+            model="GPT-5.6-SOL",
+            contract_path=contract,
+            est_input_chars=10_000,
+            n_agents=1,
+        )
+    )
+
+    assert decision.allow is False
+    assert decision.reason == ReasonCode.TIER_POLICY
+    assert _ledger_entries(tmp_path)[-1]["model"] == "GPT-5.6-SOL"
+    assert not (tmp_path / "dispatch-tickets").exists()
+
+
+def test_case_variant_of_allowed_model_stays_allowed(tmp_path: Path) -> None:
+    contract = _contract(tmp_path, "case variant of an allowed model")
+    gate = _gate(tmp_path, now=1_000)
+
+    decision = gate.check(
+        DispatchRequest(
+            runtime="codex",
+            model="GPT-5.6-Luna",
+            contract_path=contract,
+            est_input_chars=10_000,
+            n_agents=1,
+        )
+    )
+
+    assert decision.allow is True
+    assert decision.reason == ReasonCode.OK
+
+
+def test_ledger_records_which_tier_policy_decided(tmp_path: Path) -> None:
+    """The policy path is caller-supplied, so the decision must name the file."""
+
+    policy = _tier_policy(tmp_path)
+    digest = hashlib.sha256(policy.read_bytes()).hexdigest()
+    gate = _gate(tmp_path, now=1_000, tier_policy_path=policy)
+
+    allowed = gate.check(
+        DispatchRequest(
+            runtime="codex",
+            model="gpt-5.6-luna",
+            contract_path=_contract(tmp_path, "policy identity on allow"),
+            est_input_chars=10_000,
+            n_agents=1,
+        )
+    )
+    denied = gate.check(
+        DispatchRequest(
+            runtime="codex",
+            model="gpt-5.6-sol",
+            contract_path=_contract(tmp_path, "policy identity on deny"),
+            est_input_chars=10_000,
+            n_agents=1,
+        )
+    )
+
+    assert allowed.allow is True
+    assert denied.allow is False
+    entries = _ledger_entries(tmp_path)[-2:]
+    assert [entry["tier_policy_path"] for entry in entries] == [str(policy)] * 2
+    assert [entry["tier_policy_sha256"] for entry in entries] == [digest] * 2
+
+
+def test_tier_policy_rejects_case_differing_duplicate_across_sets(
+    tmp_path: Path,
+) -> None:
+    policy = tmp_path / "model-tier-policy.json"
+    policy.write_text(
+        json.dumps(
+            {
+                "version": 1,
+                "worker_allowed": ["gpt-5.6-luna"],
+                "worker_denied_tiers": ["GPT-5.6-LUNA"],
+                "unknown_model": "deny",
+            }
+        ),
+        encoding="utf-8",
+    )
+    gate = _gate(tmp_path, now=1_000, tier_policy_path=policy)
+
+    decision = gate.check(
+        DispatchRequest(
+            runtime="codex",
+            model="gpt-5.6-luna",
+            contract_path=_contract(tmp_path, "overlapping policy sets"),
+            est_input_chars=10_000,
+            n_agents=1,
+        )
+    )
+
+    assert decision.allow is False
+    assert decision.reason == ReasonCode.TIER_POLICY_UNAVAILABLE
 
 
 def _gate(


### PR DESCRIPTION
Follow-up to #19, from the two findings in https://github.com/baksohyeon/mogui-ADE-orchestrator/pull/19#issuecomment-5157575897. Both were found by running the gate at `3ba33b0` rather than reading it, and both are closed here with a live re-measurement.

## Casefolded model matching

Membership was exact-string, so a case variant of a denied tier missed `worker_denied_tiers`, fell into the unknown branch, and passed as a warning wherever `unknown_model` is `warn`.

```
policy: worker_denied_tiers=["claude-opus-5"], unknown_model="warn"

before:  --model CLAUDE-OPUS-5  ->  {"allow":true,"reason":"OK","warnings":["TIER_POLICY"]}
after:   --model CLAUDE-OPUS-5  ->  {"allow":false,"reason":"TIER_POLICY"}
```

The overlap validation now also catches sets that differ only by case. `test_noncanonical_denied_tier_never_fails_open` covered whitespace and read as though it covered this, so the case variant is now a test of its own rather than a broader name.

## The ledger names the policy that decided

The policy path is caller-supplied through `--tier-policy` or `DISPATCH_TIER_POLICY`, and nothing recorded it. An ALLOW produced under a substituted permissive policy was byte-indistinguishable from one the installation's own policy allowed. Measured before: `--model claude-opus-5 --tier-policy policy-permissive.json` returned `reason: OK` with no trace of the swap.

Every check entry now carries `tier_policy_path` and `tier_policy_sha256`, and `report` groups by policy:

```
Tier policies:
  /policies/installation.json: sha256=aaaaaaaaaaaa decisions=2
  /tmp/substituted.json: sha256=bbbbbbbbbbbb decisions=1
  /policies/legacy-entry.json: sha256=<unrecorded> decisions=1
```

More than one row in a span is the signal. Entries written before this change keep working and are labeled `<unrecorded>`.

This does not try to sandbox the gate. A caller can point `--ledger` anywhere too, and a cooperative tool cannot stop its operator. It makes the ledger able to answer which policy was in force, which is what the `report` rollup exists to do.

## Gates

- `PYTHONPATH=src uv run --with pytest --no-project python3 -m pytest tests -q` : 360 passed, 1 skipped, 13 subtests passed
- `REDACTION_REQUIRE_EXTRA=1 REDACTION_EXTRA_PATTERNS=… ./scripts/redaction-scan.sh` : exit 0, 0 findings, 125 files

Docs moved with the code: the enforcement sentence in `MASTER-OPERATIONS.md` and the v6 CHANGELOG entry both state the casefolding and the recorded policy identity. `TEMPLATE-VERSION` stays at 6, since #19 introduced it and this extends the same unreleased entry.

The third finding from that review is not here: the gate enforces the model a caller declares at `check` time, and `register` takes no model, so a worker that inherits a different model than the master declared still registers clean. That is the incident class #19 cites and it needs `register` to probe the worker's actual model, which is its own change.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes tier matching by casefolding model identifiers and records which tier policy decided each check, making denials consistent and audits traceable.

- **Bug Fixes**
  - Casefolded model matching for `worker_allowed` and `worker_denied_tiers` so case variants can’t bypass denials when `unknown_model="warn"`.
  - Validation now rejects policies where allowed/denied sets differ only by case.

- **New Features**
  - Each ledger entry now includes `tier_policy_path` and `tier_policy_sha256`.
  - `dispatch-gate report` adds a “Tier policies” section that groups decisions by policy path and digest; legacy entries without a digest show `<unrecorded>`.

<sup>Written for commit 9204a78592ec1797fd3dc3f4a918a57a88474937. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/baksohyeon/mogui-ADE-orchestrator/pull/20?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Reports now show every tier policy used for decisions, including decision counts and policy checksums when available.
  * Policy identity is recorded for each dispatch decision to improve traceability.
* **Bug Fixes**
  * Model matching is now case-insensitive for consistent allow and deny decisions.
  * Policies with conflicting case-only duplicates are rejected safely.
* **Documentation**
  * Updated dispatch gate guidance and changelog with policy attribution and matching behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->