### PR TITLE
docs: the U5 row stops naming modules removed in #14

### DIFF
--- a/docs/public/concepts.md
+++ b/docs/public/concepts.md
@@ -43,7 +43,7 @@ The master is easier to test when its responsibilities are named as runtime unit
 | U2 | Context Resolver | Decide whether a request belongs to the workspace, a repository, a worktree, or an external system. | `context/` |
 | U3 | Workspace Runtime | Own tracks, cross-repository state, and long-lived execution records. | `work_ledger.py` (`WorkspaceRuntime`) |
 | U4 | Repository Runtime Loader | Load only the Repository Harness needed for the resolved target. | none (design only) |
-| U5 | Worker Scheduler | Issue worker leases, choose isolation, dispatch workers, enforce budget, and reap resources. | partial: `dispatch_gate.py`, `adapter/dispatch.py`, `adapter/isolation.py`; no lease or reap module |
+| U5 | Worker Scheduler | Issue worker leases, choose isolation, dispatch workers, enforce budget, and reap resources. | partial: `dispatch_gate.py` budgets and brackets the dispatch; isolation and the launch moved to the host after the typed adapter path was removed in #14; no lease or reap module |
 | U6 | Approval Manager | Classify action risk and bind execution to a valid approval state. | `approval/` |
 | U7 | Role Runtime | Keep one active role, role lock, and role transition state. | partial: `RoleState` is parsed in `bootstrap.py`; the lock itself is policy |
 | U8 | Recovery Manager | Reattach, resume once, or reconstruct state before spawning a replacement session. | `recovery.py` |


### PR DESCRIPTION
One live defect left from the #38 sweep, found while translating the page: the U5 Worker Scheduler row still cited `adapter/dispatch.py` and `adapter/isolation.py` as partial implementations. Both files left with #14 (measured: `src/master_runtime/core/adapter/` holds `doctor.py` and `profile.py` only). The CHANGELOG mentions of those paths are the removal record itself and stay.

Gates: 416 passed / scan 0 findings / inventory 249 = baseline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updated the U5 Worker Scheduler row in `docs/public/concepts.md` to remove references to `adapter/dispatch.py` and `adapter/isolation.py` removed in #14. Clarifies that `dispatch_gate.py` handles budgeting/bracketing, isolation and launch moved to the host, and lease/reap modules are still absent.

<sup>Written for commit 505a53b18b2ff15dde0c94235c3b5a3b8646bc7c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/baksohyeon/mogui-ADE-orchestrator/pull/41?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

