### PR TITLE
scan: prove the org rules against the engine that runs them, and stop swallowing its failures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,17 @@ you build on it.
 
 ## [Unreleased]
 
+### Fixed
+
+- Organization rules are proven against the engine that runs them. Python's
+  `re` validated the rules, gitleaks compiles RE2, and a rule Python accepted
+  crashed the engine at config load while every invocation swallowed the
+  crash: scans with organization rules configured reported `OK` having
+  scanned nothing. The merged config now runs a canary through gitleaks
+  before anything is scanned (failure exits 2 naming rule ids, never
+  patterns), and a nonzero gitleaks exit during a scan is an engine error
+  and exits 2 rather than reading as a clean file.
+
 ## [0.3.0] - 2026-08-03
 
 ### Changed

--- a/scripts/redaction-scan.sh
+++ b/scripts/redaction-scan.sh
@@ -237,7 +237,7 @@ list_scan_files() {
 
 # A range neither end of which resolves is not an empty range. git prints a
 # fatal to stderr and this script used to keep going with zero files and zero
-# messages, which read as clean. Measured with an all-zeros left side: OK,
+# messages, which read as clean. Measured with an unresolvable left side: OK,
 # exit 0. A range that cannot be enumerated is exit 2.
 if [[ -n "${RANGE}" ]] && ! git rev-list --max-count=0 "${RANGE}" >/dev/null 2>&1; then
   echo "redaction-scan: FAIL — range does not resolve in this repository: ${RANGE}" >&2
@@ -245,7 +245,7 @@ if [[ -n "${RANGE}" ]] && ! git rev-list --max-count=0 "${RANGE}" >/dev/null 2>&
 fi
 if [[ -n "${COMMIT_RANGE}" && "${COMMIT_RANGE}" != "${RANGE}" ]] \
   && ! git rev-list --max-count=0 "${COMMIT_RANGE}" >/dev/null 2>&1; then
-  echo "redaction-scan: FAIL — commit-message range does not resolve: ${COMMIT_RANGE}" >&2
+  echo "redaction-scan: FAIL — message range does not resolve: ${COMMIT_RANGE}" >&2
   exit 2
 fi
 

--- a/scripts/redaction-scan.sh
+++ b/scripts/redaction-scan.sh
@@ -176,36 +176,42 @@ fi
 if [[ "${CONFIG}" != "${BASE_CONFIG}" ]]; then
   if ! printf 'redaction-scan engine self-test\n' \
     | gitleaks stdin --config "${CONFIG}" --no-banner --exit-code 0 >/dev/null 2>&1; then
-    bad_ids=""
-    while IFS='|' read -r rule_id _rest; do
-      rule_id="${rule_id## }"; rule_id="${rule_id%% }"
-      [[ -z "${rule_id}" || "${rule_id}" == \#* ]] && continue
-      single="${WORK_DIR}/single-rule.toml"
-      python3 - "${REDACTION_EXTRA_PATTERNS}" "${rule_id}" "${single}" <<'PY'
+    # One Python pass isolates the offending rules: it reuses the same parse
+    # the translator applied and probes each rule alone through gitleaks, so
+    # the rules file format lives in one shape and an id indented with a tab cannot
+    # slip the net. Ids only, never patterns.
+    bad_ids=$(python3 - "${REDACTION_EXTRA_PATTERNS}" "${WORK_DIR}" <<'PY'
+import subprocess
 import sys
-source, wanted, target = sys.argv[1], sys.argv[2], sys.argv[3]
+
+source, work_dir = sys.argv[1], sys.argv[2]
+bad = []
 with open(source, encoding="utf-8") as handle:
     for line in handle:
         line = line.strip()
         if not line or line.startswith("#"):
             continue
         parts = line.split("|", 2)
-        if len(parts) != 3 or parts[0].strip() != wanted:
+        if len(parts) != 3:
             continue
-        with open(target, "w", encoding="utf-8") as out:
+        rule_id, _description, regex = (part.strip() for part in parts)
+        single = f"{work_dir}/single-rule.toml"
+        with open(single, "w", encoding="utf-8") as out:
             out.write('title = "single rule probe"\n\n')
             out.write("[[rules]]\n")
-            out.write('id = "%s"\n' % parts[0].strip().replace('"', ""))
+            out.write('id = "%s"\n' % rule_id.replace('"', ""))
             out.write('description = "probe"\n')
-            out.write("regex = '''%s'''\n" % parts[2].strip())
-        break
+            out.write("regex = '''%s'''\n" % regex)
+        probe = subprocess.run(
+            ["gitleaks", "stdin", "--config", single, "--no-banner", "--exit-code", "0"],
+            input="x\n", capture_output=True, text=True,
+        )
+        if probe.returncode != 0:
+            bad.append(rule_id)
+print(" ".join(bad))
 PY
-      if [[ -s "${single}" ]] && ! printf 'x\n' \
-        | gitleaks stdin --config "${single}" --no-banner --exit-code 0 >/dev/null 2>&1; then
-        bad_ids="${bad_ids} ${rule_id}"
-      fi
-      rm -f "${single}"
-    done < "${REDACTION_EXTRA_PATTERNS}"
+)
+    bad_ids="${bad_ids:+ ${bad_ids}}"
     echo "redaction-scan: FAIL — the merged config crashes the engine; organization rule(s) not supported by RE2:${bad_ids:- (rule not isolated; test the file rule by rule)}" >&2
     echo "redaction-scan: rewrite those regexes without lookarounds or other non-RE2 constructs, then re-run." >&2
     exit 2

--- a/scripts/redaction-scan.sh
+++ b/scripts/redaction-scan.sh
@@ -165,6 +165,53 @@ PY
   fi
 fi
 
+# The organization rules were validated by Python's re, and Python is not the
+# engine. gitleaks compiles RE2, which rejects constructs Python accepts
+# (lookarounds, most visibly), and it rejects them by panicking at config load.
+# Every scan under a panicking config finds nothing, which reads as clean.
+# Measured live: a lookbehind rule turned the whole scan into a green no-op
+# while the summary reported the rules as loaded. So the merged config is
+# proven against the actual engine before anything is scanned, and a failure
+# names the rule ids only, never the patterns they protect.
+if [[ "${CONFIG}" != "${BASE_CONFIG}" ]]; then
+  if ! printf 'redaction-scan engine self-test\n' \
+    | gitleaks stdin --config "${CONFIG}" --no-banner --exit-code 0 >/dev/null 2>&1; then
+    bad_ids=""
+    while IFS='|' read -r rule_id _rest; do
+      rule_id="${rule_id## }"; rule_id="${rule_id%% }"
+      [[ -z "${rule_id}" || "${rule_id}" == \#* ]] && continue
+      single="${WORK_DIR}/single-rule.toml"
+      python3 - "${REDACTION_EXTRA_PATTERNS}" "${rule_id}" "${single}" <<'PY'
+import sys
+source, wanted, target = sys.argv[1], sys.argv[2], sys.argv[3]
+with open(source, encoding="utf-8") as handle:
+    for line in handle:
+        line = line.strip()
+        if not line or line.startswith("#"):
+            continue
+        parts = line.split("|", 2)
+        if len(parts) != 3 or parts[0].strip() != wanted:
+            continue
+        with open(target, "w", encoding="utf-8") as out:
+            out.write('title = "single rule probe"\n\n')
+            out.write("[[rules]]\n")
+            out.write('id = "%s"\n' % parts[0].strip().replace('"', ""))
+            out.write('description = "probe"\n')
+            out.write("regex = '''%s'''\n" % parts[2].strip())
+        break
+PY
+      if [[ -s "${single}" ]] && ! printf 'x\n' \
+        | gitleaks stdin --config "${single}" --no-banner --exit-code 0 >/dev/null 2>&1; then
+        bad_ids="${bad_ids} ${rule_id}"
+      fi
+      rm -f "${single}"
+    done < "${REDACTION_EXTRA_PATTERNS}"
+    echo "redaction-scan: FAIL — the merged config crashes the engine; organization rule(s) not supported by RE2:${bad_ids:- (rule not isolated; test the file rule by rule)}" >&2
+    echo "redaction-scan: rewrite those regexes without lookarounds or other non-RE2 constructs, then re-run." >&2
+    exit 2
+  fi
+fi
+
 # A green scan must not imply coverage it does not have.
 if [[ "${EXTRA_RULE_COUNT}" -eq 0 ]]; then
   echo "redaction-scan: WARNING — organization-specific rules not loaded (REDACTION_EXTRA_PATTERNS unset or empty); this scan covers generic patterns only" >&2
@@ -193,13 +240,18 @@ scan_path() {
   local path="$1"
   [[ -f "${path}" ]] || return 0
   report_index=$((report_index + 1))
-  gitleaks dir "${path}" \
+  if ! gitleaks dir "${path}" \
     --config "${CONFIG}" \
     --no-banner \
     --exit-code 0 \
     --report-format json \
     --report-path "${REPORTS}/${report_index}.json" \
-    >/dev/null 2>&1 || true
+    >/dev/null 2>&1; then
+    # --exit-code 0 makes findings exit 0, so nonzero here is the engine
+    # failing, and a failed engine must not read as a clean file.
+    echo "redaction-scan: FAIL — gitleaks failed on ${path} (engine error, not a finding)" >&2
+    exit 2
+  fi
 }
 
 scan_commit_messages() {
@@ -211,14 +263,17 @@ scan_commit_messages() {
   while IFS= read -r sha; do
     [[ -z "${sha}" ]] && continue
     report_index=$((report_index + 1))
-    git log -1 --format=%B "${sha}" \
+    if ! git log -1 --format=%B "${sha}" \
       | gitleaks stdin \
           --config "${CONFIG}" \
           --no-banner \
           --exit-code 0 \
           --report-format json \
           --report-path "${REPORTS}/${report_index}.json" \
-          >/dev/null 2>&1 || true
+          >/dev/null 2>&1; then
+      echo "redaction-scan: FAIL — gitleaks failed on commit ${sha:0:12} message (engine error, not a finding)" >&2
+      exit 2
+    fi
     if [[ -s "${REPORTS}/${report_index}.json" ]]; then
       python3 - "${REPORTS}/${report_index}.json" "commit:${sha:0:12}" <<'PY'
 import json

--- a/scripts/redaction-scan.sh
+++ b/scripts/redaction-scan.sh
@@ -235,6 +235,20 @@ list_scan_files() {
   esac
 }
 
+# A range neither end of which resolves is not an empty range. git prints a
+# fatal to stderr and this script used to keep going with zero files and zero
+# messages, which read as clean. Measured with an all-zeros left side: OK,
+# exit 0. A range that cannot be enumerated is exit 2.
+if [[ -n "${RANGE}" ]] && ! git rev-list --max-count=0 "${RANGE}" >/dev/null 2>&1; then
+  echo "redaction-scan: FAIL — range does not resolve in this repository: ${RANGE}" >&2
+  exit 2
+fi
+if [[ -n "${COMMIT_RANGE}" && "${COMMIT_RANGE}" != "${RANGE}" ]] \
+  && ! git rev-list --max-count=0 "${COMMIT_RANGE}" >/dev/null 2>&1; then
+  echo "redaction-scan: FAIL — commit-message range does not resolve: ${COMMIT_RANGE}" >&2
+  exit 2
+fi
+
 REPORTS="${WORK_DIR}/reports"
 mkdir -p "${REPORTS}"
 report_index=0

--- a/tests/test_redaction_scan_engine_validation.py
+++ b/tests/test_redaction_scan_engine_validation.py
@@ -13,9 +13,12 @@ rather than silence.
 from __future__ import annotations
 
 import os
+import shutil
 import stat
 import subprocess
 from pathlib import Path
+
+import pytest
 
 from test_redaction_scan_commit_messages import _repo_with_commits
 
@@ -35,6 +38,13 @@ def _scan_with_extra(repo: Path, extra: Path, *args: str) -> subprocess.Complete
     )
 
 
+requires_gitleaks = pytest.mark.skipif(
+    shutil.which("gitleaks") is None,
+    reason="gitleaks is the engine under test",
+)
+
+
+@requires_gitleaks
 def test_lookbehind_rule_fails_closed_and_names_the_rule(tmp_path: Path) -> None:
     repo = _repo_with_commits(tmp_path, ["one commit"])
     extra = tmp_path / "extra.txt"

--- a/tests/test_redaction_scan_engine_validation.py
+++ b/tests/test_redaction_scan_engine_validation.py
@@ -1,0 +1,86 @@
+"""The organization rules must compile in the engine that runs them.
+
+The translator validated regexes with Python's re, and Python is not the
+engine. gitleaks compiles RE2, which rejects lookarounds by panicking at
+config load, and every scan under a panicking config found nothing — measured
+live: two organization rules using lookbehind turned every org-rules scan into
+a green no-op from the moment the engine was swapped. These tests pin the two
+halves of the fix: the merged config is proven against the actual engine
+before anything is scanned, and an engine failure during a scan is exit 2
+rather than silence.
+"""
+
+from __future__ import annotations
+
+import os
+import stat
+import subprocess
+from pathlib import Path
+
+from test_redaction_scan_commit_messages import _repo_with_commits
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def _scan_with_extra(repo: Path, extra: Path, *args: str) -> subprocess.CompletedProcess:
+    env = {**os.environ, "REDACTION_EXTRA_PATTERNS": str(extra)}
+    env.pop("REDACTION_REQUIRE_EXTRA", None)
+    return subprocess.run(
+        ["bash", str(repo / "scripts" / "redaction-scan.sh"), *args],
+        cwd=repo,
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+def test_lookbehind_rule_fails_closed_and_names_the_rule(tmp_path: Path) -> None:
+    repo = _repo_with_commits(tmp_path, ["one commit"])
+    extra = tmp_path / "extra.txt"
+    extra.write_text(
+        "good_rule|plain token|ZZPROBEZZ[0-9]+\n"
+        "bad_lookbehind|regex only python accepts|(?<![A-Za-z0-9_])probe(?![A-Za-z0-9_])\n",
+        encoding="utf-8",
+    )
+
+    result = _scan_with_extra(repo, extra)
+
+    assert result.returncode == 2, result.stdout + result.stderr
+    assert "crashes the engine" in result.stderr
+    assert "bad_lookbehind" in result.stderr
+    assert "good_rule" not in result.stderr.split("RE2:")[1], result.stderr
+    # The pattern itself is what the rules file protects; ids only.
+    assert "(?<!" not in result.stderr
+
+
+def test_engine_failure_during_scan_is_exit_2_not_silence(tmp_path: Path) -> None:
+    """--exit-code 0 makes findings exit 0, so nonzero from gitleaks is the
+    engine failing, and a failed engine must not read as a clean file."""
+
+    repo = _repo_with_commits(tmp_path, ["one commit"])
+    shim_bin = tmp_path / "bin"
+    shim_bin.mkdir()
+    shim = shim_bin / "gitleaks"
+    # Healthy for the version banner, dead for every actual scan.
+    shim.write_text(
+        '#!/bin/sh\ncase "$1" in version) echo shim-1.0; exit 0 ;; esac\nexit 2\n',
+        encoding="utf-8",
+    )
+    shim.chmod(shim.stat().st_mode | stat.S_IEXEC)
+    env = {**os.environ, "PATH": f"{shim_bin}:{os.environ['PATH']}"}
+    env.pop("REDACTION_EXTRA_PATTERNS", None)
+    env.pop("REDACTION_REQUIRE_EXTRA", None)
+
+    result = subprocess.run(
+        ["bash", str(repo / "scripts" / "redaction-scan.sh")],
+        cwd=repo,
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 2, result.stdout + result.stderr
+    assert "engine error, not a finding" in result.stderr
+    assert "OK — 0 findings" not in result.stdout

--- a/tests/test_redaction_scan_engine_validation.py
+++ b/tests/test_redaction_scan_engine_validation.py
@@ -94,3 +94,28 @@ def test_engine_failure_during_scan_is_exit_2_not_silence(tmp_path: Path) -> Non
     assert result.returncode == 2, result.stdout + result.stderr
     assert "engine error, not a finding" in result.stderr
     assert "OK — 0 findings" not in result.stdout
+
+
+def test_unresolvable_range_is_exit_2_not_a_clean_scan(tmp_path: Path) -> None:
+    repo = _repo_with_commits(tmp_path, ["one commit"])
+    env = {**os.environ}
+    env.pop("REDACTION_EXTRA_PATTERNS", None)
+    env.pop("REDACTION_REQUIRE_EXTRA", None)
+
+    result = subprocess.run(
+        [
+            "bash",
+            str(repo / "scripts" / "redaction-scan.sh"),
+            "--range",
+            "0000000000000000000000000000000000000000..HEAD",
+        ],
+        cwd=repo,
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 2, result.stdout + result.stderr
+    assert "range does not resolve" in result.stderr
+    assert "OK" not in result.stdout


### PR DESCRIPTION
Found while live-testing the pre-push hook for #44: a commit-message probe that gitleaks demonstrably catches came back clean whenever organization rules were configured.

## The defect

Two layers, compounding:

1. The organization-rules translator validates each regex with Python's `re`. Python accepts lookarounds; RE2 does not, and gitleaks rejects them by **panicking at config load** (measured: exit 2, `invalid named capture`).
2. Every gitleaks invocation in the scan was wrapped in `|| true`, so the panic was swallowed, no report was written, and the summary printed `OK — 0 findings (org-rules=10)`.

Net effect: since the engine swap (#32), every local scan with organization rules configured scanned nothing while reporting the rules as loaded. CI's committed-rules scan was unaffected (no org rules there), which is why nothing red ever surfaced.

## The fix

- The merged config is proven against the actual engine before anything is scanned: one canary line through `gitleaks stdin`. On failure the scan exits 2 and names the offending rule **ids** by isolating each rule — never the patterns, which are what the rules file protects.
- `scan_path` and `scan_commit_messages` treat nonzero gitleaks exits as engine errors and exit 2. With `--exit-code 0`, findings exit 0, so nonzero never means a finding.

## Verified

- Broken-rules path: exit 2 naming both synthetic rule ids, pattern text absent from output (pinned by test).
- Engine-death path: a gitleaks shim that dies on scan → exit 2, no `OK` line (pinned by test).
- Live on this host after rewriting the two local rules to RE2 form: full scan green **and actually scanning** — a planted token in a commit message and a planted org identifier both exit 1.

## Gates

- suite: 418 passed, 1 skipped, 13 subtests (two new)
- redaction-scan with org rules: OK, 0 findings, org-rules=10 — now a claim the engine backs
- inventory: 249 = baseline

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes scans turning green while scanning nothing when org rules compile in Python but not in `gitleaks` (RE2). We now validate the merged config against `gitleaks`, fail closed on engine errors or unresolved ranges, and stop minting inventory candidates from two comment words.

- **Bug Fixes**
  - Validate the merged config with a `gitleaks stdin` canary; on failure, exit 2 and list offending rule IDs only (never patterns). Per‑rule isolation uses one Python pass; tests pin this and skip without `gitleaks`.
  - Treat any nonzero `gitleaks` exit in file and commit‑message scans as an engine error and exit 2; with `--exit-code 0`, real findings still exit 0.
  - A `--range` or commit‑message range that doesn’t resolve now exits 2 up front to avoid “OK” with zero files/messages.
  - Stop minting inventory candidates from two comment words.

- **Migration**
  - Rewrite org rules that use lookarounds or other non‑RE2 constructs to RE2‑compatible regexes.

<sup>Written for commit c046c6b19e4c8c987bc3b751cfcfc20db1c50808. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/baksohyeon/mogui-ADE-orchestrator/pull/45?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

