### PR TITLE
preflight: the Codex plugin check advises instead of blocking

### DIFF
--- a/scripts/onboarding-preflight.sh
+++ b/scripts/onboarding-preflight.sh
@@ -267,7 +267,11 @@ if [[ "${ORCA_AGENT_CLI:-}" == "claude" || "${ORCA_AGENT_CLI:-}" == "claude-code
     && grep -Fq 'codex@openai-codex' "$claude_plugins_file"; then
     pass "codex-plugin" "official Codex plugin is installed for Claude Code"
   else
-    fail "codex-plugin" "official Codex plugin missing from $claude_plugins_file; in Claude Code run: /plugin marketplace add openai/codex-plugin-cc; /plugin install codex@openai-codex; /reload-plugins; verify /codex:setup"
+    # A routing policy that sends heavy work to Codex is one workspace's choice,
+    # not a property of every Claude Code master. Wiring stays, enforcement does
+    # not: the install path is stated, and a host that never dispatches Codex
+    # workers onboards without it.
+    warn "codex-plugin" "official Codex plugin missing from $claude_plugins_file; hosts that dispatch Codex workers need it. In Claude Code: /plugin marketplace add openai/codex-plugin-cc; /plugin install codex@openai-codex; /reload-plugins; verify /codex:setup"
   fi
 elif command -v claude >/dev/null 2>&1; then
   printf 'INFO %-14s %s\n' "codex-plugin" "skipped because Claude Code is installed but ORCA_AGENT_CLI does not select it"
@@ -406,7 +410,7 @@ test_hint='PYTHONPATH=src uv run --with pytest --no-project python3 -m pytest te
 # not as an onboarding blocker for hosts that never run that tool.
 if command -v python3 >/dev/null 2>&1; then
   python_version=$(python3 -c 'import sys; print(".".join(map(str, sys.version_info[:3])))' 2>/dev/null)
-  pass "python3" "Python ${python_version:-unknown} present; no version floor is enforced here, a tool that needs a newer interpreter states that itself at runtime"
+  pass "python3" "Python ${python_version:-unknown} present; no version floor is enforced here, a tool that needs a newer interpreter states that itself at runtime (today: codex-worker-pretrust, 3.11+ for tomllib)"
 else
   fail "python3" "missing; the runtime's entry points are python3 scripts, so nothing here runs without it"
 fi


### PR DESCRIPTION
Follow-up to #37, same principle: a check blocks only with a concrete measured reason.

The `codex-plugin` check FAILed onboarding for every Claude Code master missing the official Codex plugin. That enforces one workspace's routing policy on every template user; a host that never dispatches Codex workers loses nothing without the plugin. Now WARN, with the install commands and the audience stated in the message.

The summoning path itself was re-inspected on this host before touching the check, and had not drifted: `codex@openai-codex` 1.0.6 present in `installed_plugins.json` exactly as the grep expects, codex-cli 0.146.0 on PATH, auth active and verified, companion setup reports `ready: true`.

Checks that still block, and the measured incidents behind them: `orca` (documented runaway-agent incident), `orchestration` (two failure modes measured on real hosts), `redaction-extra` (a measured leak), `agent-cli` unset (measured silent downgrade of dependent checks to INFO), `python3`/`git`/`bd` (nothing runs without them). This plugin's absence has no such incident on record.

Gates: 415 passed / scan 0 findings / inventory 249 = baseline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preflight now warns (doesn’t block) when the `codex@openai-codex` plugin is missing, and includes install steps, since only hosts that dispatch Codex workers need it. The `python3` pass message now notes `codex-worker-pretrust` needs Python 3.11+ for `tomllib`.

<sup>Written for commit ca536fadbeb2faca264e90bddf60d155a4037022. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/baksohyeon/mogui-ADE-orchestrator/pull/39?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

