### PR TITLE
docs: pin the reference command table to the scripts that exist

### DIFF
--- a/docs/public/reference.md
+++ b/docs/public/reference.md
@@ -1,10 +1,10 @@
-This reference summarizes the executable scripts in this repository. The generated section is derived from local `scripts/` help output.
+This reference summarizes the executable scripts in this repository. The table is written by hand from each script's own `--help`, and `tests/test_reference_command_table.py` fails when a command exists with no row, or a row outlives its command.
 
 # Reference
 
 Use this page for command discovery. The lifecycle and delegation guides explain when to use each entry point.
 
-<!-- AUTO-GENERATED from scripts/ --help -->
+<!-- COMMAND TABLE: rows are checked against scripts/ --help by tests/test_reference_command_table.py -->
 | Script | Command | Purpose | Key options |
 | --- | --- | --- | --- |
 | `scripts/acceptance-loop` | `acceptance-loop validate` | Check an acceptance suite file for structural validity. | None beyond `-h` or `--help`. |
@@ -12,9 +12,11 @@ Use this page for command discovery. The lifecycle and delegation guides explain
 | `scripts/acceptance-loop` | `acceptance-loop run` | Run the deterministic acceptance loop against a proposer command. | `--max-iterations`, `--baseline-ref`, `--restore-cmd`. |
 | `scripts/acceptance-loop` | `acceptance-loop inspect` | Report suite and holdout composition without running the loop. | None beyond `-h` or `--help`. |
 | `scripts/adapter` | `adapter doctor` | Report visible adapter tools and whether required local dependencies are present. | None beyond `-h` or `--help`. |
+| `scripts/codex-worker-pretrust` | `codex-worker-pretrust` | Mark a worktree as trusted in every Orca-managed Codex account config, so a dispatched worker does not stop on a trust prompt. | Positional absolute worktree path; `--accounts-dir`. Needs Python 3.11+ on the host, because it reads TOML through `tomllib`. |
 | `scripts/dispatch-gate` | `dispatch-gate check` | Evaluate a worker contract and record an allow or deny decision in the dispatch ledger. | Global `--ledger`; command options `--runtime`, `--contract`, `--agents`, `--est-chars`. |
 | `scripts/dispatch-gate` | `dispatch-gate register` | Register a worker job only after a probe confirms the job id appears in an expected artifact. | Global `--ledger`; command options `--job-id`, `--probe-cmd`, `--contract-sha`, `--runtime`. |
 | `scripts/dispatch-gate` | `dispatch-gate watch` | Check a worker log for stall conditions. | Global `--ledger`; command options `--log`, `--max-idle`. |
+| `scripts/dispatch-gate` | `dispatch-gate report` | Aggregate the ledger into denial, override, tier, and model counts, so the gate's own record can be read back. | Global `--ledger`; command option `--today` limits it to the current UTC day. |
 | `scripts/l1-digest` | `l1-digest tick` | Run one read-only L1 digest observation tick from a config file. | `--config`. |
 | `scripts/master-bootstrap` | `master-bootstrap` | Build a bounded bootstrap block from charter, optional handoff, budget, session id, and role state checks. | `--charter`, `--handoff`, `--budget`, `--session-id`, `--strict-lease`, `--json`. |
 | `scripts/master-bootstrap-live` | `master-bootstrap-live` | Emit the live session-start bootstrap block from a handoff directory and optional role-state file. | `--handoff-dir`, `--role-state-file`, `--budget`, `--bd`, `--charter-pointer`. |
@@ -27,9 +29,11 @@ Use this page for command discovery. The lifecycle and delegation guides explain
 | `scripts/master-succeed` | `master-succeed spawn` | Spawn or dry-run a clean successor terminal for a selected workspace. | `--workspace-selector`, `--kickoff-text` or `--kickoff-file`, `--root`, `--model`, `--title`, `--dry-run`, `--json`. |
 | `scripts/model-identity-probe` | `model-identity-probe` | Read recent assistant events from a transcript and compare the measured model with an expected model when supplied. | `--transcript`, `--expect`, `--limit`. Exit 0 match, 2 drift or undecidable. |
 | `scripts/model-drift-audit` | `model-drift-audit` | Walk every assistant turn in a transcript and report model transitions with timestamps. | `--transcript`, `--session`, `--expect`, `--projects-dir`, `--workspace-dir`, `--ignore-synthetic`, `--json`. Exit 0 no transition, 1 transition or expectation mismatch, 2 undecidable. |
-| `scripts/redaction-scan.sh` | `redaction-scan.sh` | Scan tracked, staged, or ranged files for secrets and internal identifiers before publication. | `--staged`, `--range A..B`, `--help`; allowlist defaults to `scripts/redaction-allowlist.txt` or `REDACTION_ALLOWLIST`. |
-<!-- END AUTO-GENERATED from scripts/ --help -->
+| `scripts/onboarding-preflight.sh` | `onboarding-preflight.sh` | Measure the tools onboarding depends on before Step 1 spawns anything, and block on a missing required one. | `--fix` may add or refresh global Orca skills and installs no applications. `PREFLIGHT_WAIVE` downgrades a named check and says so in the summary. Exit 0 ready, 1 blocked. |
+| `scripts/redaction-inventory` | `redaction-inventory` | Report tokens that no redaction rule covers, which is the inverse of what the scan asks. | `--baseline`, `--min-count`, `--json`. Exit 0 nothing uncovered, 1 candidates found, 2 cannot decide. A candidate is not a secret and an empty result is not proof of safety. |
+| `scripts/redaction-scan.sh` | `redaction-scan.sh` | Scope a gitleaks scan to tracked content, scan commit messages that gitleaks does not read, and state what was covered. | Default is all tracked files; `--staged`, `--range A..B`, `--commit-messages A..B`, `--help`. Organization rules come from `REDACTION_EXTRA_PATTERNS` as `id\|description\|regex` lines, and `REDACTION_REQUIRE_EXTRA=1` makes a missing or empty file exit 2. Exit 0 clean, 1 findings, 2 cannot decide. The `scripts/redaction-allowlist.txt` format is retired: a file still holding entries in it exits 2. |
+<!-- END COMMAND TABLE -->
 
-The generated table intentionally lists the public command surface only. Local host routing, private paths, and sensitive-lane details are outside this reference.
+The table lists the public command surface only. Local host routing, private paths, and sensitive-lane details are outside this reference.
 
 Exit codes are not shared vocabulary across these scripts. `model-identity-probe` reports both drift and undecidable as 2; `model-drift-audit` separates them. Read each script's codes from its own row rather than assuming a convention.

--- a/tests/test_reference_command_table.py
+++ b/tests/test_reference_command_table.py
@@ -1,0 +1,94 @@
+"""The reference table lists commands; this pins that list to the scripts that exist.
+
+The table sat behind an `AUTO-GENERATED from scripts/ --help` marker whose generator
+was never in the repository. Nothing measured it, so it drifted in silence: by the
+time anyone compared, `codex-worker-pretrust`, `onboarding-preflight.sh`, and
+`redaction-inventory` were absent from the page, and so was `dispatch-gate report`.
+
+The prose columns stay hand-written, because `--help` does not carry purpose and a
+generator that emitted it would emit worse prose than a person. What a machine can
+hold is the inventory, so the inventory is held here instead of in a generator.
+"""
+
+from __future__ import annotations
+
+import re
+import subprocess
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SCRIPTS_DIR = REPO_ROOT / "scripts"
+REFERENCE = REPO_ROOT / "docs" / "public" / "reference.md"
+
+# argparse prints its subcommand choices as {a,b,c} in the usage line. Scripts with
+# no subparsers print no such group and stand as a single command.
+SUBCOMMAND_GROUP = re.compile(r"\{([a-z0-9][a-z0-9,_-]+)\}")
+
+# | `scripts/x` | `x sub` | purpose | key options |
+TABLE_ROW = re.compile(r"^\|\s*`(scripts/[^`]+)`\s*\|\s*`([^`]+)`\s*\|")
+
+
+def _executables() -> list[Path]:
+    return sorted(p for p in SCRIPTS_DIR.iterdir() if p.is_file() and p.stat().st_mode & 0o100)
+
+
+def _subcommands(script: Path) -> list[str]:
+    """Read a script's own help output. A script that refuses --help still prints usage."""
+    proc = subprocess.run(
+        [str(script), "--help"],
+        capture_output=True,
+        text=True,
+        timeout=30,
+        cwd=REPO_ROOT,
+    )
+    match = SUBCOMMAND_GROUP.search(proc.stdout + proc.stderr)
+    return match.group(1).split(",") if match else []
+
+
+def measured_surface() -> set[tuple[str, str]]:
+    surface = set()
+    for script in _executables():
+        rel = f"scripts/{script.name}"
+        subs = _subcommands(script)
+        if subs:
+            surface.update((rel, f"{script.name} {sub}") for sub in subs)
+        else:
+            surface.add((rel, script.name))
+    return surface
+
+
+def documented_surface() -> set[tuple[str, str]]:
+    text = REFERENCE.read_text(encoding="utf-8")
+    return {(m.group(1), m.group(2)) for m in (TABLE_ROW.match(line) for line in text.splitlines()) if m}
+
+
+def test_reference_table_matches_the_script_surface() -> None:
+    measured = measured_surface()
+    documented = documented_surface()
+
+    missing = sorted(measured - documented)
+    stale = sorted(documented - measured)
+
+    assert not missing, (
+        "commands exist in scripts/ but are absent from docs/public/reference.md: "
+        f"{missing}. Add a row for each, or drop the command."
+    )
+    assert not stale, (
+        "docs/public/reference.md documents commands that scripts/ no longer exposes: "
+        f"{stale}. Remove the row, or restore the command."
+    )
+
+
+def test_the_check_can_fail() -> None:
+    """A comparison that cannot fail is indistinguishable from one that is not running.
+
+    Zero drift above proves nothing unless a fabricated gap is caught, so one is.
+    """
+    measured = measured_surface()
+    documented = documented_surface()
+    assert measured, "no executables discovered under scripts/; the comparison had nothing to compare"
+
+    victim = ("scripts/dispatch-gate", "dispatch-gate check")
+    assert victim in measured and victim in documented
+    assert victim not in measured - documented
+    assert victim in measured - (documented - {victim})


### PR DESCRIPTION
## What was stale

`docs/public/reference.md` carried an `AUTO-GENERATED from scripts/ --help` marker. No generator was ever in the repository, so nothing measured the table and it drifted in silence.

Measured against `scripts/` and each script's own `--help`:

| Gap | Detail |
| --- | --- |
| `codex-worker-pretrust` | no row |
| `onboarding-preflight.sh` | no row |
| `redaction-inventory` | no row |
| `dispatch-gate report` | no row, while `check`, `register`, and `watch` had one |
| `redaction-scan.sh` row | documented the retired allowlist as the mechanism |

The last one was the one that could cost a reader something. The row said the allowlist "defaults to `scripts/redaction-allowlist.txt` or `REDACTION_ALLOWLIST`". That format is retired, and a file still holding entries in it exits 2 (`scripts/redaction-scan.sh:96`), so the page was instructing a failing action. `REDACTION_EXTRA_PATTERNS`, `REDACTION_REQUIRE_EXTRA`, `--commit-messages`, gitleaks as the engine, and the exit codes were all absent.

## Checked, not generated

A generator was the obvious fix and the wrong one. `Purpose` and `Key options` are prose, and `--help` does not carry purpose; a generator would either emit worse prose or need a sidecar holding the same prose it was meant to remove.

So the inventory is checked instead. `tests/test_reference_command_table.py` reads each executable's own `--help`, extracts argparse subcommand groups, and compares the resulting `(script, command)` set against the table's rows. It fails in both directions: a command with no row, and a row that outlived its command. The prose stays where a person maintains it, and gate 1 already runs this, so no new command surface appears (which would itself have needed a row).

The marker now says what is true rather than naming a generator that does not exist.

## Evidence the check is live

It failed on all four missing entries before the table was corrected:

```
commands exist in scripts/ but are absent from docs/public/reference.md:
[('scripts/codex-worker-pretrust', 'codex-worker-pretrust'),
 ('scripts/dispatch-gate', 'dispatch-gate report'),
 ('scripts/onboarding-preflight.sh', 'onboarding-preflight.sh'),
 ('scripts/redaction-inventory', 'redaction-inventory')]
```

A second subtest fabricates a missing row and asserts it is caught, because a green comparison and a comparison that never ran look identical otherwise.

## Gates

- `PYTHONPATH=src uv run --with pytest --no-project python3 -m pytest tests -q` — 415 passed, 1 skipped, 13 subtests
- `redaction-scan.sh` with required org rules — `OK — 0 findings (mode=tracked, files=145, org-rules=10)`
- `redaction-inventory` — 249 uncovered candidates, identical to the `main` baseline

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Pins the docs command reference to the actual script surface by adding a test and fixing the table. This prevents drift and removes outdated allowlist guidance that caused failing scans.

- **New Features**
  - Added `tests/test_reference_command_table.py` to compare each script’s `--help` subcommands with the table’s `(script, command)` pairs and fail on missing or stale rows. Includes a guard subtest that fabricates a gap.

- **Bug Fixes**
  - Added missing rows: `codex-worker-pretrust`, `onboarding-preflight.sh`, `redaction-inventory`, `dispatch-gate report`.
  - Updated `redaction-scan.sh` row: gitleaks engine, commit message scanning, org rules via `REDACTION_EXTRA_PATTERNS`, enforce via `REDACTION_REQUIRE_EXTRA=1`, exit codes 0/1/2; `scripts/redaction-allowlist.txt` format retired and treated as error if present.
  - Replaced the misleading AUTO-GENERATED marker with a note that tests check the rows.

<sup>Written for commit aab15131b189a1759f06be7612f78e93e5d69c02. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/baksohyeon/mogui-ADE-orchestrator/pull/36?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the public command reference with newly supported commands and expanded redaction-scan behavior.
  * Clarified that the reference covers only the public command surface and is maintained against command help output.

* **Tests**
  * Added validation to detect missing, stale, or undocumented commands in the reference table.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->