### PR TITLE
docs: sync the scan doc to what the scan does, and put the tool bar in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,21 @@ It runs the fleet on [Orca](https://www.onorca.dev/download). A session has to o
 
 The orchestrating session is called the master, for lack of a better word. It has no name yet. Suggestions welcome.
 
+
+## Why these tools
+
+Five questions decided the stack, and they are the bar for anything proposed later:
+
+1. Does it require an API key?
+2. Does it force telemetry, or collect more than the job needs?
+3. Does it add a management point?
+4. Does it still work if the operation grows past one person?
+5. Every tool claims to help with agent context. What else does this one actually resolve?
+
+Failing the first three usually means a subscription presenting itself as a dependency. Passing them while answering nothing for the fifth means a preference, which is allowed and labelled as one, and nothing gates on it.
+
+The maintainer-facing version of this bar is in `CONTRIBUTING.md`; the installer-facing one is in `master-ops/ONBOARDING.md`.
+
 ## Quickstart
 
 ```console

--- a/docs/internal/tooling/redaction-scan.md
+++ b/docs/internal/tooling/redaction-scan.md
@@ -11,13 +11,31 @@ scripts/redaction-scan.sh
 # Staged index only
 scripts/redaction-scan.sh --staged
 
-# Commits about to be pushed (pre-push)
+# Commits about to be pushed, and those commits' messages (pre-push)
 scripts/redaction-scan.sh --range "$remote_sha..$local_sha"
+
+# Commit messages for any range, in any mode
+scripts/redaction-scan.sh --commit-messages "$remote_sha..$local_sha"
 ```
 
-- **Fail-closed:** any unallowlisted match → exit 1.
-- **Tools:** `bash`, `git`, and `rg` (preferred, PCRE2) or `grep -E`.
-- **Allowlist:** `scripts/redaction-allowlist.txt` (override with `REDACTION_ALLOWLIST=`).
+- **Fail-closed:** any match that is not exempted → exit 1.
+- **Engine:** gitleaks does the matching. The script scopes the scan to tracked content, scans commit messages, translates the organization rules, and reports what it covered.
+- **Tools:** `bash`, `git`, `python3`, and `gitleaks` on `PATH`. The former `rg` and `grep -E` paths are gone.
+- **Committed rules:** `config/gitleaks.toml`, extending gitleaks' maintained default set.
+- **Exemptions:** a `.gitleaksignore` fingerprint for one finding, or an allowlist block in `config/gitleaks.toml` for a class. The old `scripts/redaction-allowlist.txt` format is retired, and a file still holding entries in it exits 2 rather than being ignored.
+
+### Scope is stated in the output
+
+A green line that does not name its scope cannot be told apart from a full audit, so every run says what it read:
+
+```console
+$ scripts/redaction-scan.sh
+redaction-scan: OK — 0 findings (mode=tracked, files=144, commit-messages=not-scanned, org-rules=10)
+```
+
+`commit-messages=not-scanned` is the honest reading in tracked and staged modes. gitleaks does not read commit messages: a key present only in a message returns no findings while the same key in file content is found. That is measured, and it is why the message loop lives in this script.
+
+`org-rules=N` counts rules actually loaded into the run, not lines the file happens to hold.
 
 ### Organization-specific rules (`REDACTION_EXTRA_PATTERNS`)
 
@@ -35,7 +53,9 @@ RULES
 export REDACTION_EXTRA_PATTERNS=~/.config/redaction-extra.txt
 ```
 
-Each line is `id|description|regex`. Blank lines and `#` comments are ignored.
+Each line is `id|description|regex`. Blank lines and `#` comments are ignored. Only the first two pipes separate fields, so a regex may contain a pipe.
+
+The file is translated into a gitleaks config that extends the committed one, so this format is unchanged and no checkout converts anything. A line that is malformed, or whose regex does not compile, is skipped with a warning that counts it rather than dropped in silence.
 
 When no such rules are loaded, the scan prints a warning to stderr and still exits 0, so a
 green result means "generic patterns only" — not "fully audited". In CI or before a public
@@ -45,7 +65,13 @@ push, make that gap fail instead:
 bash scripts/redaction-scan.sh --require-extra    # or REDACTION_REQUIRE_EXTRA=1
 ```
 
-Exit codes: `0` clean, `1` findings or usage error, `2` required organization rules missing.
+Exit codes: `0` clean, `1` findings, `2` cannot decide — `gitleaks` missing, required organization rules missing, retired allowlist entries present, or a usage error.
+
+## What this scan does not cover
+
+The scan reads repository content. It does not read pull request titles or bodies, review comments, release notes, or issue text, because none of that is in the repository. Those are also where internal names arrive most easily, since they are prose rather than code. Grep outgoing text before posting it.
+
+`scripts/redaction-inventory` answers the inverse question, which tokens no rule covers, and has no gitleaks equivalent.
 
 ### What it flags
 


### PR DESCRIPTION
`docs/internal/tooling/redaction-scan.md` still described the engine it had this morning: `rg` or `grep -E` over a hand-written rule list, with an allowlist format that is now retired. Three changes landed today and none reached it. That is the pair failure this repository keeps writing rules about, and it landed on the person who wrote the rule.

Corrected against measured behaviour:

- gitleaks is the engine; the script scopes, scans messages, translates org rules, and reports coverage
- committed rules are `config/gitleaks.toml`; exemptions are `.gitleaksignore` fingerprints, and the retired allowlist format exits 2 rather than being ignored
- `--commit-messages` documented, and `--range` now says it scans those commits' messages too
- the scope line is shown, with what `commit-messages=not-scanned` and `org-rules=N` actually mean
- exit 2 now covers a missing `gitleaks` and retired allowlist entries, not only missing org rules

Added a section for what the scan does not cover: pull request text, review comments, release notes, issue prose. None of it is in the repository, and it is where internal names arrive most easily. A green line trusted past its scope is worse than no line.

The README gains the five questions that decided the stack, pointing at the maintainer version in `CONTRIBUTING.md` and the installer version in `master-ops/ONBOARDING.md`.

Gates: 413 passed, 1 skipped, 13 subtests; redaction scan exit 0.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updated the redaction scan docs to reflect the `gitleaks` engine, current rules in `config/gitleaks.toml`, exemptions via `.gitleaksignore`, the scope line, exit codes, and `--commit-messages`/`--range`. Added the five tool-choice questions to the README with links to `CONTRIBUTING.md` and `master-ops/ONBOARDING.md`, and noted what the scan does not cover (PR text, comments, releases, issues).

- **Migration**
  - Remove any `scripts/redaction-allowlist.txt` entries; use `.gitleaksignore` or allowlist blocks in `config/gitleaks.toml`.
  - Ensure `gitleaks` is installed and on `PATH`; missing it now exits 2.

<sup>Written for commit 88e674d3943e5d5e47df0f72542369b63fe06910. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/baksohyeon/mogui-ADE-orchestrator/pull/34?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

