### PR TITLE
feat(gate): register measures the worker's model, not just the declaration

### DIFF
--- a/master-ops/CHANGELOG.md
+++ b/master-ops/CHANGELOG.md
@@ -37,6 +37,35 @@ reporting the last released tag, so that value names the release it came from an
 not the exact body it received. When the difference matters, record the commit the
 installation was taken from alongside the tag.
 
+## Unreleased
+
+`register` now compares the model a dispatch declared with the model the worker
+actually ran. Until now the gate enforced the declaration at `check` and
+`register` took no model at all, so a worker inheriting a tier nobody asked for
+registered clean: the incident the tier policy exists for lives one step past the
+declaration.
+
+Declare the measurement per dispatch with `--model-probe-cmd`, alongside
+`--declared-model`. The command must read an artifact the agent itself produced,
+such as its session transcript; `scripts/model-identity-probe` is the reference
+implementation. A TUI status line is not a measurement source, because it is what
+a renderer drew rather than what the session recorded, and authenticating against
+it would leave a verification stamp with nothing behind it.
+
+The verdict is graded rather than absolute. No declared model warns as
+`MODEL_UNVERIFIED`, a probe that returns nothing warns as `MODEL_PROBE_FAILED`,
+and both still register: a runtime with no way to report its model would
+otherwise be unable to dispatch, and a check nobody can satisfy is a check nobody
+enables. A measured model in a tier the policy watches more closely than the
+declared one denies with `MODEL_TIER_ESCALATION`. Running looser than declared
+warns as `MODEL_MISMATCH`. Every registration records `model_declared`,
+`model_measured`, and `model_verified`, so an unverified one is distinguishable
+from a verified one.
+
+Tier ranking reuses the policy's own per-window caps rather than a new ordering
+field, so the two cannot disagree about which tier is trusted less. Version 1
+policies have no tiers to rank, so a mismatch there is recorded and not ranked.
+
 ## v0.2.0
 
 `docs/MASTER-OPERATIONS.md` gains an Incident-Derived Rules section: eleven

--- a/master-ops/docs/MASTER-OPERATIONS.md
+++ b/master-ops/docs/MASTER-OPERATIONS.md
@@ -161,12 +161,16 @@ L=~/.mogui/dispatch-ledger.jsonl
 
 "$G" --ledger "$L" check --runtime <runtime> --model <model-id> --contract <contract-file> --agents <n> --est-chars <n> --completion-channel orchestration
 <supervised dispatch command>
-"$G" --ledger "$L" register --job-id <job-id> --probe-cmd "<command proving the job-id appears in an artifact>" --orchestration-task <task-id>
+"$G" --ledger "$L" register --job-id <job-id> --probe-cmd "<command proving the job-id appears in an artifact>" --orchestration-task <task-id> --declared-model <model-id> --model-probe-cmd "<command printing the worker's actual model id>"
 ```
 
 The gate enforces `model-tier-policy.json`. A version 2 policy gates on tier multiplied by fan-out rather than on identity, because the incident it exists for was a top tier spread across ten workers: each tier carries a cap on agents dispatched inside a window, an unlisted model falls in the `unknown` tier and is capped there rather than denied, and exceeding a cap requires `--tier-override "<reason>"`. The window counts accumulation, not concurrency, so ten sequential single-agent dispatches reach the same cap as one fan-out of ten; an override passes one request without refunding what the window already counted. Version 1 policies keep their identity-based behaviour unchanged. Model identifiers match casefolded, so a tier spelled in another case is the same tier. Each decision records the policy path, its `sha256`, and the tier that decided, because that path is caller-supplied; `dispatch-gate report` lists every policy a span was judged against and every tier it spent agents in, including `unknown`, and more than one policy row means the span was not judged against one policy.
 
 The gate writes its verdict as JSON on stdout and human diagnostics on stderr. Do not merge them: `2>&1` piped into a JSON parser fails, and the failure reads like malformed output rather than like two streams. Use `2>/dev/null` for machine use, and read stderr separately when a person needs the reason.
+
+`register` compares the model the dispatch declared with the model the worker actually ran. Declare the measurement per dispatch with `--model-probe-cmd`, because every runtime reports differently and this gate is agent-neutral; the command must read an artifact the agent itself produced, such as its session transcript, for which `{{RUNTIME_ROOT}}/scripts/model-identity-probe` is the reference implementation. Do not scrape a TUI status line: that measures what a renderer drew, and authenticating a model against it leaves a verification stamp with no verification behind it.
+
+The verdict is graded. No declared model, or a probe that returns nothing, warns as `MODEL_UNVERIFIED` or `MODEL_PROBE_FAILED` and still registers, because a runtime with no way to report its model would otherwise be unable to dispatch at all and the check would simply be turned off. A measured model in a tier the policy watches more closely than the declared one denies with `MODEL_TIER_ESCALATION`. Running looser than declared warns as `MODEL_MISMATCH`. Every case records `model_declared`, `model_measured`, and `model_verified` in the ledger, so an unverified registration is distinguishable from a verified one instead of being assumed.
 
 Before attaching a Codex worker, run `scripts/codex-worker-pretrust <worktree-path>` so startup never blocks on the trust prompt.
 

--- a/scripts/dispatch-gate
+++ b/scripts/dispatch-gate
@@ -86,6 +86,9 @@ def _build_parser() -> argparse.ArgumentParser:
     register_parser.add_argument("--contract-sha")
     register_parser.add_argument("--runtime")
     register_parser.add_argument("--orchestration-task")
+    # register ranks the measured tier against the declared one, so it needs the
+    # same policy check used, and by the same resolution rules.
+    register_parser.add_argument("--tier-policy")
     register_parser.add_argument("--declared-model")
     register_parser.add_argument("--model-probe-cmd")
 

--- a/scripts/dispatch-gate
+++ b/scripts/dispatch-gate
@@ -32,6 +32,7 @@ from master_runtime.core.watchdog import StallStatus, check_stall  # noqa: E402
 
 
 ORCHESTRATION_PROBE_TIMEOUT_SECONDS = 30
+MODEL_PROBE_TIMEOUT_SECONDS = 30
 
 
 class ProbeFailure(str, Enum):
@@ -85,6 +86,8 @@ def _build_parser() -> argparse.ArgumentParser:
     register_parser.add_argument("--contract-sha")
     register_parser.add_argument("--runtime")
     register_parser.add_argument("--orchestration-task")
+    register_parser.add_argument("--declared-model")
+    register_parser.add_argument("--model-probe-cmd")
 
     watch_parser = subparsers.add_parser("watch")
     watch_parser.add_argument("--log", required=True)
@@ -147,12 +150,16 @@ def _register(args: argparse.Namespace) -> int:
     if probe_failure is not None:
         return _deny_unverified_orchestration(args, probe_failure)
 
+    measured_model, model_probe_failed = _measure_worker_model(args.model_probe_cmd)
     decision = _gate(args).register_job(
         args.job_id,
         lambda job_id: _probe_contains_job_id(args.probe_cmd, job_id),
         contract_sha=args.contract_sha,
         runtime=args.runtime,
         orchestration_task=args.orchestration_task,
+        declared_model=args.declared_model,
+        measured_model=measured_model,
+        model_probe_failed=model_probe_failed,
     )
     _print_decision(decision)
     if decision.allow:
@@ -378,6 +385,41 @@ def _probe_contains_job_id(probe_cmd: str, job_id: str) -> bool:
         text=True,
     )
     return result.returncode == 0 and job_id in result.stdout
+
+
+def _measure_worker_model(probe_cmd: str | None) -> tuple[str | None, bool]:
+    """Run a caller-declared command that prints the worker's actual model id.
+
+    The command is declared per dispatch rather than guessed, because every
+    runtime reports its model differently and this gate is agent-neutral. It must
+    read an artifact the agent itself produced, such as a session transcript;
+    scraping a TUI status line measures what a renderer drew, which is not the
+    same fact and cannot be trusted to authenticate anything.
+
+    Returns the measured id and whether the measurement itself failed, which are
+    different states: no declaration at all, and a declaration that did not
+    produce an answer.
+    """
+
+    if not probe_cmd:
+        return None, False
+    try:
+        result = subprocess.run(
+            probe_cmd,
+            shell=True,
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=MODEL_PROBE_TIMEOUT_SECONDS,
+        )
+    except (subprocess.TimeoutExpired, OSError):
+        return None, True
+    if result.returncode != 0:
+        return None, True
+    lines = [line.strip() for line in result.stdout.splitlines() if line.strip()]
+    if not lines:
+        return None, True
+    return lines[-1], False
 
 
 def _probe_orchestration_task(orchestration_task: str) -> ProbeFailure | None:

--- a/src/master_runtime/core/dispatch_gate.py
+++ b/src/master_runtime/core/dispatch_gate.py
@@ -83,6 +83,10 @@ class ReasonCode(str, Enum):
     TIER_POLICY_UNAVAILABLE = "TIER_POLICY_UNAVAILABLE"
     TIER_FANOUT_CAP = "TIER_FANOUT_CAP"
     TIER_UNKNOWN_MODEL = "TIER_UNKNOWN_MODEL"
+    MODEL_TIER_ESCALATION = "MODEL_TIER_ESCALATION"
+    MODEL_MISMATCH = "MODEL_MISMATCH"
+    MODEL_UNVERIFIED = "MODEL_UNVERIFIED"
+    MODEL_PROBE_FAILED = "MODEL_PROBE_FAILED"
 
 
 @dataclass(frozen=True)
@@ -176,6 +180,18 @@ class ModelTierPolicy:
 
         cap = self.fanout_caps.get(tier)
         return cap if isinstance(cap, int) else None
+
+    def strictness_of(self, tier: str) -> float:
+        """How closely the policy watches a tier, as its per-window cap.
+
+        Smaller is stricter. An uncapped tier is the loosest thing the policy
+        knows, so it sorts last. This is deliberately the cap rather than a
+        separate ordering field: the policy already says how much it trusts each
+        tier, and inventing a second ranking would let the two disagree.
+        """
+
+        cap = self.cap_for(tier)
+        return float("inf") if cap is None else float(cap)
 
 
 class DispatchGate:
@@ -370,11 +386,40 @@ class DispatchGate:
         contract_sha: str | None = None,
         runtime: str | None = None,
         orchestration_task: str | None = None,
+        declared_model: str | None = None,
+        measured_model: str | None = None,
+        model_probe_failed: bool = False,
     ) -> GateDecision:
         """Register a job only after independent probe verification succeeds."""
 
         if not job_id or not probe_fn(job_id):
             return GateDecision(False, ReasonCode.UNVERIFIED_JOB)
+
+        # check gates the model a caller declares; nothing until here compared
+        # that declaration with what the worker actually runs. The incident this
+        # policy exists for was a worker inheriting a tier nobody asked for, and
+        # a compliant declaration does not prevent it.
+        model_warning, escalation = self._model_verification(
+            declared_model, measured_model, model_probe_failed
+        )
+        if escalation is not None:
+            decision = GateDecision(
+                False,
+                ReasonCode.MODEL_TIER_ESCALATION,
+                message=escalation,
+            )
+            self._append_entry(
+                {
+                    "ts": self._clock(),
+                    "decision": "DENY",
+                    "reason": decision.reason.value,
+                    "job_id": job_id,
+                    "model_declared": declared_model,
+                    "model_measured": measured_model,
+                    "model_verified": True,
+                }
+            )
+            return decision
 
         runtime_filter = _normalize_runtime_filter(runtime)
         if runtime is not None and runtime_filter is None:
@@ -495,13 +540,79 @@ class DispatchGate:
             }
             if orchestration_task is not None:
                 entry["orchestration_task"] = orchestration_task
+            # Say what was verified and how, so a later reader can tell an
+            # unverified registration from a verified one instead of assuming.
+            entry["model_declared"] = declared_model
+            entry["model_measured"] = measured_model
+            entry["model_verified"] = bool(
+                declared_model and measured_model and not model_probe_failed
+            )
+            if model_warning is not None:
+                entry["warnings"] = [
+                    *entry.get("warnings", []),
+                    model_warning.value,
+                ]
             self._append_entry(entry)
+        if model_warning is not None:
+            decision = GateDecision(
+                decision.allow,
+                decision.reason,
+                warnings=(*decision.warnings, model_warning),
+                contract_sha=decision.contract_sha,
+                cost_proxy=decision.cost_proxy,
+                message=decision.message,
+                tier_override=decision.tier_override,
+            )
         return decision
 
     def ledger_entries(self) -> tuple[Mapping[str, object], ...]:
         """Return parsed ledger entries in append order."""
 
         return tuple(self._read_entries())
+
+    def _model_verification(
+        self,
+        declared_model: str | None,
+        measured_model: str | None,
+        probe_failed: bool,
+    ) -> tuple[ReasonCode | None, str | None]:
+        """Compare a declared worker model with a measured one.
+
+        Returns a warning code and, when the measured model sits in a tier the
+        policy watches more closely than the declared one, the message for a
+        denial. An absent measurement is a warning rather than a denial on
+        purpose: a runtime with no way to report its model would otherwise be
+        unable to dispatch at all, and a check nobody can satisfy is a check
+        nobody enables. What is never allowed to pass quietly is the case where a
+        measurement exists and disagrees upward.
+        """
+
+        if not declared_model:
+            return ReasonCode.MODEL_UNVERIFIED, None
+        if probe_failed:
+            return ReasonCode.MODEL_PROBE_FAILED, None
+        if not measured_model:
+            return ReasonCode.MODEL_UNVERIFIED, None
+        if measured_model.strip().casefold() == declared_model.strip().casefold():
+            return None, None
+
+        try:
+            policy = _load_tier_policy(Path(self.config.tier_policy_path))
+        except (OSError, ValueError, json.JSONDecodeError):
+            # Cannot rank the two without a policy, and a mismatch is still a
+            # mismatch worth recording.
+            return ReasonCode.MODEL_MISMATCH, None
+        if policy.version < 2:
+            return ReasonCode.MODEL_MISMATCH, None
+
+        declared_tier = policy.tier_of(declared_model.strip().casefold())
+        measured_tier = policy.tier_of(measured_model.strip().casefold())
+        if policy.strictness_of(measured_tier) < policy.strictness_of(declared_tier):
+            return None, (
+                f"declared={declared_model} tier={declared_tier} "
+                f"measured={measured_model} tier={measured_tier}"
+            )
+        return ReasonCode.MODEL_MISMATCH, None
 
     def _tier_window_agents(self, tier: str, policy: ModelTierPolicy) -> int:
         """Agents already dispatched in this tier inside the policy window.

--- a/tests/test_dispatch_gate.py
+++ b/tests/test_dispatch_gate.py
@@ -2181,6 +2181,135 @@ def test_v2_policy_validation_fails_closed(tmp_path: Path) -> None:
         assert decision.reason == ReasonCode.TIER_POLICY_UNAVAILABLE, payload
 
 
+def _registered(
+    tmp_path: Path,
+    policy: Path,
+    declared: str | None,
+    measured: str | None,
+    probe_failed: bool = False,
+    dispatch_model: str = "gpt-5.6-luna",
+    label: str = "job",
+):
+    """Issue a ticket with check, then register with a measured model."""
+
+    gate = _gate(tmp_path, now=1_000, tier_policy_path=policy)
+    gate.check(
+        DispatchRequest(
+            runtime="codex",
+            model=dispatch_model,
+            contract_path=_contract(tmp_path, f"{label} contract"),
+            est_input_chars=10_000,
+            n_agents=1,
+        )
+    )
+    return gate.register_job(
+        label,
+        lambda job_id: job_id == label,
+        declared_model=declared,
+        measured_model=measured,
+        model_probe_failed=probe_failed,
+    )
+
+
+def test_register_without_a_declared_model_warns_rather_than_denies(
+    tmp_path: Path,
+) -> None:
+    """A runtime that cannot report its model must still be able to dispatch."""
+
+    decision = _registered(tmp_path, _tier_policy_v2(tmp_path), None, None)
+
+    assert decision.allow is True
+    assert ReasonCode.MODEL_UNVERIFIED in decision.warnings
+    entry = _ledger_entries(tmp_path)[-1]
+    assert entry["model_verified"] is False
+    assert entry["warnings"] == ["MODEL_UNVERIFIED"]
+
+
+def test_register_records_a_failed_model_probe_distinctly(tmp_path: Path) -> None:
+    """Not declared and declared-but-unanswered are different states."""
+
+    decision = _registered(
+        tmp_path, _tier_policy_v2(tmp_path), "gpt-5.6-luna", None, probe_failed=True
+    )
+
+    assert decision.allow is True
+    assert ReasonCode.MODEL_PROBE_FAILED in decision.warnings
+    assert _ledger_entries(tmp_path)[-1]["model_verified"] is False
+
+
+def test_register_records_a_verified_match(tmp_path: Path) -> None:
+    decision = _registered(
+        tmp_path, _tier_policy_v2(tmp_path), "gpt-5.6-luna", "GPT-5.6-Luna"
+    )
+
+    assert decision.allow is True
+    assert decision.warnings == ()
+    entry = _ledger_entries(tmp_path)[-1]
+    assert entry["model_verified"] is True
+    assert entry["model_declared"] == "gpt-5.6-luna"
+    assert entry["model_measured"] == "GPT-5.6-Luna"
+
+
+def test_register_denies_a_measured_model_in_a_stricter_tier(tmp_path: Path) -> None:
+    """The incident was a worker inheriting a tier nobody asked for."""
+
+    decision = _registered(
+        tmp_path, _tier_policy_v2(tmp_path), "gpt-5.6-luna", "claude-opus-5"
+    )
+
+    assert decision.allow is False
+    assert decision.reason == ReasonCode.MODEL_TIER_ESCALATION
+    assert "measured=claude-opus-5" in decision.message
+    entry = _ledger_entries(tmp_path)[-1]
+    assert entry["decision"] == "DENY"
+    assert entry["model_declared"] == "gpt-5.6-luna"
+    assert entry["model_measured"] == "claude-opus-5"
+
+
+def test_register_allows_a_measured_model_in_a_looser_tier_with_a_warning(
+    tmp_path: Path,
+) -> None:
+    """Running cheaper than declared is not the failure this guards."""
+
+    decision = _registered(
+        tmp_path,
+        _tier_policy_v2(tmp_path),
+        "claude-opus-5",
+        "gpt-5.6-luna",
+        dispatch_model="claude-opus-5",
+    )
+
+    assert decision.allow is True
+    assert ReasonCode.MODEL_MISMATCH in decision.warnings
+
+
+def test_register_under_a_v1_policy_warns_but_cannot_rank(tmp_path: Path) -> None:
+    """Version 1 has no tiers to compare, so a mismatch is all it can say."""
+
+    decision = _registered(
+        tmp_path, _tier_policy(tmp_path), "gpt-5.6-luna", "gpt-5.6-sol"
+    )
+
+    assert decision.allow is True
+    assert ReasonCode.MODEL_MISMATCH in decision.warnings
+
+
+def test_cli_model_probe_separates_no_command_from_a_failed_one(
+    tmp_path: Path,
+) -> None:
+    script = runpy.run_path(str(_script()), run_name="dispatch_gate_test")
+    measure = script["_measure_worker_model"]
+
+    assert measure(None) == (None, False)
+    assert measure("echo claude-haiku-4-5") == ("claude-haiku-4-5", False)
+    assert measure("printf 'noise\nclaude-haiku-4-5\n'") == (
+        "claude-haiku-4-5",
+        False,
+    )
+    assert measure("exit 3") == (None, True)
+    assert measure("true") == (None, True)
+
+
 def _gate(
     tmp_path: Path,
     now: float | None = None,


### PR DESCRIPTION
Closes the gap the tier policy was written for but did not cover. `check` enforces the model a caller declares; `register` took no model at all. A worker inheriting a top tier nobody asked for therefore registered clean, because the declaration was compliant and nothing measured what actually ran.

## What register does now

```
register --job-id <id> --probe-cmd "<proves the job-id is in an artifact>" \
         --orchestration-task <task-id> \
         --declared-model <id> --model-probe-cmd "<prints the worker's actual model id>"
```

The probe is declared per dispatch rather than built in, because every runtime reports its model differently and this gate is agent-neutral. It must read an artifact the agent itself produced; `scripts/model-identity-probe` reads a session transcript and is the reference implementation.

**A TUI status line is not a measurement source.** It is what a renderer drew, not what the session recorded. Authenticating a model against it leaves a verification stamp with nothing behind it, which is worse than no check because the stamp suppresses the question. That constraint came from an operator who noticed the status string was the only evidence of a worker's model they actually had.

## Graded, for the same reason the preflight is

| state | verdict |
|---|---|
| no `--declared-model` | allow, warn `MODEL_UNVERIFIED` |
| probe declared but returns nothing or fails | allow, warn `MODEL_PROBE_FAILED` |
| measured matches declared (casefolded) | allow, no warning, `model_verified: true` |
| measured sits in a tier the policy watches more closely | **deny `MODEL_TIER_ESCALATION`** |
| measured sits in a looser tier | allow, warn `MODEL_MISMATCH` |

Absent measurement warns rather than denies on purpose: a runtime with no way to report its model would otherwise be unable to dispatch at all, and a check nobody can satisfy is a check nobody enables. What never passes quietly is a measurement that disagrees upward.

Every registration records `model_declared`, `model_measured`, and `model_verified`, so a later reader can tell an unverified registration from a verified one instead of assuming.

## Ranking without inventing an ordering

Tier comparison reuses the policy's own per-window caps: stricter cap means the policy watches that tier more closely, and an uncapped tier is the loosest thing it knows. No `tier_order` field, so there is nothing that can disagree with the caps about which tier is trusted less. Version 1 policies have no tiers to rank, so a mismatch there is recorded and not ranked.

## Tests

Seven added, 87 in the gate file: the two unverified states kept distinct, a verified match with casefolding, the escalation denial with its ledger row, a looser measurement allowed with a warning, a v1 policy warning without ranking, and the CLI probe separating no command from a failed one.

Two mutations confirmed they bite rather than merely pass: disabling the strictness comparison fails the escalation test, and collapsing a failed probe into "not declared" fails the distinctness test.

## Gates

- `PYTHONPATH=src uv run --with pytest --no-project python3 -m pytest tests -q` : 385 passed, 1 skipped, 13 subtests passed
- `REDACTION_REQUIRE_EXTRA=1 REDACTION_EXTRA_PATTERNS=… ./scripts/redaction-scan.sh` : exit 0

`TEMPLATE-VERSION` stays at `0.2.0`; the entry sits under `## Unreleased` per the contract that release introduced.

Tracker: `DZ-mi1`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Register now measures the worker’s actual model and compares it to the declared model, denying stricter-tier escalations and recording verification in the ledger. Addresses `DZ-mi1` by catching model-tier mismatches that can happen after the declaration.

- **New Features**
  - `register` verifies the worker’s model against the declared model.
  - Graded outcomes: deny `MODEL_TIER_ESCALATION`; warn `MODEL_MISMATCH`, `MODEL_UNVERIFIED`, `MODEL_PROBE_FAILED`.
  - Ledger records `model_declared`, `model_measured`, and `model_verified`.
  - Tier ranking reuses policy fan-out caps; v1 policies warn only (no ranking).

- **Migration**
  - Pass `--declared-model <id>`, `--model-probe-cmd "<cmd>"`, and `--tier-policy <path>` to `register`.
  - Point the probe at an agent-produced artifact (e.g., a session transcript). Do not use a TUI status line.
  - Use `scripts/model-identity-probe` as a reference command.

<sup>Written for commit fae704168f1bf03ef3c5cc34cf5412598d90a446. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/baksohyeon/mogui-ADE-orchestrator/pull/27?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

