### PR TITLE
feat: warn when organization rules carry no native script pattern

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,12 @@ you build on it.
 
 ### Added
 
+- The scan warns when organization rules contain no native script pattern:
+  a rule set that spells an identifier only in its romanized form misses the
+  same identifier in its native spelling (measured live with a Korean name).
+  The warning fires only when organization rules are loaded, and never prints
+  rule content.
+
 - `master-succeed spawn --expected-placement <worktreeId>`: after the existing
   requested versus actual check, the spawn verifies the actual worktree against
   an independently supplied expected placement and fails closed with a new exit

--- a/scripts/redaction-scan.sh
+++ b/scripts/redaction-scan.sh
@@ -142,12 +142,14 @@ with open(target, "w", encoding="utf-8") as out:
         out.write('description = "%s"\n' % description.replace('"', ""))
         out.write("regex = '''%s'''\n\n" % regex)
 
+native = sum(1 for _, _, regex in rules if any(ord(ch) > 127 for ch in regex))
+
 # Counts only. This file's contents are what the scan protects, so nothing from it
 # is printed here or anywhere else.
-print(f"{len(rules)} {unusable} {considered}")
+print(f"{len(rules)} {unusable} {considered} {native}")
 PY
   then
-    read -r EXTRA_RULE_COUNT EXTRA_UNUSABLE EXTRA_CONSIDERED < "${WORK_DIR}/counts"
+    read -r EXTRA_RULE_COUNT EXTRA_UNUSABLE EXTRA_CONSIDERED EXTRA_NATIVE < "${WORK_DIR}/counts"
   else
     echo "redaction-scan: FAIL — could not read the organization rules file" >&2
     exit 2
@@ -162,6 +164,12 @@ PY
   fi
   if [[ "${EXTRA_UNUSABLE}" -gt 0 ]]; then
     echo "redaction-scan: WARNING — ${EXTRA_UNUSABLE} of ${EXTRA_CONSIDERED} organization rule lines are unusable and were skipped" >&2
+  fi
+  if [[ "${EXTRA_RULE_COUNT}" -gt 0 && "${EXTRA_NATIVE:-0}" -eq 0 ]]; then
+    # A romanization only rule set misses the same identifier in its native
+    # spelling; measured live when a Korean name passed a scan whose rules
+    # only knew its romanization.
+    echo "redaction-scan: WARNING — organization rules contain no native script pattern; romanization only identifier rules miss native spellings" >&2
   fi
 fi
 

--- a/scripts/redaction-scan.sh
+++ b/scripts/redaction-scan.sh
@@ -142,23 +142,13 @@ with open(target, "w", encoding="utf-8") as out:
         out.write('description = "%s"\n' % description.replace('"', ""))
         out.write("regex = '''%s'''\n\n" % regex)
 
-_escape_hex = re.compile(r"\\u([0-9a-fA-F]{4})|\\U([0-9a-fA-F]{8})|\\x([0-9a-fA-F]{2})")
-_native_property = re.compile(
-    r"\\p\{(?:Han|Hangul|Hiragana|Katakana|Cyrillic|Arabic|Hebrew|Thai|Devanagari|Greek|Hangeul)\}"
+# Only literal characters can express native script in a rule that actually
+# scans: this loader's re.compile gate rejects RE2's brace and property forms
+# (backslash x brace, backslash p brace), and the engine canary rejects
+# Python's backslash u form, so no escape spelling survives both gates.
+native = sum(
+    1 for _, _, regex in rules if any(ord(ch) > 127 for ch in regex)
 )
-
-
-def _regex_has_native(regex):
-    if any(ord(ch) > 127 for ch in regex):
-        return True
-    for match in _escape_hex.finditer(regex):
-        digits = next(group for group in match.groups() if group)
-        if int(digits, 16) > 127:
-            return True
-    return bool(_native_property.search(regex))
-
-
-native = sum(1 for _, _, regex in rules if _regex_has_native(regex))
 
 # Counts only. This file's contents are what the scan protects, so nothing from it
 # is printed here or anywhere else.

--- a/scripts/redaction-scan.sh
+++ b/scripts/redaction-scan.sh
@@ -142,7 +142,7 @@ with open(target, "w", encoding="utf-8") as out:
         out.write('description = "%s"\n' % description.replace('"', ""))
         out.write("regex = '''%s'''\n\n" % regex)
 
-_escape_hex = re.compile(r"\\u([0-9a-fA-F]{4})|\\U([0-9a-fA-F]{8})|\\x\{([0-9a-fA-F]+)\}")
+_escape_hex = re.compile(r"\\u([0-9a-fA-F]{4})|\\U([0-9a-fA-F]{8})|\\x([0-9a-fA-F]{2})")
 _native_property = re.compile(
     r"\\p\{(?:Han|Hangul|Hiragana|Katakana|Cyrillic|Arabic|Hebrew|Thai|Devanagari|Greek|Hangeul)\}"
 )

--- a/scripts/redaction-scan.sh
+++ b/scripts/redaction-scan.sh
@@ -142,7 +142,12 @@ with open(target, "w", encoding="utf-8") as out:
         out.write('description = "%s"\n' % description.replace('"', ""))
         out.write("regex = '''%s'''\n\n" % regex)
 
-native = sum(1 for _, _, regex in rules if any(ord(ch) > 127 for ch in regex))
+_native_escape = re.compile(r"\\u[0-9a-fA-F]{4}|\\U[0-9a-fA-F]{8}|\\x\{[0-9a-fA-F]+\}|\\N\{")
+native = sum(
+    1
+    for _, _, regex in rules
+    if any(ord(ch) > 127 for ch in regex) or _native_escape.search(regex)
+)
 
 # Counts only. This file's contents are what the scan protects, so nothing from it
 # is printed here or anywhere else.

--- a/scripts/redaction-scan.sh
+++ b/scripts/redaction-scan.sh
@@ -142,12 +142,23 @@ with open(target, "w", encoding="utf-8") as out:
         out.write('description = "%s"\n' % description.replace('"', ""))
         out.write("regex = '''%s'''\n\n" % regex)
 
-_native_escape = re.compile(r"\\u[0-9a-fA-F]{4}|\\U[0-9a-fA-F]{8}|\\x\{[0-9a-fA-F]+\}|\\N\{")
-native = sum(
-    1
-    for _, _, regex in rules
-    if any(ord(ch) > 127 for ch in regex) or _native_escape.search(regex)
+_escape_hex = re.compile(r"\\u([0-9a-fA-F]{4})|\\U([0-9a-fA-F]{8})|\\x\{([0-9a-fA-F]+)\}")
+_native_property = re.compile(
+    r"\\p\{(?:Han|Hangul|Hiragana|Katakana|Cyrillic|Arabic|Hebrew|Thai|Devanagari|Greek|Hangeul)\}"
 )
+
+
+def _regex_has_native(regex):
+    if any(ord(ch) > 127 for ch in regex):
+        return True
+    for match in _escape_hex.finditer(regex):
+        digits = next(group for group in match.groups() if group)
+        if int(digits, 16) > 127:
+            return True
+    return bool(_native_property.search(regex))
+
+
+native = sum(1 for _, _, regex in rules if _regex_has_native(regex))
 
 # Counts only. This file's contents are what the scan protects, so nothing from it
 # is printed here or anywhere else.

--- a/tests/test_redaction_scan_native_script.py
+++ b/tests/test_redaction_scan_native_script.py
@@ -1,0 +1,72 @@
+"""Romanized-only organization rules get a warning.
+
+A rule set that spells an identifier only in its romanized form misses the
+same identifier in its native spelling; measured live when a Korean name
+passed a scan whose rules only knew its romanization. The scan cannot know
+the missing name, but it can see that no loaded rule contains a single
+character outside ASCII and say so.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+from pathlib import Path
+
+from test_redaction_scan_commit_messages import _repo_with_commits
+
+WARNING = "organization rules contain no native script pattern"
+
+
+def _scan_with_extra(repo: Path, extra: Path) -> subprocess.CompletedProcess:
+    env = {**os.environ, "REDACTION_EXTRA_PATTERNS": str(extra)}
+    env.pop("REDACTION_REQUIRE_EXTRA", None)
+    return subprocess.run(
+        ["bash", str(repo / "scripts" / "redaction-scan.sh")],
+        cwd=repo,
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+def test_romanized_only_rules_warn(tmp_path: Path) -> None:
+    repo = _repo_with_commits(tmp_path, ["plain change"])
+    extra = tmp_path / "extra.txt"
+    extra.write_text(
+        "person_x|Personal identifier|(?i)romanizedname\n",
+        encoding="utf-8",
+    )
+    result = _scan_with_extra(repo, extra)
+    assert WARNING in result.stderr
+    assert result.returncode == 0
+
+
+def test_native_script_rule_silences_warning(tmp_path: Path) -> None:
+    repo = _repo_with_commits(tmp_path, ["plain change"])
+    extra = tmp_path / "extra.txt"
+    extra.write_text(
+        "person_x|Personal identifier|(?i)romanizedname\n"
+        "person_x_ko|Personal identifier native|가나다\n",
+        encoding="utf-8",
+    )
+    result = _scan_with_extra(repo, extra)
+    assert WARNING not in result.stderr
+    assert result.returncode == 0
+
+
+def test_no_org_rules_means_no_native_warning(tmp_path: Path) -> None:
+    repo = _repo_with_commits(tmp_path, ["plain change"])
+    env = {**os.environ}
+    env.pop("REDACTION_EXTRA_PATTERNS", None)
+    env.pop("REDACTION_REQUIRE_EXTRA", None)
+    result = subprocess.run(
+        ["bash", str(repo / "scripts" / "redaction-scan.sh")],
+        cwd=repo,
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert WARNING not in result.stderr

--- a/tests/test_redaction_scan_native_script.py
+++ b/tests/test_redaction_scan_native_script.py
@@ -70,3 +70,15 @@ def test_no_org_rules_means_no_native_warning(tmp_path: Path) -> None:
         check=False,
     )
     assert WARNING not in result.stderr
+
+
+def test_escaped_native_range_silences_warning(tmp_path: Path) -> None:
+    repo = _repo_with_commits(tmp_path, ["plain change"])
+    extra = tmp_path / "extra.txt"
+    extra.write_text(
+        "person_x|Personal identifier|(?i)romanizedname\n"
+        "person_x_native|Personal identifier native|[\\uac00-\\ud7af]{2,4}\n",
+        encoding="utf-8",
+    )
+    result = _scan_with_extra(repo, extra)
+    assert WARNING not in result.stderr

--- a/tests/test_redaction_scan_native_script.py
+++ b/tests/test_redaction_scan_native_script.py
@@ -1,10 +1,17 @@
-"""Romanized-only organization rules get a warning.
+"""Romanization only organization rules get a warning.
 
 A rule set that spells an identifier only in its romanized form misses the
 same identifier in its native spelling; measured live when a Korean name
 passed a scan whose rules only knew its romanization. The scan cannot know
 the missing name, but it can see that no loaded rule contains a single
 character outside ASCII and say so.
+
+The detector reads literal characters only, and that is not a shortcut: no
+escape spelling of a native codepoint survives this pipeline. The loader's
+`re.compile` gate drops RE2's brace and property forms as unusable, and the
+engine canary exits 2 on Python's backslash-u form before anything scans.
+Two tests below pin those exclusions so a future escape-detection "fix"
+has to reckon with them.
 """
 
 from __future__ import annotations
@@ -39,8 +46,8 @@ def test_romanized_only_rules_warn(tmp_path: Path) -> None:
         encoding="utf-8",
     )
     result = _scan_with_extra(repo, extra)
-    assert WARNING in result.stderr
     assert result.returncode == 0
+    assert WARNING in result.stderr
 
 
 def test_native_script_rule_silences_warning(tmp_path: Path) -> None:
@@ -52,8 +59,8 @@ def test_native_script_rule_silences_warning(tmp_path: Path) -> None:
         encoding="utf-8",
     )
     result = _scan_with_extra(repo, extra)
-    assert WARNING not in result.stderr
     assert result.returncode == 0
+    assert WARNING not in result.stderr
 
 
 def test_no_org_rules_means_no_native_warning(tmp_path: Path) -> None:
@@ -69,38 +76,30 @@ def test_no_org_rules_means_no_native_warning(tmp_path: Path) -> None:
         text=True,
         check=False,
     )
+    assert result.returncode == 0
     assert WARNING not in result.stderr
 
 
-def test_escaped_native_range_silences_warning(tmp_path: Path) -> None:
+def test_python_u_escape_rule_dies_at_the_engine_canary(tmp_path: Path) -> None:
     repo = _repo_with_commits(tmp_path, ["plain change"])
     extra = tmp_path / "extra.txt"
     extra.write_text(
-        "person_x|Personal identifier|(?i)romanizedname\n"
         "person_x_native|Personal identifier native|[\\uac00-\\ud7af]{2,4}\n",
         encoding="utf-8",
     )
     result = _scan_with_extra(repo, extra)
-    assert WARNING not in result.stderr
+    assert result.returncode == 2
 
 
-def test_escaped_ascii_codepoints_still_warn(tmp_path: Path) -> None:
+def test_property_class_rule_is_dropped_as_unusable(tmp_path: Path) -> None:
     repo = _repo_with_commits(tmp_path, ["plain change"])
     extra = tmp_path / "extra.txt"
     extra.write_text(
-        "person_x|Personal identifier|(?i)\\u0041\\u0042name\n",
-        encoding="utf-8",
-    )
-    result = _scan_with_extra(repo, extra)
-    assert WARNING in result.stderr
-
-
-def test_unicode_property_class_silences_warning(tmp_path: Path) -> None:
-    repo = _repo_with_commits(tmp_path, ["plain change"])
-    extra = tmp_path / "extra.txt"
-    extra.write_text(
+        "person_x|Personal identifier|(?i)romanizedname\n"
         "person_x_native|Personal identifier native|\\p{Hangul}{2,4}\n",
         encoding="utf-8",
     )
     result = _scan_with_extra(repo, extra)
-    assert WARNING not in result.stderr
+    assert result.returncode == 0
+    assert "1 of 2 organization rule lines are unusable" in result.stderr
+    assert WARNING in result.stderr

--- a/tests/test_redaction_scan_native_script.py
+++ b/tests/test_redaction_scan_native_script.py
@@ -82,3 +82,25 @@ def test_escaped_native_range_silences_warning(tmp_path: Path) -> None:
     )
     result = _scan_with_extra(repo, extra)
     assert WARNING not in result.stderr
+
+
+def test_escaped_ascii_codepoints_still_warn(tmp_path: Path) -> None:
+    repo = _repo_with_commits(tmp_path, ["plain change"])
+    extra = tmp_path / "extra.txt"
+    extra.write_text(
+        "person_x|Personal identifier|(?i)\\u0041\\u0042name\n",
+        encoding="utf-8",
+    )
+    result = _scan_with_extra(repo, extra)
+    assert WARNING in result.stderr
+
+
+def test_unicode_property_class_silences_warning(tmp_path: Path) -> None:
+    repo = _repo_with_commits(tmp_path, ["plain change"])
+    extra = tmp_path / "extra.txt"
+    extra.write_text(
+        "person_x_native|Personal identifier native|\\p{Hangul}{2,4}\n",
+        encoding="utf-8",
+    )
+    result = _scan_with_extra(repo, extra)
+    assert WARNING not in result.stderr

--- a/tests/test_redaction_scan_native_script.py
+++ b/tests/test_redaction_scan_native_script.py
@@ -89,6 +89,8 @@ def test_python_u_escape_rule_dies_at_the_engine_canary(tmp_path: Path) -> None:
     )
     result = _scan_with_extra(repo, extra)
     assert result.returncode == 2
+    assert "not supported by RE2" in result.stderr
+    assert "person_x_native" in result.stderr
 
 
 def test_property_class_rule_is_dropped_as_unusable(tmp_path: Path) -> None:


### PR DESCRIPTION
## Why

A personal identifier rule that exists only in romanized form misses the same identifier in its native spelling. Measured live: a Korean name passed every scan for two master generations because the org rules only knew its romanization.

## What

When organization rules load, the scan counts rules whose regex contains any character outside ASCII and warns (stderr, informational, exit unchanged) when the count is zero. The warning names the class of gap without printing any rule content. Three tests cover: warning on a romanization only rule set, silence when a native script rule exists, silence when no org rules are loaded.

## Gates

pytest 432 passed 1 skipped; redaction scan 0 findings (live org rules carry a native rule, so the warning correctly stays silent); inventory at baseline 257.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Warns when organization redaction rules include no native script patterns, so romanization-only rules don’t miss identifiers in their native spelling. No rule content is printed and the scan exit code is unchanged.

- **New Features**
  - In `scripts/redaction-scan.sh`, counts native coverage by detecting literal non-ASCII characters in rule regex; escapes don’t count because RE2 brace/property forms are rejected and Python `\u` fails at the engine canary. Adds a fourth internal count (native) used only by the script and warns only when org rules load and native count is zero.
  - Tests cover romanized-only warns, literal native silences, no org rules silences, `\u` range dies at the canary, and `\p{...}` is dropped as unusable; the canary test now anchors on the engine error message.

<sup>Written for commit b718cac27d492968828e5ec67c34c6c2e8d745fb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/baksohyeon/mogui-ADE-orchestrator/pull/50?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a warning when organization rules contain no native-script patterns, helping identify cases where native spellings may be missed.
  * Recognizes literal characters, escaped ranges, and supported Unicode properties when determining native-script coverage.
  * Warnings avoid exposing the contents of organization rules.

* **Documentation**
  * Added an Unreleased changelog entry describing the new warning behavior.

* **Tests**
  * Added coverage for romanized-only, escaped, native-script, Unicode-property, and empty-rule scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->