### PR TITLE
docs: Step 1 handles repositories outside the workspace root explicitly

### DIFF
--- a/master-ops/CHANGELOG.md
+++ b/master-ops/CHANGELOG.md
@@ -41,6 +41,16 @@ installation was taken from alongside the tag.
 
 ## Unreleased
 
+Step 1 stops leaving outside repositories implicit. When the user names a
+repository that lives outside the confirmed workspace root, the installer asks
+which home it gets: moved or cloned under the root (recommended when the master
+will route real work into it, since the inventory and workspace-level code
+measurement only see what lives under the root) or recorded as an external
+lane, staying put with its absolute path and access rules in the operations
+document. The installer never moves repositories itself, and the step's
+verification now requires every named outside repository to end up in one of
+the two homes.
+
 The master's seat moves to the workspace level. Step 3.5 previously prescribed
 the ops repository worktree and forbade the folder route as unverified; the
 folder route is now verified from the CLI (`id:folder:<uuid>` passes precheck

--- a/master-ops/ONBOARDING.md
+++ b/master-ops/ONBOARDING.md
@@ -116,7 +116,7 @@ Read current files first, detect immediate child repositories, read the measured
 When the user names a repository that lives outside the confirmed workspace root, ask which of two homes it gets, and explain why the question matters: the master holds the repository inventory (`{{REPO_LIST}}`) and measures code across it (for example through a review graph indexed at the workspace root), so a repository outside the root is invisible to that measurement and fragments the sidebar in Orca. The two homes:
 
 - Move or clone it under the workspace root (recommend this when the master will route real work into it); then it joins `{{REPO_LIST}}` as an ordinary member.
-- Record it as an external lane: it stays where it is, enters the operations document by absolute path with its access rules (who may write, which gates run before pushing), and the master treats every claim about it as needing its own measurement, because none of the workspace-level tooling sees it. Repositories that legitimately stay outside exist — a public open-source lane or another owner's checkout — so this is a real choice, not a formality.
+- Record it as an external lane: it stays where it is, enters the operations document by absolute path with its access rules (who may write, which gates run before pushing), and the master treats every claim about it as needing its own measurement, because none of the workspace-level tooling sees it. Repositories that legitimately stay outside exist — a public lane maintained for open source or another owner's checkout — so this is a real choice, not a formality.
 
 Do not move anything yourself; moving repositories is the user's action.
 

--- a/master-ops/ONBOARDING.md
+++ b/master-ops/ONBOARDING.md
@@ -113,11 +113,19 @@ ls -la "$WORKSPACE_ROOT"
 
 Read current files first, detect immediate child repositories, read the measured list back for confirmation or exclusions, and ask again rather than inventing uncertain values.
 
+When the user names a repository that lives outside the confirmed workspace root, ask which of two homes it gets, and explain why the question matters: the master holds the repository inventory (`{{REPO_LIST}}`) and measures code across it (for example through a review graph indexed at the workspace root), so a repository outside the root is invisible to that measurement and fragments the sidebar in Orca. The two homes:
+
+- Move or clone it under the workspace root (recommend this when the master will route real work into it); then it joins `{{REPO_LIST}}` as an ordinary member.
+- Record it as an external lane: it stays where it is, enters the operations document by absolute path with its access rules (who may write, which gates run before pushing), and the master treats every claim about it as needing its own measurement, because none of the workspace-level tooling sees it. Repositories that legitimately stay outside exist — a public open-source lane or another owner's checkout — so this is a real choice, not a formality.
+
+Do not move anything yourself; moving repositories is the user's action.
+
 Verify:
 
 - `{{WORKSPACE_ROOT}}` is absolute and exists
 - `{{WORKSPACE_NAME}}` is explicit or is the confirmed root basename approved by the user
 - `{{REPO_LIST}}` matches measured repositories after user confirmation
+- every repository the user named that lives outside the root is either moved/cloned in by the user or recorded as an external lane with access rules; none is left implicit
 
 ## Step 2. Choose The Ops Repository
 


### PR DESCRIPTION
## Why

The master's repository inventory and workspace-level code measurement (review graph indexed at the root) only see repositories under the workspace root. A repository the user names but leaves outside the root today ends up implicit: orchestratable, but invisible to measurement and fragmented in the Orca sidebar. A real workspace runs exactly this shape (an open-source lane outside the root) and it works only because it is explicitly treated as an external lane.

## What

Step 1 gains a branch: an outside repository is either moved/cloned under the root by the user (recommended when real work routes into it) or recorded as an external lane with absolute path and access rules. The installer never moves repositories itself. Step verification requires every named outside repository to land in one of the two homes. Template changelog updated.

## Gates

pytest 426 passed 1 skipped; redaction scan 0 findings; inventory at baseline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Step 1 now prompts for a home for repos outside the workspace root. Users must move/clone them under the root or record them as external lanes with absolute paths and access rules; the installer never moves repos, verification enforces this, and docs clarify the measurement impact to keep the inventory baseline unchanged.

<sup>Written for commit 9297215f480055262e56a70a415decc5bf850e12. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/baksohyeon/mogui-ADE-orchestrator/pull/49?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

