### PR TITLE
changelog: the CI entry belongs to Unreleased, where it was written

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,18 @@ you build on it.
 
 ## [Unreleased]
 
+### Added
+
+- CI: `.github/workflows/gates.yml` runs the test suite (ubuntu and macos,
+  Python 3.12, checksum pinned gitleaks) and the committed ruleset redaction
+  scan on every pull request and push to main. What CI cannot cover is stated
+  in the workflow header: the organization rules live outside the repository,
+  so the full scan stays local. The inventory runs informationally.
+- An opt-in pre-push hook (`hooks/pre-push`, enable with
+  `git config core.hooksPath hooks`) scans each pushed ref range, covering
+  changed files and commit messages both, with a tracked tree fallback when no
+  range resolves.
+
 ### Fixed
 
 - Organization rules are proven against the engine that runs them. Python's
@@ -84,17 +96,6 @@ shipped in that tag but were recorded under Unreleased at the time; they are
 restored to their release here. The template's changes for the same tag are
 in `master-ops/CHANGELOG.md`.
 
-### Added
-
-- CI: `.github/workflows/gates.yml` runs the test suite (ubuntu and macos,
-  Python 3.12, checksum pinned gitleaks) and the committed ruleset redaction
-  scan on every pull request and push to main. What CI cannot cover is stated
-  in the workflow header: the organization rules live outside the repository,
-  so the full scan stays local. The inventory runs informationally.
-- An opt-in pre-push hook (`hooks/pre-push`, enable with
-  `git config core.hooksPath hooks`) scans each pushed ref range, covering
-  changed files and commit messages both, with a tracked tree fallback when no
-  range resolves.
 
 ### Added
 


### PR DESCRIPTION
The #44 squash auto-merged the CI/hook entry into the retroactive [0.2.0] section (its surrounding lines matched the merge context). This moves the block back under [Unreleased], wording untouched. Structure verified: Unreleased carries Added+Fixed, 0.2.0 carries its own two entries again.

Gates: scan OK 0 findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixed CHANGELOG placement: moved the CI workflow and opt-in pre-push hook entries back under [Unreleased] and out of [0.2.0]. No wording changes; only section relocation to restore correct release structure.

<sup>Written for commit cfc1871fd30a00b75d2cfcb66bf848418da71590. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/baksohyeon/mogui-ADE-orchestrator/pull/46?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

