### PR TITLE
charter: unresolved bot threads block the merge, and findings get measured first

### DIFF
--- a/master-ops/docs/MASTER-OPERATIONS.md
+++ b/master-ops/docs/MASTER-OPERATIONS.md
@@ -141,7 +141,7 @@ Three-vote review is the default for non-trivial merges or direct-push changes. 
 
 Use the majority verdict, but a minority P1 `FIX_FIRST` finding must be addressed or explicitly rejected with evidence.
 
-PR review-bot threads are always worker-handled without per-round owner instruction: dispatch a fix worker on arrival, the master verifies, the worker replies and resolves, and the master judges rejections only. (charter rule since template v5)
+PR review-bot threads are always worker-handled without per-round owner instruction: dispatch a fix worker on arrival, the master verifies, the worker replies and resolves, and the master judges rejections only. (charter rule since template v5) On a repository with review bots attached, zero unresolved threads is a merge precondition: every thread gets a reply stating what was done or why not, and the merge waits for the bots' pass over the latest push. Verify a bot finding against the code before acting on it — bots produce false positives, and a thread resolved without measuring is silence dressed as review.
 
 Do not run large fan-out from the master workflow by default. If it is unavoidable, report scale and estimated cost first.
 


### PR DESCRIPTION
The template's v5 bot-thread rule says who handles threads (workers, master verifies). It does not say when a merge may proceed. This adds the other half, generalized from field use on this repository (#40 ran the full cycle: 5 threads from two bots, all answered and resolved before merge):

- zero unresolved threads is a merge precondition, conditional on the repository having review bots attached — bot-less repositories inherit no ceremony
- every thread gets a reply stating what was done or why not
- the merge waits for the bots' pass over the latest push
- a bot finding is verified against the code before acting on it, because bots produce false positives and a thread resolved without measuring is silence dressed as review

Gates: 416 passed / scan 0 findings / inventory 249 = baseline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clarifies merge policy: on repos with review bots, merges require zero unresolved bot threads.
Each thread must get a reply, bots must run on the latest push, and findings must be verified against the code before acting to avoid false positives.

<sup>Written for commit 5c3c642e46126bc57eaf23b2782d1cc0e82b00b8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/baksohyeon/mogui-ADE-orchestrator/pull/42?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated pull request review guidance to require all review threads to be resolved before merging.
  * Clarified that responses should document resolution decisions and that automated findings must be verified against the code.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->