### PR TITLE
preflight: measure python3 presence, leave version floors to the tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Anyone running more than two agents at once hits this. Dorito hit it, got tired 
 
 Nothing to configure and nothing to read first. Clone it, start an agent inside the clone, tell it to wake up. The agent takes it from there and explains as it goes.
 
-It runs the fleet on [Orca](https://www.onorca.dev/download). A session has to outlive its window and be addressable by handle before anything can orchestrate it. Built and run on macOS; Orca also ships Linux and Windows. Python 3.11+, stdlib-only core, MIT. No API key.
+It runs the fleet on [Orca](https://www.onorca.dev/download). A session has to outlive its window and be addressable by handle before anything can orchestrate it. Built and run on macOS; Orca also ships Linux and Windows. Python 3, stdlib-only core, MIT. No API key.
 
 The orchestrating session is called the master, for lack of a better word. It has no name yet. Suggestions welcome.
 
@@ -305,7 +305,7 @@ Two principles shape the layout:
 
 To use the system, the [Quickstart](#quickstart) above is the whole path. This section is for changing the harness itself.
 
-Prerequisites: macOS and **Python 3.11+**. The runtime is stdlib-only; there is nothing to install.
+Prerequisites: macOS and the `python3` it already has. The runtime is stdlib-only; there is nothing to install, and no version floor is enforced: the core imports and runs on the 3.9.6 a bare Mac ends up with. A tool that needs a newer interpreter states its own requirement at runtime, and the [Reference](docs/public/reference.md) table carries each one's floor in its own row. The suite's collection imports `tomllib` (3.11+), so tests reach an older interpreter through `uv` — and tests are the agent's job either way.
 
 All CLI entry points live in `scripts/` and are self-contained (they insert `src/` on `sys.path` themselves):
 

--- a/docs/public/getting-started.md
+++ b/docs/public/getting-started.md
@@ -9,7 +9,7 @@ Everything in this list serves one goal, a running master session. The core libr
 - [Orca](https://www.onorca.dev/download). The master lives in an Orca pane, which is what lets it outlive a window. Orca ships macOS, Linux, and Windows builds.
 - The `orca` shell command. The runtime calls it to spawn, list, and retire master sessions, so succession does not work without it. Registering it is a step in Orca's settings, covered below.
 - A coding-agent CLI you already pay for: Claude Code, Codex, Grok CLI, or another one. Any single one is enough.
-- Python 3.11 or newer. The core is stdlib-only, but `scripts/codex-worker-pretrust` reads TOML through `tomllib`, which arrived in 3.11. `uv` covers the test suite on an older host and does not cover this script, which calls the host `python3` directly.
+- `python3` on `PATH` — whichever one the machine already has. The core is stdlib-only and no version floor is enforced: the preflight measures presence, not version. A tool that needs a newer interpreter states that itself when it runs, with its own error; the [Reference](reference.md) table names each tool's requirement in its own row.
 - macOS is what this project has been developed and run on. One user has reported the install working on Linux. Windows is untested.
 
 Two more tools are recommended rather than required, and the preflight warns on their absence instead of blocking:
@@ -84,6 +84,6 @@ The detailed flow lives in [master-ops/ONBOARDING.md](../../master-ops/ONBOARDIN
 
 Tests are the agent's job. Ask it to run them and report back, the same way you ask it for anything else. Nothing here expects you to type a test command.
 
-For the command surface, see [Reference](reference.md), generated from the local `scripts/` help output.
+For the command surface, see [Reference](reference.md), written from the local `scripts/` help output and pinned to it by a test that fails on drift in either direction.
 
 Read next: [Concepts](concepts.md), [Master Lifecycle](master-lifecycle.md), or [Reference](reference.md).

--- a/scripts/onboarding-preflight.sh
+++ b/scripts/onboarding-preflight.sh
@@ -399,16 +399,16 @@ else
 fi
 
 test_hint='PYTHONPATH=src uv run --with pytest --no-project python3 -m pytest tests -q'
-python_floor_ok=false
-if ! command -v python3 >/dev/null 2>&1; then
-  fail "python3" "missing; install Python 3.11+ because codex-worker-pretrust uses tomllib for safe TOML editing; test suite: $test_hint"
-elif python3 -c 'import sys; raise SystemExit(0 if sys.version_info >= (3, 11) else 1)' >/dev/null 2>&1; then
-  python_floor_ok=true
-  pass "python3" "Python 3.11+ present; codex-worker-pretrust uses tomllib for safe TOML editing; test suite: $test_hint"
+# No version floor is enforced here. The core runs on the interpreter the host
+# already has (measured down to the CLT 3.9.6 a bare Mac ends up with). A tool
+# that needs a newer one states its own requirement at runtime and exits with
+# its own error, which keeps interpreter floors where they belong: per tool,
+# not as an onboarding blocker for hosts that never run that tool.
+if command -v python3 >/dev/null 2>&1; then
+  python_version=$(python3 -c 'import sys; print(".".join(map(str, sys.version_info[:3])))' 2>/dev/null)
+  pass "python3" "Python ${python_version:-unknown} present; no version floor is enforced here, a tool that needs a newer interpreter states that itself at runtime"
 else
-  # Present but below the floor. Reporting an old interpreter as "missing" sends
-  # the operator looking for the wrong thing.
-  fail "python3" "present but $(python3 -c 'import sys; print(".".join(map(str, sys.version_info[:3])))' 2>/dev/null) is below the required 3.11, which codex-worker-pretrust needs for tomllib; install Python 3.11+ or run the suite through uv: $test_hint"
+  fail "python3" "missing; the runtime's entry points are python3 scripts, so nothing here runs without it"
 fi
 
 # --- harness and worker tool surface --------------------------------------
@@ -494,15 +494,15 @@ if command -v gh >/dev/null 2>&1; then
   fi
 fi
 
-# pytest resolving is not the same as the suite running: below the floor,
-# collection fails on tomllib before a single test executes, so an interpreter
-# under 3.11 has to reach the suite through uv.
-if [[ "$python_floor_ok" == true ]] && python3 -m pytest --version >/dev/null 2>&1; then
-  pass "pytest" "python3 -m pytest is runnable at the required interpreter version"
+# Tests are the agent's job, so how they would run is reported rather than
+# enforced. Note the wrinkle: suite collection imports tomllib, so an interpreter
+# under 3.11 reaches the suite through uv, not through python3 -m pytest.
+if python3 -c 'import sys, pytest; raise SystemExit(0 if sys.version_info >= (3, 11) else 1)' >/dev/null 2>&1; then
+  pass "pytest" "python3 -m pytest is runnable on this interpreter"
 elif command -v uv >/dev/null 2>&1; then
   pass "pytest" "uv present; the suite runs through: $test_hint"
 else
-  fail "pytest" "no way to run the test gate: pytest is not available on a 3.11+ interpreter and uv is missing; install either"
+  warn "pytest" "neither pytest on a 3.11+ interpreter nor uv is present; the agent that runs the test gate will need one of them, and this host currently offers neither"
 fi
 
 # The gate writes its ledger outside the repository. Check writability without

--- a/tests/test_onboarding_preflight.py
+++ b/tests/test_onboarding_preflight.py
@@ -136,13 +136,12 @@ def _labels(output: str, verdict: str) -> set[str]:
 def test_provisioned_host_reports_no_failure_it_can_act_on(tmp_path: Path) -> None:
     """A correctly provisioned host must be able to pass.
 
-    python3 is exempted from the assertion because the interpreter running the
-    suite is not under this test's control, and the check compares it against
-    the floor README declares.
+    python3 no longer needs an exemption here: presence is the whole check, and
+    version floors belong to the tools that have them, stated at their runtime.
     """
 
     result = _run(_host(tmp_path), tmp_path)
-    assert _labels(result.stdout, "FAIL") <= {"python3"}, result.stdout
+    assert not _labels(result.stdout, "FAIL"), result.stdout
     assert {
         "orchestration",
         "skills",
@@ -223,7 +222,7 @@ def test_waived_failure_is_labeled_and_stops_blocking(tmp_path: Path) -> None:
     """The escape exists so the whole preflight is not skipped, and it is loud."""
 
     env = _host(tmp_path, rules=None)
-    env["PREFLIGHT_WAIVE"] = "redaction-extra, python3"
+    env["PREFLIGHT_WAIVE"] = "redaction-extra"
     result = _run(env, tmp_path)
     assert "redaction-extra" not in _labels(result.stdout, "FAIL"), result.stdout
     assert "WAIVED" in result.stdout
@@ -366,6 +365,5 @@ def test_no_essential_block_when_nothing_essential_is_missing(tmp_path: Path) ->
     home = tmp_path / "home"
     for pack in ("superpowers", "ponytail"):
         (home / ".claude" / "skills" / pack).mkdir(parents=True, exist_ok=True)
-    env["PREFLIGHT_WAIVE"] = "python3"
     result = _run(env, tmp_path)
     assert "ESSENTIAL COMPONENTS MISSING" not in result.stdout, result.stdout


### PR DESCRIPTION
## The decision

Owner direction: no interpreter version enforcement at onboarding — the harness runs on whatever `python3` the host already has, and a tool that needs more says so itself. Tests are the agent's job, so how they run is the agent's concern, not an onboarding gate.

## What changed

**`scripts/onboarding-preflight.sh`**
- `python3`: presence-only. Missing still FAILs (every entry point is a python3 script). Version is reported, never compared. The message states the rule generically — a tool that needs a newer interpreter states that itself at runtime — naming no vendor's tool in the core check.
- `pytest`: FAIL → WARN. The preflight reports how the suite would run (native 3.11+ pytest, or `uv`) and stops blocking onboarding when neither is present.

**Why generically:** the previous message hardcoded `codex-worker-pretrust` as the reason for a global 3.11 floor. That coupled a core check to one vendor's tool and blocked hosts that never dispatch that worker. Per-tool floors now live where per-tool facts already live: the Reference table row and the tool's own runtime error (`codex-worker-pretrust` exits 2 with a self-describing message, pinned by an existing regression test).

**Docs**
- README headline `Python 3.11+` → `Python 3`; the working-on-the-harness prerequisites now state the no-floor rule and the one `tomllib` wrinkle.
- getting-started points version questions at each tool's Reference row.
- getting-started's stale claim that the reference page is "generated" now names the checker that pins it instead (follow-up to #36).

## Measured, on the exact host this unblocks

CLT Python 3.9.6 (what a bare Mac ends up with after Homebrew pulls Command Line Tools):

Before: `FAIL python3 ... below the required 3.11` → `BLOCKED`, exit 1.
After: `PASS python3 Python 3.9.6 present; no version floor is enforced here...`, `PASS pytest uv present...`, and the only remaining FAIL is `orchestration` (no Run bound to this terminal — true, and unrelated).

Core-on-old-python is not an assumption either: all of `src/` compiles under 3.9.6, and `detect_trigger` returns a real `TriggerDecision` from a stock 3.9.6 outside the repo with no Orca present.

## Gates

- `PYTHONPATH=src uv run --with pytest --no-project python3 -m pytest tests -q` — 415 passed, 1 skipped, 13 subtests
- `redaction-scan.sh` — `OK — 0 findings (mode=tracked, files=145, org-rules=10)`
- `redaction-inventory` — 249, identical to baseline (one new kebab-token candidate this change minted was reworded away rather than left to drift the baseline)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preflight now checks for `python3` presence only and reports its version, leaving interpreter floors to each tool at runtime. The `pytest` gate is downgraded to a warning, and docs/tests are aligned.

- **Refactors**
  - `scripts/onboarding-preflight.sh`: require `python3` presence; show version; no global version floor. Tools enforce their own floors at runtime.
  - `pytest` gate: pass if `python3` can run `pytest` (3.11+), else pass via `uv`; if neither is available, warn instead of fail. Note: suite collection imports `tomllib`, so older interpreters must use `uv`.
  - README/getting-started: switch “Python 3.11+” to “Python 3”; point version requirements to each tool’s Reference row.
  - Tests: remove `python3` waiver and assert zero FAILs on a provisioned host.

<sup>Written for commit 48f1c457e827dcec2c29d838116bba5c16c27a30. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/baksohyeon/mogui-ADE-orchestrator/pull/37?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

