### PR TITLE
feat(scan): hand matching to gitleaks, keep what gitleaks does not do

### DIFF
--- a/master-ops/CHANGELOG.md
+++ b/master-ops/CHANGELOG.md
@@ -39,6 +39,44 @@ installation was taken from alongside the tag.
 
 ## Unreleased
 
+The redaction gate now runs on gitleaks. `scripts/redaction-scan.sh` keeps only
+what gitleaks does not do: scoping to tracked content, scanning commit messages,
+translating the organization rules file, and stating what was covered. The file
+went from 440 lines to 304, and the rule list, allowlist parser, and masking
+plumbing are gone.
+
+The operator interface does not change. `REDACTION_EXTRA_PATTERNS` still names a
+file of `id|description|regex` lines outside version control, and the wrapper
+translates it into a gitleaks config that extends the committed one, so no host
+converts anything. `REDACTION_REQUIRE_EXTRA=1` still exits 2 when those rules are
+absent.
+
+Two behaviours are new because the engine changed. Exemptions move to gitleaks'
+own mechanisms, a `.gitleaksignore` fingerprint or a config allowlist, and an
+allowlist file still holding entries in the retired format now exits 2 rather than
+being ignored: an installation whose exemptions stopped applying should hear it
+from the gate. Scanning is one path per invocation, because gitleaks scopes a
+single path argument reliably and falls back to the whole directory when given
+several, which would make a tracked scan depend on untracked local scratch.
+
+The reported organization-rule count now describes what was loaded rather than what
+the file held. A mutation that kept the count while dropping the generated config
+from the run was invisible, since a clean tree stays clean either way. A test now
+plants a token no shipped rule matches and requires it to be found with the rules
+and missed without them.
+
+The adapter's health check no longer probes Orca with `orca --version`. That flag
+does not exist: on one host it prints the usage banner and exits 0, so the check
+passed while proving nothing, and a Linux user reported the same command launching
+the GUI application. It now uses `orca status --json`, the documented probe, which
+is what the onboarding preflight already used. Added to the incident-derived rules
+as its own entry, since the shape generalizes past this one tool.
+
+The preflight also requires `ctx`, the cross-provider agent history index, with a
+reachable local index. The records practice asks what happened across sessions and
+providers, which no single provider's transcript can answer. Waivable like any
+other check for a host that does no history work.
+
 Onboarding now states consequences instead of listing options.
 
 Step 7.5 offered a skill layer as optional. The template carries documents and

--- a/master-ops/ONBOARDING.md
+++ b/master-ops/ONBOARDING.md
@@ -53,7 +53,8 @@ Verify:
 - the preflight exits zero, Orca status was measured, a non-legacy orchestration Run is bound to this terminal, required skills resolve, `bd` is present and resolves to the ops repo when one exists, and Python is present
 - the named agent CLI is set and resolves on `PATH`; an unset selection is a FAIL, because it silently downgrades the agent-specific checks to INFO
 - at least one of the worker runtimes this master dispatches to resolves on `PATH`; the others are reported as warnings, since routing every lane through one executor is a normal setup
-- `gitleaks` is present, because the redaction gate's matching engine is moving onto it and its organization rules live outside version control
+- `gitleaks` is present, because it is the redaction gate's matching engine and its organization rules live outside version control
+- `ctx` is present and its index is reachable, because the records practice asks what happened across sessions and providers, which one provider's transcript cannot answer
 - Git is present, and `gh` state was reported: a missing binary blocks, while unauthenticated or a missing `workflow` scope warns, because local-only work needs no forge credentials
 - every waiver in the summary was intended, and `PREFLIGHT_WAIVE` entries that matched no check are corrected rather than left, since a misspelled waiver leaves the check enforced
 - the organization rules file loads at least one rule and no rule is malformed; the preflight reports counts only and never the file's contents

--- a/master-ops/docs/MASTER-OPERATIONS.md
+++ b/master-ops/docs/MASTER-OPERATIONS.md
@@ -243,6 +243,10 @@ Lineage is append-only observability metadata. Do not use Lineage as the bootstr
 
 Git history and the issue tracker record what happened but cannot record what shaped the master's behaviour, what it nearly did, or what it declined to do. Without that layer the owner's only observation channel is a post-incident report, which arrives only after something broke. The observability suite (`docs/observability/README.md`) fills it with voluntary standing records: the retro ledger answers why a decision took the shape it did, and the travelog answers what happened. Attribution tags, the falsifiability rule for judgment claims, freshness honesty after compaction, and the requirement to list what did not fire are specified once in that index and apply to every genre.
 
+**Probe a tool with a subcommand it must have, not a flag you assume.**
+Observed: a health check ran `orca --version`. That flag does not exist: on one host it printed the usage banner and exited 0, so the check passed while proving nothing, and a Linux user reported the same command launching the GUI application instead of answering.
+Measure: run the probe and read its output, not just its exit code. A probe whose output does not contain the fact you wanted is not a probe. Prefer the documented subcommand, here `status --json`, which fails cleanly when the tool is unusable.
+
 **Publish gates read repository content and nothing else.**
 Observed: pull request bodies, review comments, release notes, and issue text are not in the repository, so no scanner in this template reads them. An audit of one day's outgoing text found none, which is the point: it took a separate grep to know.
 Measure: before posting outgoing text, grep it for organization identifiers the way the scan greps files. A green publish gate says nothing about prose written into a forge.

--- a/scripts/onboarding-preflight.sh
+++ b/scripts/onboarding-preflight.sh
@@ -387,6 +387,20 @@ else
   fail "gitleaks" "gitleaks is not on PATH; install it (brew install gitleaks, or see https://gitleaks.io) because the redaction gate's matching engine is moving to it"
 fi
 
+# ctx indexes agent history from every provider on the host into one queryable
+# store. The records practice depends on being able to ask what happened across
+# sessions and agents, which a single provider's transcript cannot answer.
+if command -v ctx >/dev/null 2>&1; then
+  ctx_status=""
+  if ctx_status=$(ctx status 2>&1); then
+    pass "ctx" "$(ctx --version 2>&1 | head -1); index reachable"
+  else
+    fail "ctx" "ctx is installed but 'ctx status' failed; run 'ctx setup' to create the local index"
+  fi
+else
+  fail "ctx" "ctx is not on PATH; install it (see https://ctx.rs) because the records practice queries agent history across providers, and waive this check if this host does no history work"
+fi
+
 for repo_tool in git gh; do
   if command -v "$repo_tool" >/dev/null 2>&1; then
     pass "$repo_tool" "present"

--- a/scripts/redaction-scan.sh
+++ b/scripts/redaction-scan.sh
@@ -154,6 +154,11 @@ PY
   fi
   if [[ "${EXTRA_RULE_COUNT}" -gt 0 ]]; then
     CONFIG="${ORG_CONFIG}"
+  else
+    # The count describes what was loaded, never what the file happened to hold.
+    # Reporting a number the scan did not use is the same defect this gate exists
+    # to catch, one level up.
+    EXTRA_RULE_COUNT=0
   fi
   if [[ "${EXTRA_UNUSABLE}" -gt 0 ]]; then
     echo "redaction-scan: WARNING — ${EXTRA_UNUSABLE} of ${EXTRA_CONSIDERED} organization rule lines are unusable and were skipped" >&2
@@ -290,7 +295,7 @@ PY
 FINDINGS="$(wc -l < "${FINDINGS_FILE}" | tr -d ' ')"
 
 if [[ "${VERBOSE}" -eq 1 ]]; then
-  echo "redaction-scan: mode=${MODE} range=${RANGE:-none} files=${file_count} commit-messages=${COMMIT_MESSAGES_SCANNED} org-rules=${EXTRA_RULE_COUNT} engine=$(gitleaks version 2>/dev/null | head -1)"
+  echo "redaction-scan: mode=${MODE} range=${RANGE:-none} files=${file_count} commit-messages=${COMMIT_MESSAGES_SCANNED} org-rules=${EXTRA_RULE_COUNT} config=$(basename "${CONFIG}") engine=$(gitleaks version 2>/dev/null | head -1)"
 fi
 
 if [[ "${FINDINGS}" -gt 0 ]]; then

--- a/scripts/redaction-scan.sh
+++ b/scripts/redaction-scan.sh
@@ -1,40 +1,67 @@
 #!/usr/bin/env bash
 # redaction-scan.sh — fail-closed pre-push / CI scan for secrets and internal identifiers.
 #
+# gitleaks is the matching engine. This script is what gitleaks does not do: scope
+# the scan to tracked content, scan commit messages, translate the organization
+# rules file into a gitleaks config, and state what was covered.
+#
 # Usage:
-#   scripts/redaction-scan.sh                 # scan all tracked files (default)
+#   scripts/redaction-scan.sh                 # all tracked files (default)
 #   scripts/redaction-scan.sh --staged        # index / staged only
-#   scripts/redaction-scan.sh --range A..B    # files changed in git range, and those commits' messages (pre-push)
-#   scripts/redaction-scan.sh --commit-messages A..B  # message scan in any mode
+#   scripts/redaction-scan.sh --range A..B    # files changed in a range, and those commits' messages
+#   scripts/redaction-scan.sh --commit-messages A..B   # message scan in any mode
 #   scripts/redaction-scan.sh --help
 #
-# Exit: 0 clean, 1 findings (or usage/tool error), 2 internal error
+# Exit: 0 clean, 1 findings, 2 cannot decide (missing tool, missing required rules, usage)
 #
-# Allowlist: scripts/redaction-allowlist.txt (or REDACTION_ALLOWLIST env path)
-#   # comment
-#   path/to/file:LINE          # silence that file:line
-#   path/to/file               # silence whole file
-#   PREFIX:/Users/dev/         # silence matches whose text contains this prefix
-#   RULE:rule_id               # silence a whole rule (use sparingly)
+# Organization-specific rules (REDACTION_EXTRA_PATTERNS)
+#   Real company, product, and personal identifiers are deliberately not committed
+#   here: this repository is public, so committing them would publish what they
+#   protect. Supply them per checkout, one rule per line:
+#
+#     id|description|regex
+#
+#   Blank lines and lines beginning with # are skipped. Only the first two pipes
+#   separate fields, so a regex may contain a pipe. Every regex must compile.
+#   With REDACTION_REQUIRE_EXTRA=1, a missing or empty file exits 2 instead of
+#   scanning with generic rules only.
+#
+# Exemptions use gitleaks' own mechanisms: a .gitleaksignore fingerprint for one
+# finding, or config/gitleaks.toml for a whole class.
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
 cd "${REPO_ROOT}"
 
-ALLOWLIST_FILE="${REDACTION_ALLOWLIST:-${SCRIPT_DIR}/redaction-allowlist.txt}"
-REQUIRE_EXTRA="${REDACTION_REQUIRE_EXTRA:-0}"
-MODE="tracked"   # tracked | staged | range
+BASE_CONFIG="${REPO_ROOT}/config/gitleaks.toml"
+LEGACY_ALLOWLIST="${REDACTION_ALLOWLIST:-${SCRIPT_DIR}/redaction-allowlist.txt}"
+MODE="tracked"
 RANGE=""
+COMMIT_RANGE=""
 VERBOSE=0
+REQUIRE_EXTRA="${REDACTION_REQUIRE_EXTRA:-0}"
+COMMIT_MESSAGES_SCANNED="not-scanned"
+EXTRA_RULE_COUNT=0
+EXTRA_UNUSABLE=0
+EXTRA_CONSIDERED=0
 
 usage() {
-  sed -n '2,20p' "$0" | sed 's/^# \{0,1\}//'
+  sed -n '2,30p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'
 }
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
     --staged) MODE="staged"; shift ;;
+    --range)
+      MODE="range"
+      RANGE="${2:-}"
+      if [[ -z "${RANGE}" || "${RANGE}" != *..* ]]; then
+        echo "redaction-scan: --range requires A..B" >&2
+        exit 2
+      fi
+      shift 2
+      ;;
     --commit-messages)
       COMMIT_RANGE="${2:-}"
       if [[ -z "${COMMIT_RANGE}" ]]; then
@@ -43,398 +70,235 @@ while [[ $# -gt 0 ]]; do
       fi
       shift 2
       ;;
-    --range)
-      MODE="range"
-      RANGE="${2:-}"
-      if [[ -z "${RANGE}" ]]; then
-        echo "redaction-scan: --range requires A..B" >&2
-        exit 1
-      fi
-      shift 2
-      ;;
     --allowlist)
-      ALLOWLIST_FILE="${2:-}"
+      LEGACY_ALLOWLIST="${2:-}"
       shift 2
       ;;
     --require-extra) REQUIRE_EXTRA=1; shift ;;
     -v|--verbose) VERBOSE=1; shift ;;
     -h|--help) usage; exit 0 ;;
-    *)
-      echo "redaction-scan: unknown arg: $1" >&2
-      usage >&2
-      exit 1
-      ;;
+    *) echo "redaction-scan: unknown argument: $1" >&2; exit 2 ;;
   esac
 done
 
-if ! command -v git >/dev/null 2>&1; then
-  echo "redaction-scan: git is required" >&2
+if ! command -v gitleaks >/dev/null 2>&1; then
+  echo "redaction-scan: FAIL — gitleaks is not on PATH; install it (brew install gitleaks) or see https://gitleaks.io" >&2
   exit 2
 fi
-if ! command -v rg >/dev/null 2>&1 && ! command -v grep >/dev/null 2>&1; then
-  echo "redaction-scan: grep or rg is required" >&2
+if [[ ! -f "${BASE_CONFIG}" ]]; then
+  echo "redaction-scan: FAIL — missing ${BASE_CONFIG}" >&2
   exit 2
 fi
 
-# --- rules: id|description|extended-regex (ERE) ---
-# Keep secret patterns specific enough that docs saying "tokens" (LLM budget) pass.
-RULES=(
-  "private_key|PEM/OpenSSH private key header|BEGIN (RSA |OPENSSH |EC |DSA |OPENSSH )?PRIVATE KEY"
-  "aws_access_key|AWS access key id|AKIA[0-9A-Z]{16}"
-  "github_token|GitHub personal/access token|gh[pousr]_[A-Za-z0-9]{20,}"
-  "slack_token|Slack API token|xox[baprs]-[A-Za-z0-9-]{10,}"
-  "openai_sk|OpenAI-style secret key|sk-[A-Za-z0-9]{20,}"
-  "anthropic_key|Anthropic-style key|sk-ant-[A-Za-z0-9_-]{20,}"
-  "bearer_token|Bearer credential literal|Bearer [A-Za-z0-9._\\-]{24,}"
-  "assignment_secret|Hardcoded secret assignment|(?i)(api[_-]?key|secret[_-]?key|access[_-]?token|auth[_-]?token|password|passwd)\\s*[=:]\\s*['\\\"][^'\\\"\\s]{8,}['\\\"]"
-  "dotenv_export|Exported env secret|(?i)export\\s+(API_KEY|SECRET_KEY|ACCESS_TOKEN|PASSWORD|AWS_SECRET_ACCESS_KEY|ANTHROPIC_API_KEY|OPENAI_API_KEY)\\s*="
-  "home_path|Absolute home path /Users/<name>|/Users/[A-Za-z0-9._-]+"
-  "internal_ip|Private RFC1918 IP|\\b(10\\.[0-9]{1,3}\\.[0-9]{1,3}\\.[0-9]{1,3}|192\\.168\\.[0-9]{1,3}\\.[0-9]{1,3}|172\\.(1[6-9]|2[0-9]|3[0-1])\\.[0-9]{1,3}\\.[0-9]{1,3})\\b"
-  "jira_hf|Internal Jira ticket HF-*|\\bHF-[0-9]{2,}\\b"
-  "slack_url|Slack workspace/archive URL|https?://[A-Za-z0-9._-]*slack\\.com/"
-  "internal_host|Internal/corp hostname|\\b[A-Za-z0-9._-]+\\.(internal|corp|local)\\b"
-)
+# The previous allowlist format is no longer interpreted. Refuse loudly rather
+# than ignore it: an installation whose exemptions stopped applying should hear it
+# from the gate, not discover it when a finding it had accepted comes back.
+if [[ -f "${LEGACY_ALLOWLIST}" ]] \
+  && grep -qvE '^[[:space:]]*(#|$)' "${LEGACY_ALLOWLIST}" 2>/dev/null; then
+  echo "redaction-scan: FAIL — ${LEGACY_ALLOWLIST} has entries in the retired format." >&2
+  echo "redaction-scan: migrate each to a .gitleaksignore fingerprint, or to an allowlist in config/gitleaks.toml, then empty this file." >&2
+  exit 2
+fi
 
-# Values that look like placeholders / docs — never fail these lines.
-# Matched as case-insensitive substrings of the whole line.
-# Organization-specific identifiers are not hardcoded here: this repository is public,
-# so committing real company or personal names to the scanner would leak what it protects.
-# Supply them per checkout via REDACTION_EXTRA_PATTERNS (newline-separated
-# "id|description|regex" entries) and keep that file outside version control.
-EXTRA_RULE_COUNT=0
+WORK_DIR="$(mktemp -d)"
+trap 'rm -rf "${WORK_DIR}"' EXIT
+CONFIG="${BASE_CONFIG}"
+
+# Translate the organization rules file into a gitleaks config that extends the
+# committed one. The operator-facing format does not change, so no host has to
+# convert anything, and the patterns stay outside version control.
 if [[ -n "${REDACTION_EXTRA_PATTERNS:-}" && -f "${REDACTION_EXTRA_PATTERNS}" ]]; then
-  while IFS= read -r extra_rule; do
-    [[ -z "${extra_rule}" || "${extra_rule}" == \#* ]] && continue
-    RULES+=("${extra_rule}")
-    EXTRA_RULE_COUNT=$((EXTRA_RULE_COUNT + 1))
-  done < "${REDACTION_EXTRA_PATTERNS}"
+  ORG_CONFIG="${WORK_DIR}/org.toml"
+  if python3 - "${REDACTION_EXTRA_PATTERNS}" "${BASE_CONFIG}" "${ORG_CONFIG}" > "${WORK_DIR}/counts" <<'PY'
+import re
+import sys
+
+source, base, target = sys.argv[1], sys.argv[2], sys.argv[3]
+rules, unusable, considered = [], 0, 0
+with open(source, encoding="utf-8") as handle:
+    for line in handle:
+        line = line.strip()
+        if not line or line.startswith("#"):
+            continue
+        considered += 1
+        parts = line.split("|", 2)
+        if len(parts) != 3:
+            unusable += 1
+            continue
+        rule_id, description, regex = (part.strip() for part in parts)
+        try:
+            re.compile(regex)
+        except re.error:
+            unusable += 1
+            continue
+        rules.append((rule_id or f"org_rule_{len(rules)}", description, regex))
+
+with open(target, "w", encoding="utf-8") as out:
+    out.write('title = "organization rules"\n\n')
+    out.write('[extend]\npath = "%s"\n\n' % base)
+    for rule_id, description, regex in rules:
+        out.write("[[rules]]\n")
+        out.write('id = "%s"\n' % rule_id.replace('"', ""))
+        out.write('description = "%s"\n' % description.replace('"', ""))
+        out.write("regex = '''%s'''\n\n" % regex)
+
+# Counts only. This file's contents are what the scan protects, so nothing from it
+# is printed here or anywhere else.
+print(f"{len(rules)} {unusable} {considered}")
+PY
+  then
+    read -r EXTRA_RULE_COUNT EXTRA_UNUSABLE EXTRA_CONSIDERED < "${WORK_DIR}/counts"
+  else
+    echo "redaction-scan: FAIL — could not read the organization rules file" >&2
+    exit 2
+  fi
+  if [[ "${EXTRA_RULE_COUNT}" -gt 0 ]]; then
+    CONFIG="${ORG_CONFIG}"
+  fi
+  if [[ "${EXTRA_UNUSABLE}" -gt 0 ]]; then
+    echo "redaction-scan: WARNING — ${EXTRA_UNUSABLE} of ${EXTRA_CONSIDERED} organization rule lines are unusable and were skipped" >&2
+  fi
 fi
 
-# A green scan must not imply coverage it does not have: say so when the
-# organization-specific rules were never loaded.
+# A green scan must not imply coverage it does not have.
 if [[ "${EXTRA_RULE_COUNT}" -eq 0 ]]; then
   echo "redaction-scan: WARNING — organization-specific rules not loaded (REDACTION_EXTRA_PATTERNS unset or empty); this scan covers generic patterns only" >&2
   if [[ "${REQUIRE_EXTRA}" == "1" ]]; then
-    echo "redaction-scan: FAIL — --require-extra set and no organization-specific rules were loaded" >&2
+    echo "redaction-scan: FAIL — required organization rules were not loaded" >&2
     exit 2
   fi
 fi
 
-PLACEHOLDER_HINTS=(
-  "example.com"
-  "example-product"
-  "your_api_key"
-  "your-api-key"
-  "changeme"
-  "placeholder"
-  "redacted"
-  "xxx"
-  "todo"
-  "insert_"
-  "replace_me"
-  "dummy"
-  "fake_"
-  "test_secret"
-  "sk-test-"
-  "sk-ant-api03-test"
-  "ghp_example"
-  "xoxb-example"
-  "AKIAIOSFODNN7EXAMPLE"
-  "not-a-real"
-  "sample only"
-)
-
-# Synthetic path prefixes intentionally used as fixtures (still reported under allowlist PREFIX:).
-DEFAULT_SYNTHETIC_PREFIXES=(
-  "/Users/dev/"
-  "/Users/user/"
-  "/Users/example/"
-  "/Users/runner/"
-  "/Users/you/"
-  "/home/dev/"
-  "/home/user/"
-)
-
-declare -a ALLOW_PATHS=()
-declare -a ALLOW_PATH_LINES=()
-declare -a ALLOW_PREFIXES=()
-declare -a ALLOW_RULES=()
-
-load_allowlist() {
-  ALLOW_PREFIXES=("${DEFAULT_SYNTHETIC_PREFIXES[@]}")
-  [[ -f "${ALLOWLIST_FILE}" ]] || return 0
-  while IFS= read -r raw || [[ -n "${raw}" ]]; do
-    local line
-    line="$(printf '%s' "${raw}" | sed -e 's/#.*//' -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')"
-    [[ -z "${line}" ]] && continue
-    case "${line}" in
-      PREFIX:*)
-        ALLOW_PREFIXES+=("${line#PREFIX:}")
-        ;;
-      RULE:*)
-        ALLOW_RULES+=("${line#RULE:}")
-        ;;
-      *:*)
-        # path:LINE
-        ALLOW_PATH_LINES+=("${line}")
-        ;;
-      *)
-        ALLOW_PATHS+=("${line}")
-        ;;
-    esac
-  done < "${ALLOWLIST_FILE}"
-}
-
-rule_allowed() {
-  local rule_id="$1"
-  local r
-  for r in "${ALLOW_RULES[@]+"${ALLOW_RULES[@]}"}"; do
-    [[ "${r}" == "${rule_id}" ]] && return 0
-  done
-  return 1
-}
-
-path_allowed() {
-  local path="$1"
-  local p
-  for p in "${ALLOW_PATHS[@]+"${ALLOW_PATHS[@]}"}"; do
-    [[ "${p}" == "${path}" ]] && return 0
-  done
-  return 1
-}
-
-path_line_allowed() {
-  local key="$1"
-  local p
-  for p in "${ALLOW_PATH_LINES[@]+"${ALLOW_PATH_LINES[@]}"}"; do
-    [[ "${p}" == "${key}" ]] && return 0
-  done
-  return 1
-}
-
-line_is_placeholder() {
-  local text_lc
-  text_lc="$(printf '%s' "$1" | tr '[:upper:]' '[:lower:]')"
-  local h
-  for h in "${PLACEHOLDER_HINTS[@]}"; do
-    local hl
-    hl="$(printf '%s' "${h}" | tr '[:upper:]' '[:lower:]')"
-    [[ "${text_lc}" == *"${hl}"* ]] && return 0
-  done
-  return 1
-}
-
-line_has_allowed_prefix() {
-  local text="$1"
-  local pref
-  for pref in "${ALLOW_PREFIXES[@]+"${ALLOW_PREFIXES[@]}"}"; do
-    # home_path rule: if the only /Users hits are synthetic prefixes, skip.
-    if [[ "${text}" == *"${pref}"* ]]; then
-      # If text also contains another /Users/<other> not covered by prefixes, still fail later.
-      return 0
-    fi
-  done
-  return 1
-}
-
-# For home_path: true if every /Users/<name> occurrence is under an allowed prefix.
-home_path_only_synthetic() {
-  local text="$1"
-  # Extract /Users/name occurrences
-  local matches
-  matches="$(printf '%s\n' "${text}" | grep -oE '/Users/[A-Za-z0-9._-]+' || true)"
-  [[ -z "${matches}" ]] && return 1
-  local m
-  while IFS= read -r m; do
-    [[ -z "${m}" ]] && continue
-    local ok=0
-    local pref
-    for pref in "${ALLOW_PREFIXES[@]+"${ALLOW_PREFIXES[@]}"}"; do
-      # pref is like /Users/dev/ — match path start /Users/dev
-      local base="${pref%/}"
-      if [[ "${m}" == "${base}" || "${text}" == *"${pref}"* ]]; then
-        # Check this specific match is under base
-        case "${m}" in
-          "${base}"|"${base}"/*) ok=1; break ;;
-        esac
-        # /Users/dev matches /Users/dev/...
-        if [[ "${m}" == "${base}"* ]]; then
-          ok=1
-          break
-        fi
-      fi
-    done
-    if [[ "${ok}" -eq 0 ]]; then
-      return 1
-    fi
-  done <<< "${matches}"
-  return 0
-}
-
 list_scan_files() {
   case "${MODE}" in
-    tracked)
-      git ls-files -z
-      ;;
-    staged)
-      git diff --cached --name-only -z --diff-filter=ACMR
-      ;;
-    range)
-      git diff --name-only -z --diff-filter=ACMR "${RANGE}"
-      ;;
+    tracked) git ls-files -z ;;
+    staged)  git diff --cached --name-only -z --diff-filter=ACMR ;;
+    range)   git diff --name-only -z --diff-filter=ACMR "${RANGE}" ;;
   esac
 }
 
-COMMIT_MESSAGES_SCANNED="not-scanned"
+REPORTS="${WORK_DIR}/reports"
+mkdir -p "${REPORTS}"
+report_index=0
+
+scan_path() {
+  # One path per invocation. gitleaks scopes a single path argument reliably and
+  # falls back to the whole directory when given several, which would drag in
+  # untracked files and make a tracked scan depend on local scratch.
+  local path="$1"
+  [[ -f "${path}" ]] || return 0
+  report_index=$((report_index + 1))
+  gitleaks dir "${path}" \
+    --config "${CONFIG}" \
+    --no-banner \
+    --exit-code 0 \
+    --report-format json \
+    --report-path "${REPORTS}/${report_index}.json" \
+    >/dev/null 2>&1 || true
+}
 
 scan_commit_messages() {
-  # Commit messages are content this repository publishes and the file scan never
-  # sees them. An internal workspace name sat in four of them here while the gate
-  # stayed green, and a person found it by eye.
+  # gitleaks does not read commit messages: a key present only in a message
+  # returns no findings while the same key in file content is found. Measured,
+  # which is why this loop exists.
   local range="$1"
-  local count=0 sha tmp
+  local count=0 sha
   while IFS= read -r sha; do
     [[ -z "${sha}" ]] && continue
-    tmp="$(mktemp)"
-    git log -1 --format=%B "${sha}" > "${tmp}" 2>/dev/null || true
-    scan_file "${tmp}" "commit:${sha:0:12}"
-    rm -f "${tmp}"
+    report_index=$((report_index + 1))
+    git log -1 --format=%B "${sha}" \
+      | gitleaks stdin \
+          --config "${CONFIG}" \
+          --no-banner \
+          --exit-code 0 \
+          --report-format json \
+          --report-path "${REPORTS}/${report_index}.json" \
+          >/dev/null 2>&1 || true
+    if [[ -s "${REPORTS}/${report_index}.json" ]]; then
+      python3 - "${REPORTS}/${report_index}.json" "commit:${sha:0:12}" <<'PY'
+import json
+import sys
+
+path, label = sys.argv[1], sys.argv[2]
+with open(path, encoding="utf-8") as handle:
+    rows = json.load(handle)
+for row in rows:
+    row["File"] = label
+with open(path, "w", encoding="utf-8") as handle:
+    json.dump(rows, handle)
+PY
+    fi
     count=$((count + 1))
   done < <(git log --format=%H "${range}" 2>/dev/null || true)
   COMMIT_MESSAGES_SCANNED="${count}"
 }
 
-is_binary_or_skip() {
-  local path="$1"
-  case "${path}" in
-    *.png|*.jpg|*.jpeg|*.gif|*.webp|*.ico|*.pdf|*.zip|*.gz|*.tgz|*.whl|*.so|*.dylib|*.o|*.a|*.pyc|*.db|*.sqlite)
-      return 0
-      ;;
-  esac
-  # skip the scanner / allowlist / result reports themselves if present
-  case "${path}" in
-    scripts/redaction-scan.sh|scripts/redaction-allowlist.txt|mogui-redact-result.md|mogui-redaction-result.md)
-      return 0
-      ;;
-  esac
-  return 1
-}
+if [[ -z "${COMMIT_RANGE}" && "${MODE}" == "range" ]]; then
+  COMMIT_RANGE="${RANGE}"
+fi
+if [[ -n "${COMMIT_RANGE}" ]]; then
+  scan_commit_messages "${COMMIT_RANGE}"
+fi
 
-FINDINGS=0
-declare -a FINDING_LINES=()
+file_count=0
+while IFS= read -r -d '' path; do
+  [[ -z "${path}" ]] && continue
+  file_count=$((file_count + 1))
+  scan_path "${path}"
+done < <(list_scan_files)
 
-record_finding() {
-  local rule_id="$1"
-  local desc="$2"
-  local path="$3"
-  local line_no="$4"
-  local snippet="$5"
-  # Mask: keep structure, strip long secret-looking runs
-  local masked
-  masked="$(printf '%s' "${snippet}" \
-    | sed -E \
-      -e 's/(AKIA)[0-9A-Z]{16}/\1****************/g' \
-      -e 's/(gh[pousr]_)[A-Za-z0-9]{8,}/\1********/g' \
-      -e 's/(xox[baprs]-)[A-Za-z0-9-]{8,}/\1********/g' \
-      -e 's/(sk-ant-)[A-Za-z0-9_-]{8,}/\1********/g' \
-      -e 's/(sk-)[A-Za-z0-9]{8,}/\1********/g' \
-      -e 's/(Bearer )[A-Za-z0-9._-]{8,}/\1********/g' \
-      -e 's/(=[[:space:]]*["'"'"'])[^"'"'"']{8,}(["'"'"'])/\1***\2/g' \
-    | cut -c1-160)"
-  FINDING_LINES+=("${path}:${line_no}  [${rule_id}] ${desc}  :: ${masked}")
-  FINDINGS=$((FINDINGS + 1))
-}
+FINDINGS_FILE="${WORK_DIR}/findings.txt"
+python3 - "${REPORTS}" "${FINDINGS_FILE}" > /dev/null <<'PY'
+import json
+import pathlib
+import re
+import sys
 
-scan_file() {
-  # $1 is the file to read, $2 is what findings are reported as. They differ when
-  # the text did not come from a tracked file, such as a commit message.
-  local path="$1"
-  local label="${2:-$1}"
-  [[ -f "${path}" ]] || return 0
-  is_binary_or_skip "${label}" && return 0
-  path_allowed "${label}" && return 0
+reports, out_path = pathlib.Path(sys.argv[1]), pathlib.Path(sys.argv[2])
+MASKS = (
+    (re.compile(r"(AKIA)[0-9A-Z]{16}"), r"\1****************"),
+    (re.compile(r"(gh[pousr]_)[A-Za-z0-9]{8,}"), r"\1********"),
+    (re.compile(r"(xox[baprs]-)[A-Za-z0-9-]{8,}"), r"\1********"),
+    (re.compile(r"(sk-ant-)[A-Za-z0-9_-]{8,}"), r"\1********"),
+    (re.compile(r"(sk-)[A-Za-z0-9]{8,}"), r"\1********"),
+    (re.compile(r"(Bearer )[A-Za-z0-9._-]{8,}"), r"\1********"),
+    (re.compile(r"""(=\s*["'])[^"']{8,}(["'])"""), r"\1***\2"),
+)
 
-  local rule
-  for rule in "${RULES[@]}"; do
-    IFS='|' read -r rule_id desc regex <<< "${rule}"
-    rule_allowed "${rule_id}" && continue
+lines = set()
+for report in sorted(reports.glob("*.json")):
+    try:
+        rows = json.loads(report.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        continue
+    for row in rows:
+        snippet = (row.get("Match") or "").strip()
+        for pattern, replacement in MASKS:
+            snippet = pattern.sub(replacement, snippet)
+        lines.add(
+            "  {file}:{line}  [{rule}] {desc}  :: {snippet}".format(
+                file=row.get("File", "?"),
+                line=row.get("StartLine", 0),
+                rule=row.get("RuleID", "?"),
+                desc=row.get("Description", ""),
+                snippet=snippet[:160],
+            )
+        )
+out_path.write_text("".join(f"{line}\n" for line in sorted(lines)), encoding="utf-8")
+PY
 
-    # Prefer rg for PCRE (?i); fall back to grep -E (drop unsupported lookarounds lightly).
-    local matches=""
-    if command -v rg >/dev/null 2>&1; then
-      # rg: path with line numbers; PCRE2 for lookaround rules
-      matches="$(rg -n --pcre2 -e "${regex}" -- "${path}" 2>/dev/null || true)"
-    else
-      local gre_regex="${regex}"
-      # strip perl-ish (?i) and lookarounds for basic grep -E
-      gre_regex="$(printf '%s' "${gre_regex}" | sed -E 's/\(\?i\)//g; s/\(\?<![^)]*\)//g; s/\(\?![^)]*\)//g')"
-      matches="$(grep -n -E -e "${gre_regex}" -- "${path}" 2>/dev/null || true)"
-    fi
-    [[ -z "${matches}" ]] && continue
+FINDINGS="$(wc -l < "${FINDINGS_FILE}" | tr -d ' ')"
 
-    while IFS= read -r hit; do
-      [[ -z "${hit}" ]] && continue
-      local line_no="${hit%%:*}"
-      local text="${hit#*:}"
-      # Some greps include path:line:text when multi-file; we scan single file.
-      if [[ "${text}" == *:* ]] && [[ "${line_no}" == "${path}" ]]; then
-        # path:line:text form
-        local rest="${hit#*:}"
-        line_no="${rest%%:*}"
-        text="${rest#*:}"
-      fi
+if [[ "${VERBOSE}" -eq 1 ]]; then
+  echo "redaction-scan: mode=${MODE} range=${RANGE:-none} files=${file_count} commit-messages=${COMMIT_MESSAGES_SCANNED} org-rules=${EXTRA_RULE_COUNT} engine=$(gitleaks version 2>/dev/null | head -1)"
+fi
 
-      path_line_allowed "${label}:${line_no}" && continue
-      line_is_placeholder "${text}" && continue
+if [[ "${FINDINGS}" -gt 0 ]]; then
+  echo "redaction-scan: FAIL — ${FINDINGS} finding(s) (fail-closed)" >&2
+  cat "${FINDINGS_FILE}" >&2
+  echo "redaction-scan: fix, or exempt with a .gitleaksignore fingerprint, then re-run." >&2
+  exit 1
+fi
 
-      if [[ "${rule_id}" == "home_path" ]]; then
-        if home_path_only_synthetic "${text}"; then
-          continue
-        fi
-        # also skip if line only mentions allowed prefixes
-        if line_has_allowed_prefix "${text}" && home_path_only_synthetic "${text}"; then
-          continue
-        fi
-      fi
-
-      record_finding "${rule_id}" "${desc}" "${label}" "${line_no}" "${text}"
-    done <<< "${matches}"
-  done
-}
-
-main() {
-  load_allowlist
-
-  if [[ -z "${COMMIT_RANGE:-}" && "${MODE}" == "range" ]]; then
-    COMMIT_RANGE="${RANGE}"
-  fi
-  if [[ -n "${COMMIT_RANGE:-}" ]]; then
-    scan_commit_messages "${COMMIT_RANGE}"
-  fi
-
-  local file_count=0
-  while IFS= read -r -d '' path; do
-    [[ -z "${path}" ]] && continue
-    file_count=$((file_count + 1))
-    scan_file "${path}"
-  done < <(list_scan_files)
-
-  if [[ "${VERBOSE}" -eq 1 ]]; then
-    echo "redaction-scan: mode=${MODE} range=${RANGE:-none} files=${file_count} commit-messages=${COMMIT_MESSAGES_SCANNED} allowlist=${ALLOWLIST_FILE}"
-  fi
-
-  if [[ "${FINDINGS}" -gt 0 ]]; then
-    echo "redaction-scan: FAIL — ${FINDINGS} finding(s) (fail-closed)" >&2
-    local line
-    for line in "${FINDING_LINES[@]}"; do
-      echo "  ${line}" >&2
-    done
-    echo "redaction-scan: fix or allowlist (path:line / PREFIX: / RULE:) then re-run." >&2
-    exit 1
-  fi
-
-  echo "redaction-scan: OK — 0 findings (mode=${MODE}, files=${file_count}, commit-messages=${COMMIT_MESSAGES_SCANNED})"
-  exit 0
-}
-
-main
+echo "redaction-scan: OK — 0 findings (mode=${MODE}, files=${file_count}, commit-messages=${COMMIT_MESSAGES_SCANNED}, org-rules=${EXTRA_RULE_COUNT})"
+exit 0

--- a/src/master_runtime/core/adapter/doctor.py
+++ b/src/master_runtime/core/adapter/doctor.py
@@ -73,7 +73,11 @@ def default_runner(cmd: Sequence[str], cwd: Optional[str] = None) -> RunResult:
 DEFAULT_CHECKS = (
     ProbeCheck(name="git", probe_cmd=("git", "--version")),
     ProbeCheck(name="node", probe_cmd=("node", "--version")),
-    ProbeCheck(name="orca", probe_cmd=("orca", "--version")),
+    # Not `orca --version`: that flag does not exist. On this host it prints the
+    # usage banner and exits 0, so the check passed while proving nothing, and a
+    # Linux user reported the same command launching the GUI application instead.
+    # `status --json` is the documented probe and fails cleanly when unavailable.
+    ProbeCheck(name="orca", probe_cmd=("orca", "status", "--json")),
     ProbeCheck(name="bd", probe_cmd=("bd", "--version")),
 )
 

--- a/tests/test_onboarding_preflight.py
+++ b/tests/test_onboarding_preflight.py
@@ -87,7 +87,7 @@ def _host(
     _write_stub(bin_dir / "orca", ORCA_STUB)
     _write_stub(bin_dir / "bd", BD_STUB)
     _write_stub(bin_dir / "gh", GH_STUB)
-    for name in ("claude", "git", "gitleaks", *worker_runtimes):
+    for name in ("claude", "git", "gitleaks", "ctx", *worker_runtimes):
         _write_stub(bin_dir / name, TRUE_STUB)
 
     env = dict(os.environ)
@@ -269,3 +269,13 @@ def test_missing_gitleaks_fails(tmp_path: Path) -> None:
     result = _run(env, tmp_path)
     assert "gitleaks" in _labels(result.stdout, "FAIL"), result.stdout
     assert "brew install gitleaks" in result.stdout
+
+
+def test_missing_ctx_fails(tmp_path: Path) -> None:
+    """Agent history across providers is what the records practice queries."""
+
+    env = _host(tmp_path, sanitized_path=True)
+    (tmp_path / "bin" / "ctx").unlink()
+    result = _run(env, tmp_path)
+    assert "ctx" in _labels(result.stdout, "FAIL"), result.stdout
+    assert "ctx.rs" in result.stdout

--- a/tests/test_redaction_gate_coverage.py
+++ b/tests/test_redaction_gate_coverage.py
@@ -1,21 +1,16 @@
-"""Parity between the hand-written scanner and gitleaks with this repository's config.
+"""Rule coverage for the redaction gate, now that gitleaks is the matching engine.
 
-The matching half of `scripts/redaction-scan.sh` is a reimplementation of what
-gitleaks already does, and better: hundreds of maintained provider rules, entropy
-checks, baselines, allowlists, and output redaction. The plan is to hand matching
-to gitleaks and keep only what gitleaks does not do, which is commit-message
-scanning and the inverse blind-spot inventory.
+This began as a parity test between the hand-written scanner and gitleaks, and it
+did its job: three translation errors surfaced before the engine was swapped.
+Synthetic home prefixes had become gitleaks `paths`, which skips files rather than
+content, so 18 fixtures turned into findings. The placeholder list had become
+`stopwords`, which excused nothing here while `regexes` does. And the home-path
+rule had been widened from /Users to /home, which added a false positive.
 
-This test is the safety net for that swap. It runs both engines over the same
-fixtures and requires them to agree, so the engine can be replaced without the
-replacement quietly covering less. Two divergences were found and fixed while
-writing it: synthetic home prefixes had been translated into gitleaks `paths`,
-which skips files rather than content, and the placeholder list had been
-translated into `stopwords`, which did not excuse anything here while `regexes`
-does.
-
-Zero findings on both sides proves nothing on its own, so every rule gets a
-positive fixture that must be flagged and the excused classes get negatives.
+With the swap done, comparing the wrapper against gitleaks would compare gitleaks
+with itself. What remains worth pinning is coverage: every rule keeps a positive
+fixture that must be flagged, and the excused classes keep negatives that must
+not. Zero findings proves nothing on its own, which is why the positives exist.
 """
 
 from __future__ import annotations
@@ -83,6 +78,8 @@ def _fixture_repo(tmp_path: Path) -> Path:
     shutil.copy(SCANNER, repo / "scripts" / "redaction-scan.sh")
     (repo / "scripts" / "redaction-allowlist.txt").write_text("", encoding="utf-8")
     shutil.copy(CONFIG, repo / "config" / "gitleaks.toml")
+    # The gate reads config from the repository it lives in, so the fixture repo
+    # carries both, which is the shape an installation has.
     for name, body in {**MUST_FLAG, **MUST_EXCUSE}.items():
         (repo / f"{name}.txt").write_text(body + "\n", encoding="utf-8")
     subprocess.run(["git", "add", "-A"], cwd=repo, check=True, env=env)
@@ -132,39 +129,29 @@ def _gitleaks_files(repo: Path, tmp_path: Path) -> set[str]:
 
 
 @requires_gitleaks
-def test_both_engines_flag_every_positive_fixture(tmp_path: Path) -> None:
+def test_the_gate_flags_every_positive_fixture(tmp_path: Path) -> None:
     repo = _fixture_repo(tmp_path)
-    scanner = _scanner_files(repo)
-    gitleaks = _gitleaks_files(repo, tmp_path)
-
-    missed_by_scanner = sorted(set(MUST_FLAG) - scanner)
-    missed_by_gitleaks = sorted(set(MUST_FLAG) - gitleaks)
-    assert not missed_by_scanner, missed_by_scanner
-    assert not missed_by_gitleaks, missed_by_gitleaks
+    missed = sorted(set(MUST_FLAG) - _scanner_files(repo))
+    assert not missed, missed
 
 
 @requires_gitleaks
-def test_both_engines_excuse_placeholders_and_synthetic_paths(tmp_path: Path) -> None:
+def test_the_gate_excuses_placeholders_and_synthetic_paths(tmp_path: Path) -> None:
     repo = _fixture_repo(tmp_path)
-    scanner = _scanner_files(repo)
-    gitleaks = _gitleaks_files(repo, tmp_path)
-
-    wrongly_flagged_by_scanner = sorted(set(MUST_EXCUSE) & scanner)
-    wrongly_flagged_by_gitleaks = sorted(set(MUST_EXCUSE) & gitleaks)
-    assert not wrongly_flagged_by_scanner, wrongly_flagged_by_scanner
-    assert not wrongly_flagged_by_gitleaks, wrongly_flagged_by_gitleaks
+    wrongly_flagged = sorted(set(MUST_EXCUSE) & _scanner_files(repo))
+    assert not wrongly_flagged, wrongly_flagged
 
 
 @requires_gitleaks
-def test_the_two_engines_do_not_diverge_on_any_fixture(tmp_path: Path) -> None:
-    """The property the engine swap depends on."""
+def test_the_wrapper_and_a_direct_gitleaks_run_agree(tmp_path: Path) -> None:
+    """The wrapper must not narrow what the engine finds, only scope it."""
 
     repo = _fixture_repo(tmp_path)
-    scanner = _scanner_files(repo)
-    gitleaks = _gitleaks_files(repo, tmp_path)
-    assert scanner == gitleaks, {
-        "only_scanner": sorted(scanner - gitleaks),
-        "only_gitleaks": sorted(gitleaks - scanner),
+    through_wrapper = _scanner_files(repo)
+    direct = _gitleaks_files(repo, tmp_path)
+    assert through_wrapper == direct, {
+        "only_wrapper": sorted(through_wrapper - direct),
+        "only_direct": sorted(direct - through_wrapper),
     }
 
 

--- a/tests/test_redaction_gate_coverage.py
+++ b/tests/test_redaction_gate_coverage.py
@@ -61,6 +61,19 @@ requires_gitleaks = pytest.mark.skipif(
 )
 
 
+def _git(repo: Path, *args: str) -> None:
+    env = {
+        **os.environ,
+        "GIT_CONFIG_GLOBAL": "/dev/null",
+        "GIT_CONFIG_SYSTEM": "/dev/null",
+        "GIT_AUTHOR_NAME": "t",
+        "GIT_AUTHOR_EMAIL": "t@example.com",
+        "GIT_COMMITTER_NAME": "t",
+        "GIT_COMMITTER_EMAIL": "t@example.com",
+    }
+    subprocess.run(["git", *args], cwd=repo, check=True, env=env, capture_output=True)
+
+
 def _fixture_repo(tmp_path: Path) -> Path:
     repo = tmp_path / "repo"
     (repo / "scripts").mkdir(parents=True)
@@ -168,3 +181,70 @@ def test_config_does_not_carry_organization_patterns(tmp_path: Path) -> None:
     assert "GITLEAKS_CONFIG" in text, "the config must say where org rules live"
     for marker in ("person_", "company_", "org_"):
         assert marker not in text, marker
+
+
+@requires_gitleaks
+def test_organization_rules_reach_the_engine(tmp_path: Path) -> None:
+    """A count of loaded rules must mean the rules were used.
+
+    A mutation that kept the count but dropped the generated config from the run
+    was invisible: the tracked tree is clean either way, and the scope line still
+    said ten rules. The only thing that settles it is a token no shipped rule
+    matches.
+    """
+
+    repo = _fixture_repo(tmp_path)
+    token = "quokka" + "-ledger-9"
+    (repo / "org_only.txt").write_text(f"internal {token} here\n", encoding="utf-8")
+    # Tracked-mode scanning reads git ls-files, so an uncommitted fixture is out of
+    # scope. Finding that out here is the scoping working.
+    _git(repo, "add", "org_only.txt")
+    _git(repo, "commit", "-q", "-m", "org fixture")
+    rules = tmp_path / "org-rules.txt"
+    rules.write_text(f"org_codename|internal codename|{token}\n", encoding="utf-8")
+
+    env = {**os.environ, "REDACTION_EXTRA_PATTERNS": str(rules)}
+    result = subprocess.run(
+        ["bash", "scripts/redaction-scan.sh", "-v"],
+        cwd=repo,
+        capture_output=True,
+        text=True,
+        env=env,
+        check=False,
+    )
+    output = result.stdout + result.stderr
+    assert "org_codename" in output, output
+    assert "org-rules=1" in output, output
+
+    # And without them the same token is invisible, which is what makes the
+    # previous assertion evidence rather than coincidence.
+    bare = subprocess.run(
+        ["bash", "scripts/redaction-scan.sh", "-v"],
+        cwd=repo,
+        capture_output=True,
+        text=True,
+        env={k: v for k, v in os.environ.items() if k != "REDACTION_EXTRA_PATTERNS"},
+        check=False,
+    )
+    assert "org_codename" not in (bare.stdout + bare.stderr)
+    assert "org-rules=0" in (bare.stdout + bare.stderr)
+
+
+@requires_gitleaks
+def test_retired_allowlist_entries_fail_closed(tmp_path: Path) -> None:
+    """An exemption that stopped applying must be heard from the gate."""
+
+    repo = _fixture_repo(tmp_path)
+    (repo / "scripts" / "redaction-allowlist.txt").write_text(
+        "some/file.md:12\n", encoding="utf-8"
+    )
+    result = subprocess.run(
+        ["bash", "scripts/redaction-scan.sh"],
+        cwd=repo,
+        capture_output=True,
+        text=True,
+        env={k: v for k, v in os.environ.items() if k != "REDACTION_EXTRA_PATTERNS"},
+        check=False,
+    )
+    assert result.returncode == 2, result.stdout + result.stderr
+    assert "retired format" in (result.stdout + result.stderr)

--- a/tests/test_redaction_scan_commit_messages.py
+++ b/tests/test_redaction_scan_commit_messages.py
@@ -14,6 +14,7 @@ from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 SCAN = REPO_ROOT / "scripts" / "redaction-scan.sh"
+CONFIG = REPO_ROOT / "config" / "gitleaks.toml"
 
 # Matches the scanner's own aws_access_key rule. The canonical
 # AKIAIOSFODNN7EXAMPLE cannot be used because the placeholder list excuses it on
@@ -48,7 +49,12 @@ def _repo_with_commits(tmp_path: Path, messages: list[str]) -> Path:
         SCAN.read_text(encoding="utf-8"), encoding="utf-8"
     )
     (repo / "scripts" / "redaction-allowlist.txt").write_text("", encoding="utf-8")
-    _git(repo, "add", "scripts")
+    # The wrapper reads its gitleaks config from the repository it lives in.
+    (repo / "config").mkdir()
+    (repo / "config" / "gitleaks.toml").write_text(
+        CONFIG.read_text(encoding="utf-8"), encoding="utf-8"
+    )
+    _git(repo, "add", "scripts", "config")
     _git(repo, "commit", "-q", "-m", "carry the scanner")
     for index, message in enumerate(messages):
         (repo / f"f{index}.md").write_text(f"file {index}\n", encoding="utf-8")


### PR DESCRIPTION
The swap #30 prepared. gitleaks does the matching; the wrapper keeps the four things gitleaks does not do. **440 lines to 304**, and the rule list, allowlist parser, and masking plumbing are gone.

## The interface does not change

`REDACTION_EXTRA_PATTERNS` still names a file of `id|description|regex` lines outside version control. The wrapper translates it into a gitleaks config that **extends** the committed one, verified as a working chain: default rules, repository rules, and organization rules all fire together. No host converts anything, and `REDACTION_REQUIRE_EXTRA=1` still exits 2 when the rules are absent.

```
redaction-scan: OK — 0 findings (mode=tracked, files=144, commit-messages=not-scanned, org-rules=10)
1.8s for 144 files
```

## Two behaviours change because the engine did

**Exemptions move to gitleaks' mechanisms** — a `.gitleaksignore` fingerprint, or a config allowlist for a class. An allowlist file still holding retired-format entries now **exits 2** rather than being ignored: an installation whose exemptions silently stopped applying should hear it from the gate, not discover it when an accepted finding returns.

**One path per invocation.** gitleaks scopes a single path argument reliably and falls back to scanning the whole directory when given several, which would make a tracked scan depend on untracked local scratch. Measured: `gitleaks dir a.txt b.txt` flagged an untracked third file.

## The mutation that found a real defect

Disabling the org-config selection changed nothing observable: the tree is clean either way, and the scope line still said `org-rules=10` because the count came from the file rather than from what the run used. Fixed, and pinned by a test that plants a token no shipped rule matches, then requires it found with the rules and missed without them.

That is the same defect class this gate exists to catch, one level up.

## Two more, both from measurement

**`ctx` is now required by the preflight**, with a reachable index. The records practice asks what happened across sessions and providers, and no single provider's transcript answers that. Waivable like any check.

**The adapter health check stops probing `orca --version`.** That flag does not exist. On this host it prints the usage banner and exits 0, so the check passed while proving nothing; a Linux user reported the same command launching the GUI application instead. It now uses `orca status --json`, which the preflight already used. Recorded as an incident-derived rule, because the shape generalizes: probe with a subcommand the tool must have, and read the output rather than the exit code.

## Tests

The parity test becomes a coverage test, since comparing the wrapper to gitleaks would now compare gitleaks with itself. Kept: a positive fixture per rule that must be flagged, negatives that must be excused, wrapper-versus-direct agreement, org rules reaching the engine, and retired allowlist entries failing closed.

Mutations re-run against the new tests: dropping the org config fails the reachability test, and disabling the commit-message loop fails three.

## Gates

- `PYTHONPATH=src uv run --with pytest --no-project python3 -m pytest tests -q` : 407 passed, 1 skipped, 13 subtests passed
- `REDACTION_REQUIRE_EXTRA=1 REDACTION_EXTRA_PATTERNS=… ./scripts/redaction-scan.sh` : exit 0, 144 files, org-rules 10

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switched the redaction gate to `gitleaks` for matching; the wrapper now only scopes to tracked files, scans commit messages, translates org rules, and reports coverage. Interface stays the same; the scan script drops from 440 to 304 lines.

- **Refactors**
  - Use `gitleaks` as the engine; translate `REDACTION_EXTRA_PATTERNS` into a config that extends `config/gitleaks.toml`; `REDACTION_REQUIRE_EXTRA=1` unchanged.
  - Accurate org-rule count: report only rules actually loaded; coverage tests ensure org rules reach the engine and wrapper vs direct `gitleaks` runs agree.
  - Safer scoping: run `gitleaks` once per path to avoid whole-directory fallback; commit messages are scanned via `stdin`.
  - Health check now probes `orca status --json` instead of `--version`.

- **Migration**
  - Exemptions move to `.gitleaksignore` or config allowlists; legacy `redaction-allowlist.txt` entries now exit 2 until migrated.
  - Preflight requires `ctx` with a reachable index (waivable if this host does no history work).
  - No change to org-rule inputs: keep using `REDACTION_EXTRA_PATTERNS`; missing required rules still exit 2.

<sup>Written for commit c3f17f035ad62fbdeb9db7b6c8a6b697c395e3f1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/baksohyeon/mogui-ADE-orchestrator/pull/32?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Redaction scanning now provides clearer detection results, exemption validation, masked findings, and support for commit-message checks.
  - Onboarding preflight now verifies that the local indexing service is installed and reachable.
  - Health checks now use structured Orca status information for more reliable availability reporting.

- **Bug Fixes**
  - Improved handling of invalid configuration, unavailable tools, and legacy exemptions with clearer failure outcomes.

- **Documentation**
  - Updated onboarding and operations guidance for redaction checks, service probes, and local indexing requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->