### PR TITLE
docs(onboarding): say the consequence of declining, and name what the gates miss

### DIFF
--- a/master-ops/CHANGELOG.md
+++ b/master-ops/CHANGELOG.md
@@ -39,6 +39,24 @@ installation was taken from alongside the tag.
 
 ## Unreleased
 
+Onboarding now states consequences instead of listing options.
+
+Step 7.5 offered a skill layer as optional. The template carries documents and
+scripts and cannot carry the host layer that makes a master behave the way those
+documents describe, so several of those components are optional in name only. Each
+one now comes with the consequence of declining it, said in the same breath as the
+offer, and the user's answer is recorded per component including a decline. A
+declined component is a fact about the installation; later behaviour that looks
+like a master defect is often a declined component instead.
+
+New Step 7.6 states what the publish gates do not cover: pull request titles and
+bodies, review comments, release notes, issue text, and anything typed into a
+forge web interface. None of it is in the repository, so no scanner here reads it,
+and it is where internal names arrive most easily because it is prose rather than
+code. A gate trusted beyond its scope is worse than no gate, since it turns an
+unchecked surface into a believed-clean one. The same rule is added to the
+incident-derived rules section with the grep that settles it.
+
 The redaction gate starts moving onto gitleaks as its matching engine, and this
 release carries the preparation rather than the swap.
 

--- a/master-ops/ONBOARDING.md
+++ b/master-ops/ONBOARDING.md
@@ -234,7 +234,34 @@ Verify the hook spec is documented, no sensitive implementation was added, and i
 
 Explain each component in one sentence before showing any command. Print approved install commands and stop; do not run them or edit `settings.json`, hooks, or plugin configuration.
 
+Say which of them are optional in name only. The template carries documents and scripts; it cannot carry the host layer that makes a master behave the way the documents describe, so a component listed here as recommended is often load-bearing. State the consequence of declining each one in a sentence, in the same breath as the offer, rather than leaving the user to discover it later:
+
+- a methodology skill layer changes how the master plans and verifies; without it the master still runs, and reads the charter as advice rather than procedure
+- a restraint skill layer keeps the master from over-building; without it, expect larger diffs and more speculative structure. It pairs with the methodology layer rather than competing with it: one decides how to approach work, the other decides how much to build
+- a tracker skill layer is what makes execution state survive a session; without it, state lives only in the transcript
+- a worker runtime is what makes delegation possible at all; without at least one, the master does every task itself
+
+Record the user's answer per component, including a decline. A declined component is a fact about the installation, and later behaviour that looks like a master defect is often a declined component instead.
+
 Verify the explanation preceded commands, nothing was installed or configured by the agent, and the user's choice—including no installation—is recorded.
+
+## Step 7.6. State What The Publish Gates Do Not Cover
+
+**Position and action:** Step 7.6 follows immediately, while the gates are fresh: tell the user what the redaction gates check and, more importantly, where they are silent.
+
+**Why/caution:** A gate that is trusted beyond its scope is worse than no gate, because it converts an unchecked surface into a believed-clean one.
+
+The gates read repository content. Name the surfaces they do not read, so nobody assumes coverage that does not exist:
+
+- pull request titles, bodies, and review comments
+- release notes and issue text
+- anything typed into a forge web interface
+
+None of those are in the repository, so no scanner in this template sees them. They are also where internal names most easily arrive, because they are written in prose rather than code. The habit that works is to grep your own outgoing text for organization identifiers before posting it, exactly as the scan does for files.
+
+Tell the user that organization-specific patterns live in a file outside version control, that the gates fail closed without it, and that its format is one rule per line as `id|description|regex`. That file is what makes the gates able to catch a workspace name; the shipped rules only catch generic provider secrets.
+
+Verify the user can state one surface the gates do not cover, and that the organization rules file exists or its absence is recorded as a known gap.
 
 ## Step 8. Spawn The Founding Master Through Orchestration
 

--- a/master-ops/docs/MASTER-OPERATIONS.md
+++ b/master-ops/docs/MASTER-OPERATIONS.md
@@ -243,6 +243,10 @@ Lineage is append-only observability metadata. Do not use Lineage as the bootstr
 
 Git history and the issue tracker record what happened but cannot record what shaped the master's behaviour, what it nearly did, or what it declined to do. Without that layer the owner's only observation channel is a post-incident report, which arrives only after something broke. The observability suite (`docs/observability/README.md`) fills it with voluntary standing records: the retro ledger answers why a decision took the shape it did, and the travelog answers what happened. Attribution tags, the falsifiability rule for judgment claims, freshness honesty after compaction, and the requirement to list what did not fire are specified once in that index and apply to every genre.
 
+**Publish gates read repository content and nothing else.**
+Observed: pull request bodies, review comments, release notes, and issue text are not in the repository, so no scanner in this template reads them. An audit of one day's outgoing text found none, which is the point: it took a separate grep to know.
+Measure: before posting outgoing text, grep it for organization identifiers the way the scan greps files. A green publish gate says nothing about prose written into a forge.
+
 ## 8. Incident-Derived Rules
 
 Every rule below was paid for. Each one names the observation that produced it and the measurement that settles it, because a rule without its evidence gets argued away by the next reader, and a rule without a measurement cannot be checked. Add to this section the same way: rule, what was observed, how to measure it. Do not add a rule you cannot measure.


### PR DESCRIPTION
Two things that only surface after using this for a while, both from today.

## Optional in name only

Step 7.5 offered the skill layer as optional. The template carries documents and scripts and cannot carry the host layer that makes a master behave the way those documents describe, so several of those components are load-bearing while reading as preferences.

Each now states the consequence of declining, in the same breath as the offer:

- methodology layer: without it the master still runs, and reads the charter as advice rather than procedure
- restraint layer: without it, expect larger diffs and more speculative structure. It **pairs** with the methodology layer rather than competing, one deciding how to approach work and the other how much to build
- tracker layer: without it, execution state lives only in the transcript
- worker runtime: without at least one, the master does every task itself

The answer is recorded per component, including a decline, because a declined component is a fact about the installation. Behaviour that later looks like a master defect is often a declined component instead.

This is the honest version of a required-options prompt: no fake agreement to click, just the cost of each no said out loud and written down.

## What the gates do not cover

New Step 7.6. The publish gates read repository content. They do not read:

- pull request titles, bodies, review comments
- release notes, issue text
- anything typed into a forge web interface

None of it is in the repository, and it is where internal names arrive most easily because it is prose rather than code. A gate trusted past its scope is worse than no gate: it converts an unchecked surface into a believed-clean one.

Added to the incident-derived rules with its measurement, which came from auditing one day of outgoing text across twelve pull requests, their comments, the commit messages, and the release notes. Result was clean, and that is the point: it took a separate grep to know, because no gate covers it.

## Gates

- `PYTHONPATH=src uv run --with pytest --no-project python3 -m pytest tests -q` : 404 passed, 1 skipped, 13 subtests passed
- `REDACTION_REQUIRE_EXTRA=1 REDACTION_EXTRA_PATTERNS=… ./scripts/redaction-scan.sh` : exit 0

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clarifies onboarding by stating the real consequences of declining recommended skill components and documenting what publish gates do not cover, to prevent misconfiguration and false “clean” assumptions.

- **New Features**
  - Step 7.5: each recommended component now states the consequence of declining, and the choice is recorded per component.
  - Consequences: methodology (charter becomes advice), restraint (larger diffs; pairs with methodology), tracker (state only in transcript), worker runtime (no delegation).
  - Step 7.6: documents surfaces gates do not read (PR titles/bodies, review comments, release notes, issue text, forge UI), adds an incident-derived rule with measurement, and advises grepping outgoing prose.

<sup>Written for commit a7dd7dbe0a4df5a03295c2e51ef401cff4c1cb3c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/baksohyeon/mogui-ADE-orchestrator/pull/31?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

