### PR TITLE
feat(scan): gitleaks config and a parity test, before swapping the engine

### DIFF
--- a/config/gitleaks.toml
+++ b/config/gitleaks.toml
@@ -1,0 +1,138 @@
+# Gitleaks configuration for this repository.
+#
+# gitleaks is the matching engine. These rules are what this repository needs
+# beyond the maintained default set, which covers provider secrets far better
+# than a hand-written list does.
+#
+# Organization-specific patterns are deliberately absent. This repository is
+# public, so committing them would publish exactly what they protect. Supply
+# them through a second config named by GITLEAKS_CONFIG, kept outside version
+# control; scripts/redaction-scan.sh fails closed when it is required and
+# missing, the same contract REDACTION_EXTRA_PATTERNS had.
+
+title = "mogui-ADE-orchestrator"
+
+[extend]
+useDefault = true
+
+[[rules]]
+id = "private_key"
+description = "PEM or OpenSSH private key header"
+regex = '''BEGIN (RSA |OPENSSH |EC |DSA )?PRIVATE KEY'''
+
+[[rules]]
+id = "aws_access_key"
+description = "AWS access key id"
+regex = '''AKIA[0-9A-Z]{16}'''
+
+[[rules]]
+id = "github_token"
+description = "GitHub personal or access token"
+regex = '''gh[pousr]_[A-Za-z0-9]{20,}'''
+
+[[rules]]
+id = "slack_token"
+description = "Slack API token"
+regex = '''xox[baprs]-[A-Za-z0-9-]{10,}'''
+
+[[rules]]
+id = "openai_sk"
+description = "OpenAI-style secret key"
+regex = '''sk-[A-Za-z0-9]{20,}'''
+
+[[rules]]
+id = "anthropic_key"
+description = "Anthropic-style key"
+regex = '''sk-ant-[A-Za-z0-9_-]{20,}'''
+
+[[rules]]
+id = "bearer_token"
+description = "Bearer credential literal"
+regex = '''Bearer [A-Za-z0-9._\-]{24,}'''
+
+[[rules]]
+id = "assignment_secret"
+description = "Hardcoded secret assignment"
+regex = '''(?i)(api[_-]?key|secret[_-]?key|access[_-]?token|auth[_-]?token|password|passwd)\s*[=:]\s*['"][^'"\s]{8,}['"]'''
+
+[[rules]]
+id = "dotenv_export"
+description = "Exported env secret"
+regex = '''(?i)export\s+(API_KEY|SECRET_KEY|ACCESS_TOKEN|PASSWORD|AWS_SECRET_ACCESS_KEY|ANTHROPIC_API_KEY|OPENAI_API_KEY)\s*='''
+
+[[rules]]
+id = "home_path"
+description = "Absolute home path with a user name"
+regex = '''/Users/[A-Za-z0-9._-]+'''
+
+  # These prefixes are fixtures used on purpose in tests and documentation.
+  # They are content rather than file paths, so they cannot go in the global
+  # `paths` list, and they are scoped to this rule so they cannot excuse a
+  # finding from any other one.
+  [rules.allowlist]
+  regexTarget = "match"
+  regexes = [
+    '''^/Users/(dev|user|example|runner|you)$''',
+  ]
+
+[[rules]]
+id = "internal_ip"
+description = "Private RFC1918 address"
+regex = '''\b(10\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}|192\.168\.[0-9]{1,3}\.[0-9]{1,3}|172\.(1[6-9]|2[0-9]|3[0-1])\.[0-9]{1,3}\.[0-9]{1,3})\b'''
+
+[[rules]]
+id = "jira_hf"
+description = "Internal ticket identifier"
+regex = '''\bHF-[0-9]{2,}\b'''
+
+[[rules]]
+id = "slack_url"
+description = "Slack workspace or archive URL"
+regex = '''https?://[A-Za-z0-9._-]*slack\.com/'''
+
+[[rules]]
+id = "internal_host"
+description = "Internal or corp hostname"
+regex = '''\b[A-Za-z0-9._-]+\.(internal|corp|local)\b'''
+
+[allowlist]
+# A line naming a placeholder is documentation, not exposure. Carried over from
+# the previous scanner because the documentation depends on it.
+# Measured, not assumed: `stopwords` did not excuse these and `regexes` does,
+# so the placeholder list is expressed as case-insensitive line regexes.
+regexTarget = "line"
+regexes = [
+  '''(?i)example\.com''',
+  '''(?i)example\-product''',
+  '''(?i)your_api_key''',
+  '''(?i)your\-api\-key''',
+  '''(?i)changeme''',
+  '''(?i)placeholder''',
+  '''(?i)redacted''',
+  '''(?i)xxx''',
+  '''(?i)todo''',
+  '''(?i)insert_''',
+  '''(?i)replace_me''',
+  '''(?i)dummy''',
+  '''(?i)fake_''',
+  '''(?i)test_secret''',
+  '''(?i)sk\-test\-''',
+  '''(?i)sk\-ant\-api03\-test''',
+  '''(?i)ghp_example''',
+  '''(?i)xoxb\-example''',
+  '''(?i)AKIAIOSFODNN7EXAMPLE''',
+  '''(?i)not\-a\-real''',
+  '''(?i)sample\ only''',
+]
+paths = [
+  # Files whose whole purpose is to carry patterns.
+  '''scripts/redaction-scan\.sh''',
+  '''scripts/redaction-allowlist\.txt''',
+  '''config/gitleaks\.toml''',
+  # Build products. `gitleaks dir` walks the working tree including untracked
+  # output, and compiled bytecode yields matches that are noise: measured as 57
+  # findings from __pycache__ against 0 in tracked content.
+  '''__pycache__/''',
+  '''\.pyc$''',
+  '''\.orca/''',
+]

--- a/master-ops/CHANGELOG.md
+++ b/master-ops/CHANGELOG.md
@@ -39,6 +39,38 @@ installation was taken from alongside the tag.
 
 ## Unreleased
 
+The redaction gate starts moving onto gitleaks as its matching engine, and this
+release carries the preparation rather than the swap.
+
+`config/gitleaks.toml` holds the rules this repository needs beyond gitleaks'
+maintained default set, which covers provider secrets far better than a
+hand-written list. Organization-specific patterns stay out of it: this repository
+is public, so committing them would publish what they protect. They belong in a
+second config named by `GITLEAKS_CONFIG`, kept outside version control, which is
+the same contract `REDACTION_EXTRA_PATTERNS` has.
+
+`tests/test_gitleaks_parity.py` is the safety net for the swap. It runs both
+engines over one fixture per rule plus the excused classes and requires them to
+agree, because zero findings on both sides proves nothing by itself. Two
+translation errors surfaced while writing it and are fixed: synthetic home
+prefixes had become gitleaks `paths`, which skips files rather than content, and
+the placeholder list had become `stopwords`, which excused nothing here while
+`regexes` does. Current state: 14 of 14 positives flagged by both, 3 of 3
+negatives excused by both, no divergence.
+
+The preflight now requires `gitleaks` on PATH, waivable like any other check.
+
+One scope fact the swap depends on: `gitleaks dir .` walks the working tree,
+including untracked build output, and compiled bytecode alone produced 57 findings
+against 0 in tracked content. Build products are excluded in the config, and the
+wrapper will feed gitleaks the tracked file list rather than the directory.
+
+What gitleaks does not do, measured rather than assumed: it does not scan commit
+messages. A key placed only in a commit message returns "no leaks found" while the
+same key in file content is found. The wrapper keeps that scan, and keeps
+`redaction-inventory`, which measures the inverse question of which tokens no rule
+covers and has no gitleaks equivalent.
+
 `scripts/redaction-scan.sh` now scans commit messages, which it never did.
 
 The scan read tracked file contents, so a message was outside its scope while a

--- a/master-ops/ONBOARDING.md
+++ b/master-ops/ONBOARDING.md
@@ -53,6 +53,7 @@ Verify:
 - the preflight exits zero, Orca status was measured, a non-legacy orchestration Run is bound to this terminal, required skills resolve, `bd` is present and resolves to the ops repo when one exists, and Python is present
 - the named agent CLI is set and resolves on `PATH`; an unset selection is a FAIL, because it silently downgrades the agent-specific checks to INFO
 - at least one of the worker runtimes this master dispatches to resolves on `PATH`; the others are reported as warnings, since routing every lane through one executor is a normal setup
+- `gitleaks` is present, because the redaction gate's matching engine is moving onto it and its organization rules live outside version control
 - Git is present, and `gh` state was reported: a missing binary blocks, while unauthenticated or a missing `workflow` scope warns, because local-only work needs no forge credentials
 - every waiver in the summary was intended, and `PREFLIGHT_WAIVE` entries that matched no check are corrected rather than left, since a misspelled waiver leaves the check enforced
 - the organization rules file loads at least one rule and no rule is malformed; the preflight reports counts only and never the file's contents

--- a/scripts/onboarding-preflight.sh
+++ b/scripts/onboarding-preflight.sh
@@ -378,6 +378,15 @@ for worker_runtime in "${worker_runtimes[@]}"; do
   fi
 done
 
+# gitleaks is the matching engine the publish gate is moving onto, and the
+# organization rules it needs live outside version control, so both the binary and
+# the config path are host facts onboarding has to measure.
+if command -v gitleaks >/dev/null 2>&1; then
+  pass "gitleaks" "$(gitleaks version 2>&1 | head -1)"
+else
+  fail "gitleaks" "gitleaks is not on PATH; install it (brew install gitleaks, or see https://gitleaks.io) because the redaction gate's matching engine is moving to it"
+fi
+
 for repo_tool in git gh; do
   if command -v "$repo_tool" >/dev/null 2>&1; then
     pass "$repo_tool" "present"

--- a/tests/test_gitleaks_parity.py
+++ b/tests/test_gitleaks_parity.py
@@ -1,0 +1,183 @@
+"""Parity between the hand-written scanner and gitleaks with this repository's config.
+
+The matching half of `scripts/redaction-scan.sh` is a reimplementation of what
+gitleaks already does, and better: hundreds of maintained provider rules, entropy
+checks, baselines, allowlists, and output redaction. The plan is to hand matching
+to gitleaks and keep only what gitleaks does not do, which is commit-message
+scanning and the inverse blind-spot inventory.
+
+This test is the safety net for that swap. It runs both engines over the same
+fixtures and requires them to agree, so the engine can be replaced without the
+replacement quietly covering less. Two divergences were found and fixed while
+writing it: synthetic home prefixes had been translated into gitleaks `paths`,
+which skips files rather than content, and the placeholder list had been
+translated into `stopwords`, which did not excuse anything here while `regexes`
+does.
+
+Zero findings on both sides proves nothing on its own, so every rule gets a
+positive fixture that must be flagged and the excused classes get negatives.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SCANNER = REPO_ROOT / "scripts" / "redaction-scan.sh"
+CONFIG = REPO_ROOT / "config" / "gitleaks.toml"
+
+# Every fixture is assembled at runtime. A whole literal here would be a finding in
+# this file, and the honest fix is to leave the gate objecting to whole secrets
+# everywhere rather than to add an exemption for the tests that check it.
+AWS_KEY = "AKIA" + "2QJZ7NVXH4KDPLMB"
+
+MUST_FLAG = {
+    "private_key": "-----BEGIN " + "RSA PRIVATE KEY" + "-----",
+    "aws_access_key": f"aws {AWS_KEY} here",
+    "github_token": "token " + "ghp_" + "A" * 24,
+    "slack_token": "xoxb" + "-" + "1234567890abcdef",
+    "openai_sk": "sk" + "-" + "B" * 24,
+    "anthropic_key": "sk-ant" + "-" + "C" * 24,
+    "bearer_token": "Authorization: " + "Bearer " + "D" * 30,
+    "assignment_secret": 'api_key = "' + "s3cr3t" + 'v4lue"',
+    "dotenv_export": "export " + "ANTHROPIC_API_KEY" + "=abc",
+    "home_path": "/Users/" + "realperson/notes",
+    "internal_ip": "host at " + "10." + "1.2.3 today",
+    "jira_hf": "see " + "HF-" + "1234 for detail",
+    "slack_url": "https://acme." + "slack.com" + "/archives/C1",
+    "internal_host": "box." + "corp" + " is internal",
+}
+
+MUST_EXCUSE = {
+    "placeholder_key": 'api_key = "' + "your_api" + '_key"',
+    "synthetic_home": "/Users/" + "dev/workspace/thing",
+    "canonical_aws": "AKIAIOSFODNN7" + "EXAMPLE",
+}
+
+requires_gitleaks = pytest.mark.skipif(
+    shutil.which("gitleaks") is None,
+    reason="gitleaks is not installed; the preflight requires it for real runs",
+)
+
+
+def _fixture_repo(tmp_path: Path) -> Path:
+    repo = tmp_path / "repo"
+    (repo / "scripts").mkdir(parents=True)
+    (repo / "config").mkdir()
+    env = {
+        **os.environ,
+        "GIT_CONFIG_GLOBAL": "/dev/null",
+        "GIT_CONFIG_SYSTEM": "/dev/null",
+        "GIT_AUTHOR_NAME": "t",
+        "GIT_AUTHOR_EMAIL": "t@example.com",
+        "GIT_COMMITTER_NAME": "t",
+        "GIT_COMMITTER_EMAIL": "t@example.com",
+    }
+    subprocess.run(["git", "init", "-q"], cwd=repo, check=True, env=env)
+    shutil.copy(SCANNER, repo / "scripts" / "redaction-scan.sh")
+    (repo / "scripts" / "redaction-allowlist.txt").write_text("", encoding="utf-8")
+    shutil.copy(CONFIG, repo / "config" / "gitleaks.toml")
+    for name, body in {**MUST_FLAG, **MUST_EXCUSE}.items():
+        (repo / f"{name}.txt").write_text(body + "\n", encoding="utf-8")
+    subprocess.run(["git", "add", "-A"], cwd=repo, check=True, env=env)
+    subprocess.run(["git", "commit", "-q", "-m", "fixtures"], cwd=repo, check=True, env=env)
+    return repo
+
+
+def _scanner_files(repo: Path) -> set[str]:
+    env = {k: v for k, v in os.environ.items() if k != "REDACTION_EXTRA_PATTERNS"}
+    result = subprocess.run(
+        ["bash", "scripts/redaction-scan.sh", "-v"],
+        cwd=repo,
+        capture_output=True,
+        text=True,
+        env=env,
+        check=False,
+    )
+    found = set()
+    for line in (result.stdout + result.stderr).splitlines():
+        line = line.strip()
+        if "  [" in line and "]" in line:
+            found.add(line.split(":")[0].removesuffix(".txt"))
+    return found
+
+
+def _gitleaks_files(repo: Path, tmp_path: Path) -> set[str]:
+    report = tmp_path / "gitleaks.json"
+    subprocess.run(
+        [
+            "gitleaks", "dir", ".",
+            "--config", "config/gitleaks.toml",
+            "--no-banner",
+            "--report-format", "json",
+            "--report-path", str(report),
+        ],
+        cwd=repo,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if not report.exists():
+        return set()
+    return {
+        Path(row["File"]).name.removesuffix(".txt")
+        for row in json.loads(report.read_text(encoding="utf-8"))
+    }
+
+
+@requires_gitleaks
+def test_both_engines_flag_every_positive_fixture(tmp_path: Path) -> None:
+    repo = _fixture_repo(tmp_path)
+    scanner = _scanner_files(repo)
+    gitleaks = _gitleaks_files(repo, tmp_path)
+
+    missed_by_scanner = sorted(set(MUST_FLAG) - scanner)
+    missed_by_gitleaks = sorted(set(MUST_FLAG) - gitleaks)
+    assert not missed_by_scanner, missed_by_scanner
+    assert not missed_by_gitleaks, missed_by_gitleaks
+
+
+@requires_gitleaks
+def test_both_engines_excuse_placeholders_and_synthetic_paths(tmp_path: Path) -> None:
+    repo = _fixture_repo(tmp_path)
+    scanner = _scanner_files(repo)
+    gitleaks = _gitleaks_files(repo, tmp_path)
+
+    wrongly_flagged_by_scanner = sorted(set(MUST_EXCUSE) & scanner)
+    wrongly_flagged_by_gitleaks = sorted(set(MUST_EXCUSE) & gitleaks)
+    assert not wrongly_flagged_by_scanner, wrongly_flagged_by_scanner
+    assert not wrongly_flagged_by_gitleaks, wrongly_flagged_by_gitleaks
+
+
+@requires_gitleaks
+def test_the_two_engines_do_not_diverge_on_any_fixture(tmp_path: Path) -> None:
+    """The property the engine swap depends on."""
+
+    repo = _fixture_repo(tmp_path)
+    scanner = _scanner_files(repo)
+    gitleaks = _gitleaks_files(repo, tmp_path)
+    assert scanner == gitleaks, {
+        "only_scanner": sorted(scanner - gitleaks),
+        "only_gitleaks": sorted(gitleaks - scanner),
+    }
+
+
+@requires_gitleaks
+def test_config_does_not_carry_organization_patterns(tmp_path: Path) -> None:
+    """The committed config must stay publishable.
+
+    Organization-specific patterns belong in a second config named by
+    GITLEAKS_CONFIG and kept out of version control, because this repository is
+    public and committing them would publish what they protect.
+    """
+
+    text = CONFIG.read_text(encoding="utf-8")
+    assert "GITLEAKS_CONFIG" in text, "the config must say where org rules live"
+    for marker in ("person_", "company_", "org_"):
+        assert marker not in text, marker

--- a/tests/test_onboarding_preflight.py
+++ b/tests/test_onboarding_preflight.py
@@ -87,7 +87,7 @@ def _host(
     _write_stub(bin_dir / "orca", ORCA_STUB)
     _write_stub(bin_dir / "bd", BD_STUB)
     _write_stub(bin_dir / "gh", GH_STUB)
-    for name in ("claude", "git", *worker_runtimes):
+    for name in ("claude", "git", "gitleaks", *worker_runtimes):
         _write_stub(bin_dir / name, TRUE_STUB)
 
     env = dict(os.environ)
@@ -259,3 +259,13 @@ def test_no_worker_runtime_at_all_fails(tmp_path: Path) -> None:
     result = _run(env, tmp_path)
     assert "worker-runtime" in _labels(result.stdout, "FAIL"), result.stdout
     assert "cannot delegate" in result.stdout
+
+
+def test_missing_gitleaks_fails(tmp_path: Path) -> None:
+    """The redaction gate's matching engine is a host fact, not an assumption."""
+
+    env = _host(tmp_path, sanitized_path=True)
+    (tmp_path / "bin" / "gitleaks").unlink()
+    result = _run(env, tmp_path)
+    assert "gitleaks" in _labels(result.stdout, "FAIL"), result.stdout
+    assert "brew install gitleaks" in result.stdout


### PR DESCRIPTION
You were right that this was a wheel already turning. The matching half of `scripts/redaction-scan.sh` reimplements gitleaks and worse: fourteen hand-written rules against a maintained set of hundreds, no entropy checks, plus its own baseline, allowlist, and output masking. gitleaks 8.30.1 is already installed on the hosts this runs on.

This PR lands the preparation, not the swap, because the swap needs a safety net first.

## What is reinvention, and what is not

Measured, not assumed:

| our scanner | gitleaks |
|---|---|
| 14 regex rules | maintained default set plus entropy |
| `PLACEHOLDER_HINTS` | `[allowlist] regexes` |
| `.redaction-inventory-baseline` | `--baseline-path` |
| `sed` masking in `record_finding` | `--redact` |
| `--staged` / `--range` modes | `git --staged` / `--log-opts` / `--pre-commit` |
| rg-then-grep fallback with lookaround stripping | one engine |
| **commit message scanning** | **does not do it** |
| **`redaction-inventory`, the inverse question** | **no equivalent** |

The last two rows are why the wrapper survives. A key placed only in a commit message returns `no leaks found`, while the same key in file content is found. That was the incident this repository actually had.

## The constraint that made adoption possible

Organization patterns must not be committed here, and gitleaks honors `--config` then `GITLEAKS_CONFIG` then `GITLEAKS_CONFIG_TOML` before the in-tree file, so they can stay out of version control exactly as `REDACTION_EXTRA_PATTERNS` does today. Verified: a custom rule in an out-of-tree config fires.

## The parity test is the point

`tests/test_gitleaks_parity.py` runs both engines over one fixture per rule plus the excused classes and requires agreement. Zero findings on both sides proves nothing, so every rule gets a positive that must be flagged.

**14 of 14 positives flagged by both. 3 of 3 negatives excused by both. No divergence.**

Three translation errors surfaced while writing it, which is the whole reason to write it before touching the gate:

1. synthetic home prefixes became gitleaks `paths`, which skips *files* rather than content, so 18 fixtures became findings
2. the placeholder list became `stopwords`, which excused nothing here; `regexes` does
3. the rule had been widened from `/Users` to `/home`, adding a false positive. A migration keeps the previous scope

One scope fact the swap depends on: `gitleaks dir .` walks the working tree including untracked output, and compiled bytecode alone gave 57 findings against 0 in tracked content. Build products are excluded in the config, and the wrapper will feed the tracked file list rather than the directory.

## Preflight

`gitleaks` is now a required check, waivable via `PREFLIGHT_WAIVE` like everything else. No special forced-install path.

## Gates

- `PYTHONPATH=src uv run --with pytest --no-project python3 -m pytest tests -q` : 404 passed, 1 skipped, 13 subtests passed
- current scanner on this branch: exit 0
- `gitleaks dir . --config config/gitleaks.toml` : no leaks found

## Next, as a separate PR

Reduce `redaction-scan.sh` to a wrapper: gitleaks for matching over the tracked list, the existing loop for commit messages through `gitleaks stdin`, and the honest scope line kept. The parity test is what makes that reviewable.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prepares the redaction gate to use `gitleaks` by adding a repo config and a parity test that proves our scanner and `gitleaks` match. Onboarding now requires `gitleaks` on PATH.

- **New Features**
  - Added `config/gitleaks.toml` extending defaults; org patterns load from `GITLEAKS_CONFIG` (kept out of VCS) and build products are excluded to prevent noisy findings.
  - Added `tests/test_gitleaks_parity.py`; both engines flag all 14 positives and excuse 3 negatives with no divergence.
  - Fixed config translations found by the test: content vs `paths`, placeholder handling via `regexes`, and restored `/Users` scope.
  - Updated preflight to require `gitleaks`; tests cover the missing-binary case.

<sup>Written for commit 36da49a581f95f6ae4ac51a2a82048fe7f5ffa6e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/baksohyeon/mogui-ADE-orchestrator/pull/30?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

