### PR TITLE
feat(onboarding): essential components get a re-ask, and the session ends with a card

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,6 +2,20 @@
 
 Small repository, one maintainer. Issues and pull requests are both welcome.
 
+## Adding a component to the harness
+
+Answer these five before proposing any tool, and put the answers in the pull request. A component that arrives without them is one nobody can argue out later.
+
+1. Does it require an API key?
+2. Does it force telemetry, or collect more than the job needs?
+3. Does it add a management point?
+4. Does it still work if the operation grows past one person?
+5. Every tool claims to help with agent context. What else does this one actually resolve?
+
+The first three are usually disqualifying on their own: a component that fails them is a subscription presenting itself as a dependency. A component that passes them and answers nothing for the fifth is a preference. Preferences are allowed, and they get labelled as preferences, and nothing gates on them.
+
+This is a maintainer question rather than an operator one. An installation does not choose the stack; it receives one, and `master-ops/ONBOARDING.md` carries the same five questions for the narrower decision an installer does make, which is what to install of what is offered.
+
 ## Running it
 
 ```console

--- a/master-ops/CHANGELOG.md
+++ b/master-ops/CHANGELOG.md
@@ -39,6 +39,72 @@ installation was taken from alongside the tag.
 
 ## Unreleased
 
+Onboarding gains a Step 10 that ends the session properly.
+
+Everything installed is worthless if the user does not know the handful of
+sentences that operate it, so the installer prints an operating card as plain text
+and tells the user to keep it under a name they will find again. The card is written
+to be pasted into any agent, so it depends on nothing about the installer session:
+how to ask for role state, how to propose and approve, how to delegate, which gates
+run before publishing and what they do not cover, how to ask for succession, and
+which components were declined at install so behaviour that looks like a defect can
+be checked against that first. A blank decline line is not allowed, because blank
+reads as unknown rather than as none.
+
+The step also verifies the conversation rather than the artifacts. The earlier steps
+ask questions, and a run that produced files without answers guessed; the check is
+that facts were confirmed rather than inferred and that each essential decline was
+re-asked once.
+
+Then it asks the user to close the installer terminal, with the reason: two agents
+holding one repository is how uncommitted work gets lost, and the installer has no
+further role. The installer does not close anything itself.
+
+Onboarding now names the stack this template was built against, with each
+component's role and the boundary it is deliberately kept inside. A tool adopted
+without its boundary becomes the next thing to unwind, so the table states both:
+the tracker's memory is a pointer cache toward Git rather than the knowledge source
+of truth, the history index is a trace archive rather than routine boot context,
+the review graph earns its place on token cost rather than correctness, and the
+worker runtime plugin is one wiring of the adapter layer rather than a harness
+requirement. The same boundaries are recorded in `docs/MASTER-OPERATIONS.md`, where
+the master reads them daily.
+
+The preflight checks the behaviour-shaping layers, methodology and restraint. Both
+are skill packs rather than one agent's plugins, so detection is agent-neutral and
+accepts either packaging: a skill directory under any known root, or an agent's
+plugin manifest, which is the same content wrapped differently. Only the install
+hint varies by host. They warn rather than fail, with the consequence attached to
+the warning: without the methodology layer the charter reads as advice rather than
+procedure, and without the restraint layer expect larger diffs and more speculative
+structure.
+
+Onboarding also records the five questions that decided the stack, so the same test
+applies to what an installer chooses to install: does it require an API key, does it
+force or over-collect telemetry, does it add a management point, does it survive the
+operation growing past one person, and what does it resolve beyond the agent-context
+help that every tool claims. The maintainer-facing version of the same bar lives in
+`CONTRIBUTING.md`, since an installation receives a stack rather than choosing one.
+
+Declining an essential component now gets one re-ask. Not a nag: the consequence is
+restated and the question is asked again, once, then the answer is final. The first
+no usually answers a different question, because a component list reads as
+preferences: the first pass answers "do I want this" while the question that matters
+is "am I accepting this behaviour". The confirmed decline is recorded together with
+what it accepts. Where the agent has no interactive query interface the re-ask cannot
+happen, so the contract carries the confirmed declines up front and the record says
+they were confirmed in advance rather than asked.
+
+The preflight summary repeats every missing essential component with its consequence
+in a block of its own, because fifteen lines of check output is exactly the length at
+which the important line gets skimmed past.
+
+And one asymmetry is written down rather than left to be discovered: an agent with
+no interactive query interface cannot run the steps that ask the user a question.
+Onboarding is a conversation, so either run it from an agent that can ask, or supply
+every answer in the dispatch contract and record that they were answered in advance
+rather than asked.
+
 The redaction gate now runs on gitleaks. `scripts/redaction-scan.sh` keeps only
 what gitleaks does not do: scoping to tracked content, scanning commit messages,
 translating the organization rules file, and stating what was covered. The file

--- a/master-ops/ONBOARDING.md
+++ b/master-ops/ONBOARDING.md
@@ -235,6 +235,43 @@ Verify the hook spec is documented, no sensitive implementation was added, and i
 
 Explain each component in one sentence before showing any command. Print approved install commands and stop; do not run them or edit `settings.json`, hooks, or plugin configuration.
 
+These five questions decided what is in the stack, and they are worth repeating when a component is proposed later:
+
+1. does it require an API key
+2. does it force telemetry, or collect more than the job needs
+3. does it add a management point
+4. does it still work if the operation grows past one person
+5. every tool claims to help with agent context. What else does this one actually resolve
+
+A component that fails the first three is usually a subscription pretending to be a dependency. A component that passes them but answers nothing for the fifth is a preference, and should be labelled as one.
+
+The stack this template was built against, with what each one is for and what it is deliberately not used for. Name the role before the install command, because a tool adopted without its boundary becomes the next thing to unwind:
+
+| component | role here | not used for |
+|---|---|---|
+| Orca | execution substrate: worktrees, terminals, sessions, supervised dispatch | required infrastructure, not a swappable preference |
+| tracker (Beads) | execution state that survives a session, as an issue graph | its memory is a short pointer cache toward Git, not the knowledge source of truth |
+| `ctx` | trace archive: cross-provider session history, queryable when handoff, ledger, and Git do not answer | not part of routine boot context |
+| `gitleaks` | matching engine for the publish gate | not the scope decision, which the wrapper keeps |
+| methodology skills | how the master plans and verifies | without them the charter reads as advice rather than procedure |
+| restraint skills | how much the master builds | pairs with the methodology layer rather than competing |
+| review graph | impact radius and review context, locally parsed | optional; its value is token cost, not correctness |
+| spec-driven framework | phase discipline from research through verification | installs lifecycle hooks, so it needs a deliberate yes |
+| worker runtime plugin | lets the master delegate implementation from inside its own session | one wiring of the adapter layer, not a harness requirement |
+
+Claude Code is the recommended host for the master, and a worker runtime such as Codex is a first-class executor rather than a fallback. Expect the preference to split hard between the two camps; the contracts hold either way, which is the point of an agent-neutral template.
+
+One asymmetry to plan around rather than discover: an agent without an interactive query interface cannot run the steps of this document that ask the user a question. Onboarding is a conversation. Run it from an agent that can ask, or supply every answer in the dispatch contract up front and record that the questions were answered in advance rather than asked.
+
+Install commands for the Claude Code case, printed and not run:
+
+```console
+$ /plugin marketplace add openai/codex-plugin-cc
+$ /plugin install codex@openai-codex
+$ /reload-plugins
+$ /codex:setup
+```
+
 Say which of them are optional in name only. The template carries documents and scripts; it cannot carry the host layer that makes a master behave the way the documents describe, so a component listed here as recommended is often load-bearing. State the consequence of declining each one in a sentence, in the same breath as the offer, rather than leaving the user to discover it later:
 
 - a methodology skill layer changes how the master plans and verifies; without it the master still runs, and reads the charter as advice rather than procedure
@@ -242,9 +279,15 @@ Say which of them are optional in name only. The template carries documents and 
 - a tracker skill layer is what makes execution state survive a session; without it, state lives only in the transcript
 - a worker runtime is what makes delegation possible at all; without at least one, the master does every task itself
 
-Record the user's answer per component, including a decline. A declined component is a fact about the installation, and later behaviour that looks like a master defect is often a declined component instead.
+When the user declines a component the preflight treats as essential, ask once more. Not as a nag: restate the specific behaviour that changes, then ask whether to proceed without it. One re-ask, then take the answer as final.
 
-Verify the explanation preceded commands, nothing was installed or configured by the agent, and the user's choice—including no installation—is recorded.
+The reason to ask twice is that the first no is usually answering a different question. A component list reads as preferences, so the first pass is "do I want this", while the question that matters is "am I accepting this behaviour". Restating the consequence is what turns one into the other.
+
+Record the confirmed decline together with what is being accepted, in the user's own terms where possible. A declined component is a fact about the installation, and later behaviour that looks like a master defect is often a declined component instead.
+
+Where the agent running onboarding has no interactive query interface, the re-ask cannot happen at all. In that case the dispatch contract carries the confirmed declines up front, and the record says they were confirmed in advance rather than asked.
+
+Verify the explanation preceded commands, nothing was installed or configured by the agent, every essential decline was re-asked once with its consequence restated, and the user's choice—including no installation—is recorded with what it accepts.
 
 ## Step 7.6. State What The Publish Gates Do Not Cover
 
@@ -333,3 +376,53 @@ Verify:
 - placement evidence includes the host pane/worktree selector, process cwd under `{{WORKSPACE_ROOT}}`, and session artifact/log namespace
 - no placeholders remain unless the user intentionally deferred them
 - the founding Task and Dispatch complete through `worker_done`
+
+## Step 10. Hand The Human A Card, Then Close The Installer
+
+**Position and action:** Step 10 runs after the master reports a clean boot: verify the conversation actually happened, hand the user something portable, and ask them to close the installer terminal.
+
+**Why/caution:** Everything installed here is worthless if the user does not know the four or five sentences that operate it, and an installer session left running is a second agent holding the same repository.
+
+First verify the conversation, not just the artifacts. The steps above ask questions; a run that produced files without answers is a run that guessed. Check that the workspace facts were confirmed rather than inferred, that the component choices are recorded including declines, and that each essential decline was re-asked once. If any answer is missing, ask now rather than recording an assumption as a decision.
+
+Then write the operating card. Print it, and tell the user to keep it wherever they keep notes, as plain text under a name they will find again, such as `llm.txt`. It is written to be pasted into any agent, so it must not depend on this session existing:
+
+```text
+# Operating this workspace
+
+Master lives in: {{WORKSPACE_ROOT}}          Ops repository: {{OPS_REPO}}
+State: the issue tracker in the ops repository. Long-term decisions: Git.
+
+To start work, tell the master:
+  "Role State?"                     it reports its active role and lock
+  "Propose <goal>"                  it plans, then waits for your approval
+  "Approved, execute"               it executes only what you approved
+
+To delegate, tell the master:
+  "Dispatch <task> to a worker"     it runs the gate, dispatches, and verifies
+                                     the result before accepting it
+
+Before publishing anything, the master runs:
+  the test suite, the redaction scan, the redaction inventory
+  A green scan covers repository content only. Pull request text,
+  release notes, and issue prose are not scanned by anything.
+
+When a session gets long:
+  "Propose succession"              it audits, spawns a clean successor,
+                                     and freezes itself
+
+If the master behaves unlike the documents, check what was declined at
+onboarding before assuming a defect. Declined at install:
+  <declined components, or the word none>
+```
+
+Fill the last line from the recorded choices. If nothing was declined, write the word none rather than leaving it blank, because a blank line reads as unknown. The angle-bracket slots in the card are filled by hand at print time; do not introduce a new `{{...}}` placeholder for them, since Step 4 verifies that only the eight allowed placeholders remain anywhere in this document.
+
+Finally, ask the user to close this installer terminal now that the master is running. Say why in one sentence: two agents holding one repository is how uncommitted work gets lost, and the installer has no further role. Do not close it yourself, and do not close the master's terminal.
+
+Verify:
+
+- the card was printed in full, with placeholders replaced and the declined line filled or explicitly none
+- the user was told where to keep it and that it works when pasted into any agent
+- the user was asked to close the installer terminal, with the reason given
+- the master's terminal was left running

--- a/master-ops/docs/MASTER-OPERATIONS.md
+++ b/master-ops/docs/MASTER-OPERATIONS.md
@@ -251,6 +251,17 @@ Measure: run the probe and read its output, not just its exit code. A probe whos
 Observed: pull request bodies, review comments, release notes, and issue text are not in the repository, so no scanner in this template reads them. An audit of one day's outgoing text found none, which is the point: it took a separate grep to know.
 Measure: before posting outgoing text, grep it for organization identifiers the way the scan greps files. A green publish gate says nothing about prose written into a forge.
 
+### Tool Boundaries
+
+Each tool has a role and an edge. The edge is the part that gets lost first.
+
+- The execution substrate owns worktrees, terminals, sessions, and supervised dispatch. Placement checks read its state; they are not a dispatch mechanism.
+- The tracker owns execution state across sessions. Its memory is a pointer cache toward Git, kept small and curated; it is not the knowledge source of truth, and it is not a second copy of this document.
+- The history index is a trace archive. Query it when the handoff, the ledger, and Git together do not answer a question. It does not belong in routine boot context.
+- The secret scanner is a matching engine. Scope, commit messages, and what the run covered stay with the wrapper, because those are decisions rather than matches.
+- The review graph earns its place on token cost and impact radius, not on correctness. Nothing gates on it.
+- Documentation stays plain Markdown in Git. No format lock means any tool can read it, including the next one.
+
 ## 8. Incident-Derived Rules
 
 Every rule below was paid for. Each one names the observation that produced it and the measurement that settles it, because a rule without its evidence gets argued away by the next reader, and a rule without a measurement cannot be checked. Add to this section the same way: rule, what was observed, how to measure it. Do not add a rule you cannot measure.

--- a/scripts/onboarding-preflight.sh
+++ b/scripts/onboarding-preflight.sh
@@ -25,6 +25,28 @@ fi
 waived_labels=()
 seen_labels=()
 
+# Checks whose absence changes what the harness can do at all. A missing one is
+# repeated at the end with its consequence, because fifteen lines of output is
+# exactly the length at which the important line gets skimmed past.
+ESSENTIAL_LABELS=(
+  orca orchestration skills agent-cli worker-runtime bd python3
+  gitleaks ctx redaction-extra skill-stack
+)
+essential_gaps=()
+
+is_essential() {
+  local candidate
+  for candidate in "${ESSENTIAL_LABELS[@]}"; do
+    [[ "${candidate}" == "$1" ]] && return 0
+  done
+  return 1
+}
+
+note_gap() {
+  is_essential "$1" || return 0
+  essential_gaps+=("$1|$2")
+}
+
 is_waived() {
   local candidate
   for candidate in ${waive_list[@]+"${waive_list[@]}"}; do
@@ -42,17 +64,22 @@ pass() {
 fail() {
   seen_labels+=("$1")
   if is_waived "$1"; then
+    # A waiver is an explicit decision the summary already names. Repeating it in
+    # the essential block would make that block noise, and a block that is noise
+    # stops being read, which is the only thing it had going for it.
     waived=$((waived + 1))
     waived_labels+=("$1")
     printf 'WAIVED %-12s %s (downgraded from FAIL by PREFLIGHT_WAIVE)\n' "$1" "$2"
     return
   fi
+  note_gap "$1" "$2"
   failures=$((failures + 1))
   printf 'FAIL %-14s %s\n' "$1" "$2"
 }
 
 warn() {
   seen_labels+=("$1")
+  note_gap "$1" "$2"
   warnings=$((warnings + 1))
   printf 'WARN %-14s %s\n' "$1" "$2"
 }
@@ -247,6 +274,47 @@ elif command -v claude >/dev/null 2>&1; then
 else
   printf 'INFO %-14s %s\n' "codex-plugin" "skipped because Claude Code is not the selected agent"
 fi
+
+# The behaviour-shaping layer: methodology and restraint. Both are distributed as
+# skill packs and are not tied to one agent, so the check is agent-neutral and only
+# the install hint differs. Detection accepts either packaging: a skill directory
+# under any known root, or an agent's plugin manifest, which is the same content
+# wrapped differently.
+#
+# They warn rather than fail. A master runs without them; it runs differently, and
+# the warning carries that cost so the operator learns it here instead of later.
+behaviour_packs=(
+  "superpowers|methodology|without it the master reads the charter as advice rather than procedure"
+  "ponytail|restraint|without it expect larger diffs and more speculative structure; it pairs with the methodology layer rather than competing"
+)
+claude_plugins_file="${HOME}/.claude/plugins/installed_plugins.json"
+for pack_entry in "${behaviour_packs[@]}"; do
+  IFS='|' read -r pack_id pack_name pack_cost <<<"${pack_entry}"
+  pack_found=""
+  for skills_root in ${skills_roots[@]+"${skills_roots[@]}"}; do
+    if [[ -e "${skills_root}/${pack_id}" ]]; then
+      pack_found="${skills_root}/${pack_id}"
+      break
+    fi
+  done
+  if [[ -z "${pack_found}" && -f "${claude_plugins_file}" ]] \
+    && grep -Fq "\"${pack_id}@" "${claude_plugins_file}"; then
+    pack_found="agent plugin manifest"
+  fi
+  if [[ -n "${pack_found}" ]]; then
+    pass "skill-stack" "${pack_id} (${pack_name}) resolves via ${pack_found}"
+  else
+    case "${ORCA_AGENT_CLI:-}" in
+      claude|claude-code)
+        pack_install="/plugin install ${pack_id}@<marketplace>, after /plugin marketplace add"
+        ;;
+      *)
+        pack_install="install the ${pack_id} skill pack for ${ORCA_AGENT_CLI:-your agent}, or place it under one of: ${skills_roots[*]}"
+        ;;
+    esac
+    warn "skill-stack" "${pack_id} (${pack_name}) missing: ${pack_cost}. Install with: ${pack_install}"
+  fi
+done
 
 # Required, not optional: REDACTION_REQUIRE_EXTRA=1 scanning exits 2 with no
 # rules loaded, and redaction-inventory exits 2 when this file is unset or
@@ -481,6 +549,16 @@ if [[ ${#unmatched_waivers[@]} -gt 0 ]]; then
   printf '  NOTE: PREFLIGHT_WAIVE named checks that did not run: %s; those checks are still enforced\n' \
     "$(IFS=,; printf '%s' "${unmatched_waivers[*]}")"
 fi
+if [[ ${#essential_gaps[@]} -gt 0 ]]; then
+  printf '\n'
+  printf '  !! ESSENTIAL COMPONENTS MISSING (%d) — the harness will not behave as documented\n' "${#essential_gaps[@]}"
+  for gap_entry in "${essential_gaps[@]}"; do
+    printf '  !!   %-14s %s\n' "${gap_entry%%|*}" "${gap_entry#*|}"
+  done
+  printf '  !! These are not preferences. Install them, or record the decline and the\n'
+  printf '  !! behaviour you are accepting, before spawning a master.\n'
+fi
+
 if [[ $failures -eq 0 ]]; then
   if [[ $waived -gt 0 ]]; then
     printf '  READY WITH WAIVERS: %d required check(s) were downgraded, not satisfied\n' "$waived"

--- a/tests/test_onboarding_preflight.py
+++ b/tests/test_onboarding_preflight.py
@@ -279,3 +279,86 @@ def test_missing_ctx_fails(tmp_path: Path) -> None:
     result = _run(env, tmp_path)
     assert "ctx" in _labels(result.stdout, "FAIL"), result.stdout
     assert "ctx.rs" in result.stdout
+
+
+def test_missing_behaviour_packs_warn_with_their_cost(tmp_path: Path) -> None:
+    """Behaviour-shaping layers warn: a master runs without them, differently."""
+
+    env = _host(tmp_path)
+    home = tmp_path / "home"
+    (home / ".claude" / "plugins" / "installed_plugins.json").write_text(
+        '{"plugins":{"codex@openai-codex":[{"scope":"user"}]}}', encoding="utf-8"
+    )
+    result = _run(env, tmp_path)
+    assert "skill-stack" in _labels(result.stdout, "WARN"), result.stdout
+    assert "skill-stack" not in _labels(result.stdout, "FAIL"), result.stdout
+    assert "superpowers" in result.stdout
+    assert "ponytail" in result.stdout
+    # The consequence travels with the warning, not in a separate document.
+    assert "advice rather than procedure" in result.stdout
+    assert "pairs with the methodology layer" in result.stdout
+
+
+def test_present_behaviour_packs_pass(tmp_path: Path) -> None:
+    env = _host(tmp_path)
+    home = tmp_path / "home"
+    (home / ".claude" / "plugins" / "installed_plugins.json").write_text(
+        '{"plugins":{"codex@openai-codex":[{}],"superpowers@official":[{}],'
+        '"ponytail@ponytail":[{}]}}',
+        encoding="utf-8",
+    )
+    result = _run(env, tmp_path)
+    assert "skill-stack" in _labels(result.stdout, "PASS"), result.stdout
+    assert "skill-stack" not in _labels(result.stdout, "WARN"), result.stdout
+
+
+def test_behaviour_packs_resolve_from_a_neutral_skill_root(tmp_path: Path) -> None:
+    """These packs are not one agent's plugins, so detection must not assume that."""
+
+    env = _host(tmp_path)
+    home = tmp_path / "home"
+    (home / ".claude" / "plugins" / "installed_plugins.json").write_text(
+        "{}", encoding="utf-8"
+    )
+    for pack in ("superpowers", "ponytail"):
+        (home / ".claude" / "skills" / pack).mkdir(parents=True, exist_ok=True)
+    result = _run(env, tmp_path)
+    assert "skill-stack" in _labels(result.stdout, "PASS"), result.stdout
+    assert "skill-stack" not in _labels(result.stdout, "WARN"), result.stdout
+
+
+def test_install_hint_follows_the_selected_agent(tmp_path: Path) -> None:
+    env = _host(tmp_path)
+    (tmp_path / "home" / ".claude" / "plugins" / "installed_plugins.json").write_text(
+        "{}", encoding="utf-8"
+    )
+    env["ORCA_AGENT_CLI"] = "codex"
+    (tmp_path / "bin" / "codex").chmod(0o755)
+    result = _run(env, tmp_path)
+    assert "skill-stack" in _labels(result.stdout, "WARN"), result.stdout
+    assert "/plugin install" not in result.stdout, result.stdout
+    assert "skill pack for codex" in result.stdout, result.stdout
+
+
+def test_essential_gaps_are_repeated_loudly_with_their_consequence(
+    tmp_path: Path,
+) -> None:
+    """Fifteen lines of output is where the important line gets skimmed past."""
+
+    env = _host(tmp_path, rules=None)
+    result = _run(env, tmp_path)
+    assert "ESSENTIAL COMPONENTS MISSING" in result.stdout, result.stdout
+    assert "redaction-extra" in result.stdout
+    assert "not preferences" in result.stdout
+
+
+def test_no_essential_block_when_nothing_essential_is_missing(tmp_path: Path) -> None:
+    """The loud block must stay rare, or it becomes decoration."""
+
+    env = _host(tmp_path)
+    home = tmp_path / "home"
+    for pack in ("superpowers", "ponytail"):
+        (home / ".claude" / "skills" / pack).mkdir(parents=True, exist_ok=True)
+    env["PREFLIGHT_WAIVE"] = "python3"
+    result = _run(env, tmp_path)
+    assert "ESSENTIAL COMPONENTS MISSING" not in result.stdout, result.stdout


### PR DESCRIPTION
Onboarding is where this transfers or does not, and the missing part was never the command list.

## Tools come with their boundaries

The role is easy to write down; the edge is what gets lost first. Both are now stated, in `ONBOARDING.md` for the installer and in `MASTER-OPERATIONS.md` for the master that reads it daily:

| component | role | not used for |
|---|---|---|
| tracker | execution state across sessions | its memory is a pointer cache toward Git, not the knowledge source of truth |
| history index | trace archive, queried when handoff/ledger/Git do not answer | not routine boot context |
| scanner | matching engine | not the scope decision, which stays with the wrapper |
| review graph | impact radius, token cost | not correctness; nothing gates on it |
| worker runtime plugin | one wiring of the adapter layer | not a harness requirement |

## Behaviour layers are checked, agent-neutrally

Methodology and restraint are skill packs, not one vendor's plugins, so detection accepts a skill directory under any known root **or** an agent's plugin manifest. Only the install hint varies by host. They warn rather than fail, and the warning carries the cost: without methodology the charter reads as advice rather than procedure; without restraint expect larger diffs and more speculative structure.

## Declining an essential thing gets asked twice

Once. Not a nag.

The first no usually answers a different question, because a component list reads as preferences: the first pass answers *do I want this*, while the question that matters is *am I accepting this behaviour*. Restating the consequence converts one into the other. Then the answer is final and recorded with what it accepts.

Where the agent has no interactive query interface the re-ask cannot happen at all, so the contract carries the confirmed declines up front and the record says they were confirmed in advance rather than asked.

The preflight also repeats missing essentials in a block of their own:

```
  !! ESSENTIAL COMPONENTS MISSING (1) — the harness will not behave as documented
  !!   agent-cli      ORCA_AGENT_CLI is unset; name the agent CLI this master runs …
  !! These are not preferences. Install them, or record the decline and the
  !! behaviour you are accepting, before spawning a master.
```

Waived checks are excluded from it. A waiver is a decision the summary already names, and a block that repeats decisions becomes noise, which is the only thing it had going for it.

## Step 10 ends the session

- **verify the conversation, not the artifacts**: a run that produced files without answers guessed
- **print an operating card** the user keeps as plain text under a name they will find again. Written to be pasted into any agent, so it depends on nothing about the installer session: role state, propose and approve, delegate, which gates run and what they do not cover, succession, and what was declined at install
- **ask the user to close the installer terminal**, with the reason: two agents holding one repository is how uncommitted work gets lost. The installer closes nothing itself

## The maintainer bar moved

The five questions for adding a component now live in `CONTRIBUTING.md`. An installation receives a stack rather than choosing one; `ONBOARDING.md` keeps the same questions for the narrower choice an installer does make.

## Caught while writing this

The card first used a new `{{...}}` placeholder, which Step 4 verifies against a list of eight. Same mistake as this morning's `{{ORCA}}`, so the doc now says explicitly that the card's angle-bracket slots are filled by hand and must not become placeholders.

## Gates

- `PYTHONPATH=src uv run --with pytest --no-project python3 -m pytest tests -q` : 413 passed, 1 skipped, 13 subtests passed
- `REDACTION_REQUIRE_EXTRA=1 REDACTION_EXTRA_PATTERNS=… ./scripts/redaction-scan.sh` : exit 0
- five preflight tests added; a mutation shortening the warning to "missing" fails the one that requires the cost to travel with it

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Onboarding now verifies decisions, prints a portable operating card, and ends the installer session safely. Preflight re-asks once on essential declines, repeats missing essentials with their consequence, and checks methodology/restraint skill packs in an agent-neutral way.

- **New Features**
  - Added Step 10: confirm answers, print a plain‑text operating card, and ask the user to close the installer terminal.
  - Preflight: one-time re-ask for essential declines; new “ESSENTIAL COMPONENTS MISSING” block with consequences; waivers excluded from that block.
  - Agent-neutral checks for behavior packs: detect `superpowers` (methodology) and `ponytail` (restraint) via skill directories or plugin manifests; warn with the cost if missing and tailor install hints to the selected agent.
  - Documented tool boundaries in `ONBOARDING.md` and `docs/MASTER-OPERATIONS.md` (e.g., `gitleaks` is a matcher; review graph earns its place on token cost, not correctness).
  - Moved the maintainer tool bar and five decision questions to `CONTRIBUTING.md`; added preflight tests around behavior packs and essential gap summaries.

<sup>Written for commit a33cfb6a56b35c9833c993e5bef18acd5d35b2f0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/baksohyeon/mogui-ADE-orchestrator/pull/33?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

