### PR TITLE
feat(preflight): graded enforcement with printed waivers

### DIFF
--- a/master-ops/CHANGELOG.md
+++ b/master-ops/CHANGELOG.md
@@ -55,6 +55,17 @@ Python before onboarding proceeds. It also gates the rest of the tool surface a
 master and its workers actually invoke: the named agent CLI, the worker runtimes
 dispatch targets, Git, an authenticated `gh`, a runnable test entry point, a
 writable dispatch ledger directory, and the organization rules file.
+
+Enforcement is graded rather than absolute, because a check that cannot be
+satisfied and cannot be waived teaches the operator to skip the whole preflight
+and lose every other check with it. `PREFLIGHT_WAIVE=<labels>` downgrades named
+failures to printed, counted waivers, and the summary then reads READY WITH
+WAIVERS and lists them: a waived required check was not satisfied. Entries that
+match no check are named as well, since a misspelled waiver leaves the check
+enforced while the operator believes otherwise. Two checks are graded on their
+own: a missing worker runtime warns when another listed runtime resolves, and
+`gh` blocks only when the binary is absent, while unauthenticated or a missing
+`workflow` scope warns.
 `ONBOARDING.md` is rewritten as a token-lean script-and-command flow while
 retaining its questions, safeguards, and verification gates; `--fix` may add or
 refresh only the required global skills. Template v5 also adds the append-only

--- a/master-ops/ONBOARDING.md
+++ b/master-ops/ONBOARDING.md
@@ -33,7 +33,7 @@ Use only these template placeholders: `{{WORKSPACE_NAME}}`, `{{WORKSPACE_ROOT}}`
 
 **Position and action:** Step 0 starts after orientation, with no workspace state changed: run `bash scripts/onboarding-preflight.sh` from `{{RUNTIME_ROOT}}` and fix every FAIL before continuing.
 
-**Why/caution:** Orca, an orchestration Run bound to this terminal, the Orca skills, Beads, Python, the named agent CLI, the worker runtimes it dispatches to, Git, `gh`, and the organization rules file are all required; do not offer a non-Orca fallback. Orchestration is measured by capability rather than reachability: a retained legacy coordinator answers reads and drops writes with `effectsApplied:false`, so a dispatch record can survive while the worker receives nothing. If the preflight reports that, bind a fresh Run with `orca orchestration run-create` and measure again; restarting the app does not clear it.
+**Why/caution:** Orca, an orchestration Run bound to this terminal, the Orca skills, Beads, Python, the named agent CLI, at least one worker runtime to dispatch to, Git, and the organization rules file are all required; do not offer a non-Orca fallback. A host that legitimately cannot satisfy one required check sets `PREFLIGHT_WAIVE=<check-label>`, which downgrades that FAIL to a printed and counted waiver; the summary then reads READY WITH WAIVERS and names them, because a required check that was waived was not satisfied. Never suggest skipping the preflight itself: that discards every other check with it. Orchestration is measured by capability rather than reachability: a retained legacy coordinator answers reads and drops writes with `effectsApplied:false`, so a dispatch record can survive while the worker receives nothing. If the preflight reports that, bind a fresh Run with `orca orchestration run-create` and measure again; restarting the app does not clear it.
 
 Ask whether the user is ready for local read-only checks and which agent CLI they expect to use, such as `claude`.
 
@@ -52,8 +52,9 @@ Verify:
 
 - the preflight exits zero, Orca status was measured, a non-legacy orchestration Run is bound to this terminal, required skills resolve, `bd` is present and resolves to the ops repo when one exists, and Python is present
 - the named agent CLI is set and resolves on `PATH`; an unset selection is a FAIL, because it silently downgrades the agent-specific checks to INFO
-- the worker runtimes this master dispatches to resolve on `PATH`
-- Git and `gh` are present, `gh` is authenticated, and a missing `workflow` scope was reported
+- at least one of the worker runtimes this master dispatches to resolves on `PATH`; the others are reported as warnings, since routing every lane through one executor is a normal setup
+- Git is present, and `gh` state was reported: a missing binary blocks, while unauthenticated or a missing `workflow` scope warns, because local-only work needs no forge credentials
+- every waiver in the summary was intended, and `PREFLIGHT_WAIVE` entries that matched no check are corrected rather than left, since a misspelled waiver leaves the check enforced
 - the organization rules file loads at least one rule and no rule is malformed; the preflight reports counts only and never the file's contents
 
 ## Step 1. Collect Workspace Facts

--- a/scripts/onboarding-preflight.sh
+++ b/scripts/onboarding-preflight.sh
@@ -11,18 +11,48 @@ esac
 failures=0
 passes=0
 warnings=0
+waived=0
+
+# A required check that cannot be waived pushes the operator toward skipping the
+# whole preflight, which loses every other check with it. PREFLIGHT_WAIVE names
+# checks to downgrade from FAIL to WARN, and a waiver is always printed and
+# counted: the escape exists, and it is never silent. Same shape as the gate's
+# ledgered --tier-override.
+waive_list=()
+if [[ -n "${PREFLIGHT_WAIVE:-}" ]]; then
+  IFS=',' read -r -a waive_list <<<"$PREFLIGHT_WAIVE"
+fi
+waived_labels=()
+seen_labels=()
+
+is_waived() {
+  local candidate
+  for candidate in ${waive_list[@]+"${waive_list[@]}"}; do
+    [[ "${candidate// /}" == "$1" ]] && return 0
+  done
+  return 1
+}
 
 pass() {
+  seen_labels+=("$1")
   passes=$((passes + 1))
   printf 'PASS %-14s %s\n' "$1" "$2"
 }
 
 fail() {
+  seen_labels+=("$1")
+  if is_waived "$1"; then
+    waived=$((waived + 1))
+    waived_labels+=("$1")
+    printf 'WAIVED %-12s %s (downgraded from FAIL by PREFLIGHT_WAIVE)\n' "$1" "$2"
+    return
+  fi
   failures=$((failures + 1))
   printf 'FAIL %-14s %s\n' "$1" "$2"
 }
 
 warn() {
+  seen_labels+=("$1")
   warnings=$((warnings + 1))
   printf 'WARN %-14s %s\n' "$1" "$2"
 }
@@ -328,10 +358,21 @@ else
   pass "agent-cli" "$agent_cli resolves on PATH"
 fi
 
+# One reachable executor is enough to delegate. Requiring every listed runtime
+# blocks a host that routes all work through one of them, which is a normal
+# setup, so a missing runtime is a WARN and no runtime at all is the failure.
 worker_runtimes=(codex cursor-agent)
+worker_runtime_found=false
+for worker_runtime in "${worker_runtimes[@]}"; do
+  if command -v "$worker_runtime" >/dev/null 2>&1; then
+    worker_runtime_found=true
+  fi
+done
 for worker_runtime in "${worker_runtimes[@]}"; do
   if command -v "$worker_runtime" >/dev/null 2>&1; then
     pass "worker-runtime" "$worker_runtime present"
+  elif [[ "$worker_runtime_found" == true ]]; then
+    warn "worker-runtime" "$worker_runtime is not on PATH; another listed runtime is, so dispatch is still possible on this host"
   else
     fail "worker-runtime" "$worker_runtime is not on PATH; a master that cannot reach its executors cannot delegate"
   fi
@@ -355,7 +396,9 @@ if command -v gh >/dev/null 2>&1; then
       warn "gh-auth" "authenticated without the workflow scope; pushing or editing GitHub Actions workflows will fail; run: gh auth refresh -h github.com -s workflow"
     fi
   else
-    fail "gh-auth" "gh is not authenticated; run: gh auth login"
+    # Local-only work needs no forge credentials; the block belongs at push time,
+    # not at onboarding. Waive-able as gh-auth if the host never pushes.
+    warn "gh-auth" "gh is not authenticated, so pushing branches and opening pull requests will fail; run: gh auth login"
   fi
 fi
 
@@ -389,12 +432,38 @@ else
   fi
 fi
 
+# A waiver that matched nothing is a typo, and a typo'd waiver leaves the check
+# enforced while the operator believes otherwise. Name the ones that never fired.
+unmatched_waivers=()
+for waive_label in ${waive_list[@]+"${waive_list[@]}"}; do
+  waive_label="${waive_label// /}"
+  [[ -z "$waive_label" ]] && continue
+  waive_matched=false
+  for seen_label in ${seen_labels[@]+"${seen_labels[@]}"}; do
+    [[ "$seen_label" == "$waive_label" ]] && waive_matched=true && break
+  done
+  [[ "$waive_matched" == false ]] && unmatched_waivers+=("$waive_label")
+done
+
 printf '\nPreflight summary\n'
 printf '  PASS: %d\n' "$passes"
 printf '  WARN: %d\n' "$warnings"
 printf '  FAIL: %d\n' "$failures"
+printf '  WAIVED: %d' "$waived"
+if [[ ${#waived_labels[@]} -gt 0 ]]; then
+  printf ' (%s)' "$(IFS=,; printf '%s' "${waived_labels[*]}")"
+fi
+printf '\n'
+if [[ ${#unmatched_waivers[@]} -gt 0 ]]; then
+  printf '  NOTE: PREFLIGHT_WAIVE named checks that did not run: %s; those checks are still enforced\n' \
+    "$(IFS=,; printf '%s' "${unmatched_waivers[*]}")"
+fi
 if [[ $failures -eq 0 ]]; then
-  printf '  READY: all required checks passed\n'
+  if [[ $waived -gt 0 ]]; then
+    printf '  READY WITH WAIVERS: %d required check(s) were downgraded, not satisfied\n' "$waived"
+  else
+    printf '  READY: all required checks passed\n'
+  fi
 else
   printf '  BLOCKED: fix every FAIL before onboarding\n'
   exit 1

--- a/tests/test_onboarding_preflight.py
+++ b/tests/test_onboarding_preflight.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import os
 import re
 import subprocess
+import sys
 from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
@@ -55,7 +56,13 @@ def _write_stub(path: Path, body: str) -> None:
     path.chmod(0o755)
 
 
-def _host(tmp_path: Path, *, rules: str | None = "id|description|abc[0-9]+") -> dict:
+def _host(
+    tmp_path: Path,
+    *,
+    rules: str | None = "id|description|abc[0-9]+",
+    worker_runtimes: tuple[str, ...] = ("codex", "cursor-agent"),
+    sanitized_path: bool = False,
+) -> dict:
     """Provision a stub host and return the env for running the preflight."""
 
     home = tmp_path / "home"
@@ -80,14 +87,22 @@ def _host(tmp_path: Path, *, rules: str | None = "id|description|abc[0-9]+") -> 
     _write_stub(bin_dir / "orca", ORCA_STUB)
     _write_stub(bin_dir / "bd", BD_STUB)
     _write_stub(bin_dir / "gh", GH_STUB)
-    for name in ("codex", "cursor-agent", "claude", "git"):
+    for name in ("claude", "git", *worker_runtimes):
         _write_stub(bin_dir / name, TRUE_STUB)
 
     env = dict(os.environ)
+    # Sanitized PATH keeps a runtime absent even when the developer's machine has
+    # it installed; the system directories stay because the script uses sed,
+    # grep, dirname, realpath, and python3.
+    path = (
+        f"{bin_dir}:{Path(sys.executable).parent}:/usr/bin:/bin"
+        if sanitized_path
+        else f"{bin_dir}:{env['PATH']}"
+    )
     env.update(
         {
             "HOME": str(home),
-            "PATH": f"{bin_dir}:{env['PATH']}",
+            "PATH": path,
             "ORCA_AGENT_CLI": "claude",
             "ORCA_CLI_COMMAND": "",
             "ORCA_DEV_REPO_ROOT": "",
@@ -202,3 +217,45 @@ def test_malformed_rule_fails_and_nothing_from_the_file_is_printed(
     assert "1 of 2" in output, output
     for leaked in ("canary", "abc(unclosed", "xyz[0-9]"):
         assert leaked not in output, output
+
+
+def test_waived_failure_is_labeled_and_stops_blocking(tmp_path: Path) -> None:
+    """The escape exists so the whole preflight is not skipped, and it is loud."""
+
+    env = _host(tmp_path, rules=None)
+    env["PREFLIGHT_WAIVE"] = "redaction-extra, python3"
+    result = _run(env, tmp_path)
+    assert "redaction-extra" not in _labels(result.stdout, "FAIL"), result.stdout
+    assert "WAIVED" in result.stdout
+    assert "downgraded from FAIL by PREFLIGHT_WAIVE" in result.stdout
+    assert "READY WITH WAIVERS" in result.stdout
+    assert "downgraded, not satisfied" in result.stdout
+    assert result.returncode == 0, result.stdout
+
+
+def test_waiver_that_matched_nothing_keeps_the_check_enforced(tmp_path: Path) -> None:
+    """A typo'd waiver must not read as a waiver."""
+
+    env = _host(tmp_path, rules=None)
+    env["PREFLIGHT_WAIVE"] = "redaction-extras"
+    result = _run(env, tmp_path)
+    assert "redaction-extra" in _labels(result.stdout, "FAIL"), result.stdout
+    assert "named checks that did not run: redaction-extras" in result.stdout
+    assert "still enforced" in result.stdout
+    assert result.returncode == 1
+
+
+def test_one_missing_worker_runtime_warns_when_another_is_present(
+    tmp_path: Path,
+) -> None:
+    env = _host(tmp_path, worker_runtimes=("codex",), sanitized_path=True)
+    result = _run(env, tmp_path)
+    assert "worker-runtime" in _labels(result.stdout, "WARN"), result.stdout
+    assert "worker-runtime" not in _labels(result.stdout, "FAIL"), result.stdout
+
+
+def test_no_worker_runtime_at_all_fails(tmp_path: Path) -> None:
+    env = _host(tmp_path, worker_runtimes=(), sanitized_path=True)
+    result = _run(env, tmp_path)
+    assert "worker-runtime" in _labels(result.stdout, "FAIL"), result.stdout
+    assert "cannot delegate" in result.stdout


### PR DESCRIPTION
Follows #17, which made the new checks absolute. Absolute is the wrong setting for some of them, and the failure mode is specific: a required check a host cannot satisfy and cannot waive teaches the operator to skip the whole preflight, losing every other check with it.

## PREFLIGHT_WAIVE

`PREFLIGHT_WAIVE=<labels>` downgrades named failures. A waiver is printed and counted, never inferred:

```
$ bash scripts/onboarding-preflight.sh
FAIL python3        present but 3.9.6 is below the required 3.11 …
FAIL agent-cli      ORCA_AGENT_CLI is unset …
  FAIL: 2
  BLOCKED: fix every FAIL before onboarding      (exit 1)

$ PREFLIGHT_WAIVE="python3, agent-cli" bash scripts/onboarding-preflight.sh
WAIVED python3      … (downgraded from FAIL by PREFLIGHT_WAIVE)
WAIVED agent-cli    … (downgraded from FAIL by PREFLIGHT_WAIVE)
  FAIL: 0
  WAIVED: 2 (python3,agent-cli)
  READY WITH WAIVERS: 2 required check(s) were downgraded, not satisfied      (exit 0)
```

The summary says downgraded, not satisfied, on purpose. A waiver is a record that something is missing, not a pass.

A waiver that matched no check is named as well, because a misspelled waiver leaves the check enforced while the operator believes it is waived:

```
$ PREFLIGHT_WAIVE="pythonn" bash scripts/onboarding-preflight.sh
  WAIVED: 0
  NOTE: PREFLIGHT_WAIVE named checks that did not run: pythonn; those checks are still enforced
  BLOCKED: fix every FAIL before onboarding      (exit 1)
```

This is the same shape as the gate's `--tier-override`: the escape exists and it lands in the record.

## Two checks graded without needing a waiver

- a missing worker runtime warns when another listed runtime resolves. Routing every lane through one executor is a normal setup; only zero reachable executors makes delegation impossible, and that still fails
- `gh` blocks when the binary is absent. Unauthenticated, or authenticated without the `workflow` scope, warns: local-only work needs no forge credentials, and the block belongs at push time

What stays absolute: Orca, a bound non-legacy orchestration Run, the Orca skills, the named agent CLI, `bd`, the Python floor, a runnable test entry point, a writable ledger directory, and the organization rules file. Any of them can still be waived explicitly, which is the point.

## Tests

Four added, twelve total in this file: a waived failure exits zero while labeled, a waiver that matched nothing keeps the check enforced, one missing runtime warns while another is present, and no runtime at all fails. The last two run with a sanitized `PATH` so a runtime stays absent on a machine that has it installed.

Both waiver paths were mutation-checked rather than assumed: deleting the WAIVED line fails `test_waived_failure_is_labeled_and_stops_blocking`, and disabling the unmatched-waiver note fails `test_waiver_that_matched_nothing_keeps_the_check_enforced`.

## Gates

- `PYTHONPATH=src uv run --with pytest --no-project python3 -m pytest tests -q` : 372 passed, 1 skipped, 13 subtests passed
- `REDACTION_REQUIRE_EXTRA=1 REDACTION_EXTRA_PATTERNS=… ./scripts/redaction-scan.sh` : exit 0, 0 findings, 126 files

`ONBOARDING.md` and the v6 CHANGELOG entry both moved with the code: the required-list sentence, the Step 0 acceptance bullets, and the instruction never to suggest skipping the preflight itself.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds graded enforcement to the onboarding preflight so required failures can be downgraded to printed waivers via `PREFLIGHT_WAIVE`, reducing pressure to skip the preflight. Also relaxes `worker-runtime` and `gh` auth checks to warn in common acceptable setups.

- **New Features**
  - `PREFLIGHT_WAIVE=<labels>` downgrades named `FAIL` checks to `WAIVED`, prints them, counts them, and summarizes as “READY WITH WAIVERS”.
  - Flags waiver labels that matched no check, clarifying those checks are still enforced.
  - `worker-runtime`: warn when at least one listed runtime is present; fail only when none are reachable.
  - `gh`: fail only when the binary is missing; unauthenticated or missing `workflow` scope now warns.
  - Updated `ONBOARDING.md` and `CHANGELOG.md` to document graded enforcement and waiver usage.

- **Migration**
  - Use `PREFLIGHT_WAIVE="label1,label2"` when a host cannot satisfy specific required checks.
  - Review the summary for “READY WITH WAIVERS” and confirm each waiver was intended.
  - Fix any waiver labels called out as “did not run”; those checks remain enforced.

<sup>Written for commit 2ebddd4d201e8947660c683996e7d3e5da8caa78. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/baksohyeon/mogui-ADE-orchestrator/pull/22?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

