### PR TITLE
test(inventory): first tests for redaction-inventory, and two silent passes closed

### DIFF
--- a/master-ops/CHANGELOG.md
+++ b/master-ops/CHANGELOG.md
@@ -39,6 +39,27 @@ installation was taken from alongside the tag.
 
 ## Unreleased
 
+`scripts/redaction-inventory` gets its first tests, and two ways it could report
+a clean result without having read anything are closed.
+
+Rule lines that are malformed or whose regex does not compile were dropped in
+silence, so the printed rule count described what loaded rather than what the file
+held: coverage narrowed while the file still looked populated. The scope line and
+the JSON output now report how many lines were considered and how many were
+unusable.
+
+A repository with no tracked files reported OK. Reading nothing is not a clean
+result, so that case now exits 2 as undecidable, the same as a missing pattern
+file or a non-repository.
+
+Nine tests drive the real script in temporary git repositories and assert exit
+codes, since the exit code is what the publish gate consumes: unset pattern file,
+a file with no usable rule, unusable lines reported, no tracked files, outside a
+repository, an uncovered candidate, a rule that covers it, a baseline that
+suppresses it, and the JSON scope fields. Two mutations confirmed they bite:
+restoring the silent drop fails two of them, and letting an empty repository pass
+fails another.
+
 `register` now compares the model a dispatch declared with the model the worker
 actually ran. Until now the gate enforced the declaration at `check` and
 `register` took no model at all, so a worker inheriting a tier nobody asked for

--- a/scripts/redaction-inventory
+++ b/scripts/redaction-inventory
@@ -57,20 +57,29 @@ def run(cmd):
 
 
 def load_rules(path):
-    """Pull just the regexes out of the pattern file."""
-    pats = []
+    """Pull the regexes out of the pattern file, and count what could not be used.
+
+    A line that is malformed or whose regex does not compile used to be dropped in
+    silence, so the reported rule count described what loaded rather than what the
+    file held: coverage narrowed while the file still looked populated. Return the
+    unusable count as well so the caller can say so out loud.
+    """
+    pats, unusable, considered = [], 0, 0
     with open(path, encoding="utf-8") as fh:
         for line in fh:
             line = line.strip()
             if not line or line.startswith("#"):
                 continue
+            considered += 1
             parts = line.split("|", 2)
-            if len(parts) == 3:
-                try:
-                    pats.append(re.compile(parts[2]))
-                except re.error:
-                    pass
-    return pats
+            if len(parts) != 3:
+                unusable += 1
+                continue
+            try:
+                pats.append(re.compile(parts[2]))
+            except re.error:
+                unusable += 1
+    return pats, unusable, considered
 
 
 def load_dictionary():  # use it if present, empty set if not
@@ -89,7 +98,7 @@ def covered(token, rules):
 
 
 def harvest():
-    """Collect the text to be scanned."""
+    """Collect the text to be scanned, with the number of tracked files read."""
     rc, files = run(["git", "ls-files"])
     if rc != 0:
         return None
@@ -105,8 +114,9 @@ def harvest():
         if b"\x00" in raw[:8192]:
             continue
         blobs.append(raw.decode("utf-8", errors="ignore"))
-    blobs.append(" ".join(files.splitlines()))
-    return "\n".join(blobs)
+    names = files.splitlines()
+    blobs.append(" ".join(names))
+    return "\n".join(blobs), len(names)
 
 
 def main():
@@ -122,15 +132,21 @@ def main():
         print("redaction-inventory: FAIL. REDACTION_EXTRA_PATTERNS is unset. "
               "A blind spot cannot be measured without rules.", file=sys.stderr)
         return 2
-    rules = load_rules(os.path.expanduser(path))
+    rules, unusable_rules, considered_rules = load_rules(os.path.expanduser(path))
     if not rules:
         print("redaction-inventory: FAIL. No rules could be read from the pattern file.", file=sys.stderr)
         return 2
 
     words = load_dictionary()
-    text = harvest()
-    if text is None:
+    harvested = harvest()
+    if harvested is None:
         print("redaction-inventory: FAIL. Not a git repository.", file=sys.stderr)
+        return 2
+    text, tracked_files = harvested
+    if not tracked_files:
+        # Nothing to read is not a clean result. Without this an empty checkout
+        # reports OK, and "checked nothing" reads the same as "found nothing".
+        print("redaction-inventory: FAIL. No tracked files to scan.", file=sys.stderr)
         return 2
 
     buckets = {
@@ -159,14 +175,23 @@ def main():
 
     total = sum(len(v) for v in uncovered.values())
     if a.json:
-        print(json.dumps({"rules": len(rules), "baseline": len(base),
+        print(json.dumps({"rules": len(rules),
+                          "rules_unusable": unusable_rules,
+                          "rules_considered": considered_rules,
+                          "tracked_files": tracked_files,
+                          "baseline": len(base),
                           "uncovered_total": total,
                           "uncovered": {k: [{"token": t, "count": n} for t, n in v]
                                         for k, v in uncovered.items()}},
                          ensure_ascii=False, indent=2))
     else:
         scope = "tracked"
-        print(f"redaction-inventory: {len(rules)} rules / scope {scope} / baseline {len(base)}")
+        unusable_note = (
+            f" / {unusable_rules} unusable of {considered_rules} rule lines"
+            if unusable_rules else ""
+        )
+        print(f"redaction-inventory: {len(rules)} rules / scope {scope}"
+              f" / {tracked_files} files / baseline {len(base)}{unusable_note}")
         if not total:
             print("redaction-inventory: OK. 0 uncovered candidates")
         else:

--- a/tests/test_redaction_inventory.py
+++ b/tests/test_redaction_inventory.py
@@ -1,0 +1,139 @@
+"""Tests for scripts/redaction-inventory.
+
+The script had none, which is the defect it exists to prevent: a green result
+that cannot be told apart from having read nothing. Each case below drives the
+real script in a temporary git repository and asserts the exit code, because the
+exit code is what the publish gate consumes.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+INVENTORY = REPO_ROOT / "scripts" / "redaction-inventory"
+
+GOOD_RULE = "acme|Acme internal name|acme-[a-z]+"
+
+
+def _git_repo(tmp_path: Path, files: dict[str, str] | None = None) -> Path:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    env = {**os.environ, "GIT_CONFIG_GLOBAL": "/dev/null", "GIT_CONFIG_SYSTEM": "/dev/null"}
+    subprocess.run(["git", "init", "-q"], cwd=repo, check=True, env=env)
+    for name, body in (files or {}).items():
+        path = repo / name
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(body, encoding="utf-8")
+        subprocess.run(["git", "add", name], cwd=repo, check=True, env=env)
+    return repo
+
+
+def _rules(tmp_path: Path, *lines: str, name: str = "rules.txt") -> Path:
+    path = tmp_path / name
+    path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+    return path
+
+
+def _run(repo: Path, rules: Path | None, *args: str) -> subprocess.CompletedProcess:
+    env = {**os.environ}
+    env.pop("REDACTION_EXTRA_PATTERNS", None)
+    if rules is not None:
+        env["REDACTION_EXTRA_PATTERNS"] = str(rules)
+    return subprocess.run(
+        ["python3", str(INVENTORY), *args],
+        cwd=repo,
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+def test_unset_pattern_file_cannot_decide(tmp_path: Path) -> None:
+    repo = _git_repo(tmp_path, {"a.md": "nothing here\n"})
+    result = _run(repo, None)
+    assert result.returncode == 2, result.stdout + result.stderr
+    assert "REDACTION_EXTRA_PATTERNS is unset" in result.stderr
+
+
+def test_pattern_file_with_no_usable_rule_cannot_decide(tmp_path: Path) -> None:
+    repo = _git_repo(tmp_path, {"a.md": "nothing here\n"})
+    rules = _rules(tmp_path, "# only a comment", "")
+    result = _run(repo, rules)
+    assert result.returncode == 2, result.stdout + result.stderr
+    assert "No rules could be read" in result.stderr
+
+
+def test_unusable_rule_lines_are_reported_not_dropped_in_silence(
+    tmp_path: Path,
+) -> None:
+    """A narrowed rule set must say it narrowed."""
+
+    repo = _git_repo(tmp_path, {"a.md": "plain prose\n"})
+    rules = _rules(
+        tmp_path,
+        GOOD_RULE,
+        "broken|missing regex field",
+        "bad|uncompilable|abc(unclosed",
+    )
+    result = _run(repo, rules)
+    assert "1 rules" in result.stdout, result.stdout
+    assert "2 unusable of 3 rule lines" in result.stdout, result.stdout
+
+
+def test_repository_with_no_tracked_files_cannot_decide(tmp_path: Path) -> None:
+    """Reading nothing is not a clean result."""
+
+    repo = _git_repo(tmp_path)
+    rules = _rules(tmp_path, GOOD_RULE)
+    result = _run(repo, rules)
+    assert result.returncode == 2, result.stdout + result.stderr
+    assert "No tracked files" in result.stderr
+
+
+def test_outside_a_git_repository_cannot_decide(tmp_path: Path) -> None:
+    outside = tmp_path / "plain"
+    outside.mkdir()
+    rules = _rules(tmp_path, GOOD_RULE)
+    result = _run(outside, rules)
+    assert result.returncode == 2, result.stdout + result.stderr
+
+
+def test_uncovered_candidate_is_reported_with_exit_one(tmp_path: Path) -> None:
+    repo = _git_repo(tmp_path, {"a.md": "the widget-factory ships today\n"})
+    rules = _rules(tmp_path, GOOD_RULE)
+    result = _run(repo, rules)
+    assert result.returncode == 1, result.stdout + result.stderr
+    assert "widget-factory" in result.stdout
+
+
+def test_a_rule_that_covers_the_token_clears_it(tmp_path: Path) -> None:
+    repo = _git_repo(tmp_path, {"a.md": "the widget-factory ships today\n"})
+    rules = _rules(tmp_path, "widget|internal product|widget-[a-z]+")
+    result = _run(repo, rules)
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert "0 uncovered candidates" in result.stdout
+
+
+def test_baseline_suppresses_a_reviewed_token(tmp_path: Path) -> None:
+    repo = _git_repo(tmp_path, {"a.md": "the widget-factory ships today\n"})
+    (repo / "baseline.txt").write_text("widget-factory\n", encoding="utf-8")
+    rules = _rules(tmp_path, GOOD_RULE)
+    result = _run(repo, rules, "--baseline", "baseline.txt")
+    assert result.returncode == 0, result.stdout + result.stderr
+
+
+def test_json_output_carries_the_scope_it_measured(tmp_path: Path) -> None:
+    repo = _git_repo(tmp_path, {"a.md": "the widget-factory ships today\n"})
+    rules = _rules(tmp_path, GOOD_RULE, "broken|missing regex field")
+    result = _run(repo, rules, "--json")
+    payload = json.loads(result.stdout)
+    assert payload["rules"] == 1
+    assert payload["rules_unusable"] == 1
+    assert payload["rules_considered"] == 2
+    assert payload["tracked_files"] == 1
+    assert payload["uncovered_total"] >= 1


### PR DESCRIPTION
`scripts/redaction-inventory` measures the redaction rules' blind spot and had no test of its own, so nothing checked the property that matters about it: that a green result means something was read. Tracker: `DZ-c7t`.

## Two silent passes

**Unusable rule lines were dropped in silence.** A line that is malformed, or whose regex does not compile, was skipped without a word, so the printed rule count described what loaded rather than what the file held. An operator with a broken rule got narrower coverage and a confident number.

```
before:  redaction-inventory: 1 rules / scope tracked / baseline 0
after:   redaction-inventory: 1 rules / scope tracked / 1 files / baseline 0 / 2 unusable of 3 rule lines
```

**A repository with no tracked files reported OK.** Reading nothing is not a clean result, and "checked nothing" read exactly like "found nothing". That case now exits 2 as undecidable, the same as a missing pattern file or a non-repository.

## Tests

Nine, driving the real script in temporary git repositories and asserting exit codes, because the exit code is what the publish gate consumes:

| case | expected |
|---|---|
| pattern file unset | 2 |
| pattern file with no usable rule | 2 |
| unusable lines present | reported in the scope line |
| repository with no tracked files | 2 |
| run outside a git repository | 2 |
| uncovered candidate present | 1, token named |
| a rule that covers the token | 0 |
| baseline suppresses the token | 0 |
| `--json` | carries rules, rules_unusable, rules_considered, tracked_files |

Two mutations confirmed they bite rather than merely pass: restoring the silent drop fails two tests, and letting an empty repository pass fails a third.

## Gates

- `PYTHONPATH=src uv run --with pytest --no-project python3 -m pytest tests -q` : 394 passed, 1 skipped, 13 subtests passed
- `REDACTION_REQUIRE_EXTRA=1 REDACTION_EXTRA_PATTERNS=… ./scripts/redaction-scan.sh` : exit 0
- `REDACTION_EXTRA_PATTERNS=… ./scripts/redaction-inventory` : exit 1, the pre-existing triage list, unchanged in count by this branch

Entry sits under `## Unreleased`; `TEMPLATE-VERSION` stays `0.2.0`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a test suite for `scripts/redaction-inventory` and ensures a green result only happens when something was read (Linear `DZ-c7t`).

- **Bug Fixes**
  - Unusable rule lines are counted and reported instead of being silently dropped.
  - Repositories with no tracked files now exit 2 (undecidable).

- **New Features**
  - JSON output adds `rules_unusable`, `rules_considered`, and `tracked_files`; the scope line shows tracked file count and an unusable-note when present.
  - Nine tests drive the real script and assert exit codes and JSON fields.

<sup>Written for commit 28e8f68d78047bed60eee51c6e57cc2acaf68be1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/baksohyeon/mogui-ADE-orchestrator/pull/28?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

