### PR TITLE
ci: run the gates where the author's word is not the evidence

### DIFF
--- a/.github/workflows/gates.yml
+++ b/.github/workflows/gates.yml
@@ -9,9 +9,9 @@
 #
 # gitleaks is installed in both jobs, not only the redaction one: the test
 # suite exercises redaction-scan.sh for real (measured on the first run of this
-# workflow — four commit-message scan tests failed on a runner without it).
+# workflow — four commit message scan tests failed on a runner without it).
 # The install block is duplicated across jobs because Actions YAML has no
-# cross-job anchors and a composite action is more machinery than two copies.
+# anchors across jobs and a composite action is more machinery than two copies.
 name: gates
 
 on:
@@ -31,7 +31,7 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: "3.12"
-      - name: Install gitleaks (pinned, checksum-verified)
+      - name: Install gitleaks (pinned, checksum verified)
         shell: bash
         run: |
           case "$(uname -s)-$(uname -m)" in
@@ -50,7 +50,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Install gitleaks (pinned, checksum-verified)
+      - name: Install gitleaks (pinned, checksum verified)
         shell: bash
         run: |
           case "$(uname -s)-$(uname -m)" in

--- a/.github/workflows/gates.yml
+++ b/.github/workflows/gates.yml
@@ -1,0 +1,45 @@
+# The same three gates that run locally before a push, run where the author's
+# word is not the evidence. The 0.1.0 changelog said it plainly: "a passing
+# count in a pull request is the author's word." This closes that.
+#
+# What CI cannot cover, stated rather than implied: the organization rules file
+# (REDACTION_EXTRA_PATTERNS) is deliberately not in the repository, so the scan
+# here runs the committed ruleset only. The full scan with organization rules
+# still runs locally before a push.
+name: gates
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  tests:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - run: python3 -m pip install pytest
+      - run: PYTHONPATH=src python3 -m pytest tests -q
+
+  redaction:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install gitleaks (pinned, checksum-verified)
+        run: |
+          curl -sSfL -o gitleaks.tgz \
+            https://github.com/gitleaks/gitleaks/releases/download/v8.30.1/gitleaks_8.30.1_linux_x64.tar.gz
+          echo "551f6fc83ea457d62a0d98237cbad105af8d557003051f41f3e7ca7b3f2470eb  gitleaks.tgz" | sha256sum -c -
+          tar -xzf gitleaks.tgz gitleaks
+          sudo install -m 0755 gitleaks /usr/local/bin/gitleaks
+      - name: Scan tracked content (committed rules)
+        run: ./scripts/redaction-scan.sh
+      - name: Inventory (informational — exit 1 is the normal triage state)
+        run: ./scripts/redaction-inventory || true

--- a/.github/workflows/gates.yml
+++ b/.github/workflows/gates.yml
@@ -6,6 +6,12 @@
 # (REDACTION_EXTRA_PATTERNS) is deliberately not in the repository, so the scan
 # here runs the committed ruleset only. The full scan with organization rules
 # still runs locally before a push.
+#
+# gitleaks is installed in both jobs, not only the redaction one: the test
+# suite exercises redaction-scan.sh for real (measured on the first run of this
+# workflow — four commit-message scan tests failed on a runner without it).
+# The install block is duplicated across jobs because Actions YAML has no
+# cross-job anchors and a composite action is more machinery than two copies.
 name: gates
 
 on:
@@ -25,6 +31,18 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: "3.12"
+      - name: Install gitleaks (pinned, checksum-verified)
+        shell: bash
+        run: |
+          case "$(uname -s)-$(uname -m)" in
+            Linux-x86_64) f=gitleaks_8.30.1_linux_x64.tar.gz;    sum=551f6fc83ea457d62a0d98237cbad105af8d557003051f41f3e7ca7b3f2470eb ;;
+            Darwin-arm64) f=gitleaks_8.30.1_darwin_arm64.tar.gz; sum=b40ab0ae55c505963e365f271a8d3846efbc170aa17f2607f13df610a9aeb6a5 ;;
+            *) echo "unmapped runner: $(uname -s)-$(uname -m)"; exit 1 ;;
+          esac
+          curl -sSfL -o gitleaks.tgz "https://github.com/gitleaks/gitleaks/releases/download/v8.30.1/$f"
+          echo "$sum  gitleaks.tgz" | shasum -a 256 -c -
+          tar -xzf gitleaks.tgz gitleaks
+          sudo install -m 0755 gitleaks /usr/local/bin/gitleaks
       - run: python3 -m pip install pytest
       - run: PYTHONPATH=src python3 -m pytest tests -q
 
@@ -33,10 +51,15 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Install gitleaks (pinned, checksum-verified)
+        shell: bash
         run: |
-          curl -sSfL -o gitleaks.tgz \
-            https://github.com/gitleaks/gitleaks/releases/download/v8.30.1/gitleaks_8.30.1_linux_x64.tar.gz
-          echo "551f6fc83ea457d62a0d98237cbad105af8d557003051f41f3e7ca7b3f2470eb  gitleaks.tgz" | sha256sum -c -
+          case "$(uname -s)-$(uname -m)" in
+            Linux-x86_64) f=gitleaks_8.30.1_linux_x64.tar.gz;    sum=551f6fc83ea457d62a0d98237cbad105af8d557003051f41f3e7ca7b3f2470eb ;;
+            Darwin-arm64) f=gitleaks_8.30.1_darwin_arm64.tar.gz; sum=b40ab0ae55c505963e365f271a8d3846efbc170aa17f2607f13df610a9aeb6a5 ;;
+            *) echo "unmapped runner: $(uname -s)-$(uname -m)"; exit 1 ;;
+          esac
+          curl -sSfL -o gitleaks.tgz "https://github.com/gitleaks/gitleaks/releases/download/v8.30.1/$f"
+          echo "$sum  gitleaks.tgz" | shasum -a 256 -c -
           tar -xzf gitleaks.tgz gitleaks
           sudo install -m 0755 gitleaks /usr/local/bin/gitleaks
       - name: Scan tracked content (committed rules)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,18 @@ you build on it.
 
 ### Added
 
+- CI: `.github/workflows/gates.yml` runs the test suite (ubuntu and macos,
+  Python 3.12, checksum-pinned gitleaks) and the committed-ruleset redaction
+  scan on every pull request and push to main. What CI cannot cover is stated
+  in the workflow header: the organization rules live outside the repository,
+  so the full scan stays local. The inventory runs informationally.
+- An opt-in pre-push hook (`hooks/pre-push`, enable with
+  `git config core.hooksPath hooks`) scans each pushed ref range, covering
+  changed files and commit messages both, with a tracked-tree fallback when no
+  range resolves.
+
+### Added
+
 - Spawn liveness verification against reissued terminal handles. Orca reissues a
   terminal's handle between creation and first use (observed twice on 2026-08-02,
   once per spawned master), so the handle a spawn returns can be stale on arrival.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,13 +16,13 @@ you build on it.
 ### Added
 
 - CI: `.github/workflows/gates.yml` runs the test suite (ubuntu and macos,
-  Python 3.12, checksum-pinned gitleaks) and the committed-ruleset redaction
+  Python 3.12, checksum pinned gitleaks) and the committed ruleset redaction
   scan on every pull request and push to main. What CI cannot cover is stated
   in the workflow header: the organization rules live outside the repository,
   so the full scan stays local. The inventory runs informationally.
 - An opt-in pre-push hook (`hooks/pre-push`, enable with
   `git config core.hooksPath hooks`) scans each pushed ref range, covering
-  changed files and commit messages both, with a tracked-tree fallback when no
+  changed files and commit messages both, with a tracked tree fallback when no
   range resolves.
 
 ### Added

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -46,7 +46,20 @@ usage or tool error into 1. Read each script's codes rather than assuming.
 
 **The redaction scanners read tracked files.** An unstaged new file is
 invisible to them, and the run comes back green without having looked at it.
-Stage first, then scan. These run locally before publishing, not in CI.
+Stage first, then scan.
+
+CI (`.github/workflows/gates.yml`) runs the test suite and the scan with the
+committed ruleset on every pull request. The organization rules file is
+deliberately not in the repository, so the full scan with those rules still
+runs only locally. To make the local scan automatic, enable the committed
+pre-push hook once per clone:
+
+```console
+$ git config core.hooksPath hooks
+```
+
+The hook runs the scan and nothing else — the test suite stays out of it, so
+the hook stays fast enough that nobody reaches for `--no-verify`.
 
 `redaction-inventory` also skips binary files, judged by a NUL byte in the
 first 8 KB. That is a heuristic and it is silent: the output still says the

--- a/hooks/pre-push
+++ b/hooks/pre-push
@@ -1,16 +1,51 @@
 #!/usr/bin/env bash
-# Opt-in pre-push hook: run the redaction scan before anything leaves the
-# machine. Enable once per clone with:
+# Opt-in pre-push hook: scan what is actually being pushed, before it leaves
+# the machine. Enable once per clone with:
 #
 #   git config core.hooksPath hooks
 #
-# Discipline already says the gates run before a push; this turns the habit
-# into wiring for the one gate whose failure is expensive in public. The test
-# suite stays out of the hook deliberately — tests are the agent's job, and a
-# multi-second hook gets bypassed with --no-verify until it might as well not
-# exist. The scan honors the same environment as a manual run, so a checkout
-# with organization rules configured scans with them.
+# git feeds pre-push one line per ref on stdin (<local ref> <local sha>
+# <remote ref> <remote sha>), and the scan runs over each pushed range with
+# --range, which covers both the files those commits change and the commit
+# messages themselves. A tip-of-tree scan would miss a secret that lives in an
+# intermediate commit and is gone from the final tree — the one real leak this
+# repository has had was exactly that shape.
+#
+# The scan honors the caller's environment: a checkout with organization rules
+# configured (REDACTION_EXTRA_PATTERNS, REDACTION_REQUIRE_EXTRA) scans with
+# them. The hook does not demand them, deliberately — this file is committed to
+# a public repository, and a contributor cannot have rules that are private to
+# the organization. The test suite also stays out: tests are the agent's job,
+# and a slow hook gets bypassed with --no-verify until it might as well not
+# exist.
 set -euo pipefail
 
 repo_root=$(git rev-parse --show-toplevel)
-exec "$repo_root/scripts/redaction-scan.sh"
+zero=0000000000000000000000000000000000000000
+status=0
+scanned_any=false
+
+while read -r _local_ref local_sha _remote_ref remote_sha; do
+  # Deleting a remote ref pushes nothing scannable.
+  [ "$local_sha" = "$zero" ] && continue
+  if [ "$remote_sha" = "$zero" ]; then
+    # New ref: the remote has no tip to diff against. Anchor on the default
+    # branch when one is known; a repository where even that fails falls
+    # through to the whole-tree scan below.
+    base=$(git merge-base "$local_sha" origin/main 2>/dev/null) || base=""
+  else
+    base=$remote_sha
+  fi
+  if [ -n "$base" ] && [ "$base" != "$local_sha" ]; then
+    "$repo_root/scripts/redaction-scan.sh" --range "$base..$local_sha" || status=$?
+    scanned_any=true
+  fi
+done
+
+# No ranges resolved (empty stdin, ref deletions only, or no usable base):
+# fall back to the tracked-tree scan rather than passing silently.
+if [ "$scanned_any" = false ]; then
+  "$repo_root/scripts/redaction-scan.sh" || status=$?
+fi
+
+exit "$status"

--- a/hooks/pre-push
+++ b/hooks/pre-push
@@ -7,7 +7,7 @@
 # git feeds pre-push one line per ref on stdin (<local ref> <local sha>
 # <remote ref> <remote sha>), and the scan runs over each pushed range with
 # --range, which covers both the files those commits change and the commit
-# messages themselves. A tip-of-tree scan would miss a secret that lives in an
+# messages themselves. A tip of tree scan would miss a secret that lives in an
 # intermediate commit and is gone from the final tree — the one real leak this
 # repository has had was exactly that shape.
 #
@@ -31,7 +31,7 @@ while read -r _local_ref local_sha _remote_ref remote_sha; do
   if [ "$remote_sha" = "$zero" ]; then
     # New ref: the remote has no tip to diff against. Anchor on the default
     # branch when one is known; a repository where even that fails falls
-    # through to the whole-tree scan below.
+    # through to the whole tree scan below.
     base=$(git merge-base "$local_sha" origin/main 2>/dev/null) || base=""
   else
     base=$remote_sha
@@ -43,7 +43,7 @@ while read -r _local_ref local_sha _remote_ref remote_sha; do
 done
 
 # No ranges resolved (empty stdin, ref deletions only, or no usable base):
-# fall back to the tracked-tree scan rather than passing silently.
+# fall back to the tracked tree scan rather than passing silently.
 if [ "$scanned_any" = false ]; then
   "$repo_root/scripts/redaction-scan.sh" || status=$?
 fi

--- a/hooks/pre-push
+++ b/hooks/pre-push
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+# Opt-in pre-push hook: run the redaction scan before anything leaves the
+# machine. Enable once per clone with:
+#
+#   git config core.hooksPath hooks
+#
+# Discipline already says the gates run before a push; this turns the habit
+# into wiring for the one gate whose failure is expensive in public. The test
+# suite stays out of the hook deliberately — tests are the agent's job, and a
+# multi-second hook gets bypassed with --no-verify until it might as well not
+# exist. The scan honors the same environment as a manual run, so a checkout
+# with organization rules configured scans with them.
+set -euo pipefail
+
+repo_root=$(git rev-parse --show-toplevel)
+exec "$repo_root/scripts/redaction-scan.sh"

--- a/hooks/pre-push
+++ b/hooks/pre-push
@@ -33,8 +33,14 @@ while read -r _local_ref local_sha _remote_ref remote_sha; do
     # branch when one is known; a repository where even that fails falls
     # through to the whole tree scan below.
     base=$(git merge-base "$local_sha" origin/main 2>/dev/null) || base=""
-  else
+  elif git cat-file -e "$remote_sha^{commit}" 2>/dev/null; then
     base=$remote_sha
+  else
+    # A forced update can advertise a remote tip whose object this clone never
+    # fetched. Handing the scan a range it cannot walk used to read as a clean
+    # empty scan; the scan now exits 2 on that, and the hook does not hand it
+    # one in the first place.
+    base=$(git merge-base "$local_sha" origin/main 2>/dev/null) || base=""
   fi
   if [ -n "$base" ] && [ "$base" != "$local_sha" ]; then
     "$repo_root/scripts/redaction-scan.sh" --range "$base..$local_sha" || status=$?


### PR DESCRIPTION
DZ-u4t, unblocked today by the `workflow` scope grant.

## What runs

`.github/workflows/gates.yml`, on every PR and on pushes to main:

- **tests** — the suite on `ubuntu-latest` and `macos-latest`, Python 3.12, plain `pip install pytest` + `PYTHONPATH=src python3 -m pytest tests -q`. No third-party actions beyond `checkout` and `setup-python`.
- **redaction** — `redaction-scan.sh` with the committed ruleset, gitleaks pinned at 8.30.1 and checksum-verified before install. The workflow header states what this does NOT cover: the organization rules file is deliberately outside the repository, so the full scan with those rules remains a local, pre-push act.
- **inventory** — informational (`|| true`), because exit 1 is its documented normal state (uncovered-candidate triage list).

## The hook

`hooks/pre-push` runs the scan before anything leaves the machine, opt-in via `git config core.hooksPath hooks`. Scan only — the suite stays out so the hook never gets bypassed with `--no-verify` out of impatience. Tested live before committing: `OK — 0 findings`.

## After this lands

Once the workflow has a green run on main, the branch ruleset (20183984) gets the two jobs as required status checks — separate step, so a misnamed job context cannot lock the repository.

Gates locally: 416 passed / scan 0 findings (org-rules=10) / inventory 249 = baseline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a gates CI workflow that runs tests and a redaction scan on every PR and push to `main`, plus an opt-in pre-push hook that scans the exact ranges being pushed (files and commit messages). Installs `gitleaks` in both jobs so commit‑message scan tests run in CI.

- **New Features**
  - Tests: `ubuntu-latest` and `macos-latest`, Python 3.12; `pip install pytest`; run with `PYTHONPATH=src python3 -m pytest tests -q`.
  - Redaction: `scripts/redaction-scan.sh`; `scripts/redaction-inventory` runs informationally and filters prose to reduce noise.
  - `gitleaks`: v8.30.1 pinned and checksum‑verified; installed in both `tests` and `redaction` jobs.
  - Local: `hooks/pre-push` scans pushed ranges (files + commit messages) with a tracked-tree fallback; enable with `git config core.hooksPath hooks`. CI uses the committed rules only; org rules stay local.

- **Bug Fixes**
  - Pre-push hook: avoids using an unfetched remote tip as the range base; falls back to `merge-base` with `origin/main` to prevent empty scans.

<sup>Written for commit 5e4f41eff5b1fdbf9a0a449fd4c30688a1ef3d17. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/baksohyeon/mogui-ADE-orchestrator/pull/44?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

