### PR TITLE
docs: retirement is three measured disappearances, and frozen sessions can be revived

### DIFF
--- a/docs/public/master-lifecycle.md
+++ b/docs/public/master-lifecycle.md
@@ -137,6 +137,8 @@ scripts/master-succeed retire \
 
 Add `--execute` only when the operator intends to close the predecessor terminal.
 
+Retiring a predecessor ends with three measured disappearances, never with a close command's return value: process, host pane, and tty. A frozen session also stays resumable forever from any terminal its agent CLI runs in, phones and remote machines included, so the boot card adds a revival check: scan running agent processes for lineage session ids (the session id is the portable key; resume flags differ per CLI), recover any unanswered owner instruction from a revived session, then take the revival through the same three disappearances. Four retired masters revived at once by a mobile resume is the measured incident behind the rule (2026-08-03).
+
 Early planned successions changed the procedure. One handoff described the predecessor as gone while the process was still alive, so runtime state is now checked separately from handoff text. Later successions added command-line and session-path matching before retirement, plus explicit cleanup and restart of monitors under the successor's ownership. A clean succession is therefore not only "the successor read the handoff"; it is a measured transfer of role, track, process ownership, and verification responsibility.
 
 ## Lineage

--- a/docs/public/orca-concepts.md
+++ b/docs/public/orca-concepts.md
@@ -48,6 +48,10 @@ Two rules fall out:
 
 **Empty `worktreePath`** in `orca terminal list --json` output is the same fact from the CLI side: folder workspaces report a `worktreeId` of `folder:<uuid>` and an empty path. Judge placement by `worktreeId`, not by the path field or by the repository name shown in a pane's status line, which only reflects the shell's cwd.
 
+## Beyond This Machine
+
+Orca sessions are not bound to the desk they started on: the docs snapshot covers SSH remote worktrees (remote repo registration, relay grace periods, remote PTY leases), headless `orca serve` with pairing to a remote runtime, and a mobile companion app. Two consequences matter for this runtime. A frozen master session can be reopened from a phone, which is why retirement is only complete when process, pane, and tty are all measured gone and why boot includes a revival check. And a repository on a remote machine is observable only through its git remote and forge state, so claims about it need their own measurement.
+
 ## Where To Learn More
 
 Agents should ground further Orca claims in the Orca docs snapshot (agent index first) linked from the README rather than improvising. Humans can start at the [Orca site](https://www.onorca.dev/); the onboarding flow in `master-ops/ONBOARDING.md` also answers Orca questions in place during installation.

--- a/master-ops/CHANGELOG.md
+++ b/master-ops/CHANGELOG.md
@@ -41,6 +41,16 @@ installation was taken from alongside the tag.
 
 ## Unreleased
 
+Retirement gets a completion criterion and a revival check. Complete means
+three measured disappearances (process, pane, tty), never a close command's
+return value, which has been wrong in both directions on real hosts. Frozen
+sessions stay resumable forever from any terminal the agent CLI runs in,
+phones included; four retired masters revived at once by a mobile resume is
+the measured incident. The boot card now scans running agent processes for
+lineage session ids (the session id is the portable key, since resume flags
+differ per agent CLI), recovers unanswered owner instructions from revivals,
+and takes them through the same three disappearances.
+
 Step 1 stops leaving outside repositories implicit. When the user names a
 repository that lives outside the confirmed workspace root, the installer asks
 which home it gets: moved or cloned under the root (recommended when the master

--- a/master-ops/docs/runbooks/succession-boot-card.md
+++ b/master-ops/docs/runbooks/succession-boot-card.md
@@ -23,6 +23,15 @@ Placement evidence three-set:
 2. process current working directory is under `{{WORKSPACE_ROOT}}`
 3. session artifact or log path belongs to the expected workspace/session namespace
 
+## Retirement Completion And Revival Checks
+
+Retirement of a session is complete only when three disappearances are measured, not when a close command returns: the process (pid gone), the host pane (no live handle in the host's terminal list), and the tty (device and login chain gone). Close command return values have been wrong in both directions on real hosts; the measurement decides.
+
+A frozen session stays resumable forever, from any terminal the agent CLI runs in, including a phone or a remote machine. Measured live: four retired masters were revived at once by a mobile resume, attached to ttys outside the host runtime where pane doctrine cannot see them. Therefore:
+
+- At boot, and whenever the owner reports stray sessions, scan running agent processes for the session ids recorded in `docs/lineage/MASTER-LINEAGE.md`. Resume arguments differ per agent CLI, so the key is the session id itself in the process argv, not any one CLI's flag.
+- On a hit, in order: read the revived session's own record for activity since freezing (tool calls, repository writes); recover any unanswered owner instruction into the current master; terminate the agent process; hang up the hosting terminal chain; confirm the tty is gone. A shell with other children gets its children measured first.
+
 ## Accident Recovery
 
 Process death, host restart, stale UI handle, or accidental pane closure is not succession. First try same-session resume after proving no live duplicate process owns the session. If host runtime state is stale, recover the host, reacquire the handle, and verify connected state before continuing.


### PR DESCRIPTION
## Why

Killing a master's process is not the end of it. Measured live (2026-08-03): four retired masters were revived at once by a mobile resume, attached to ttys outside the host runtime where pane doctrine cannot see them; separately, close commands have returned wrong results in both directions across three successions.

## What

- Template succession boot card: retirement completion = three measured disappearances (process, pane, tty); a revival check keyed by lineage session ids in agent process argv (agent neutral — resume flags differ per CLI, the session id is the portable key); recovery of unanswered owner instructions from revivals before teardown.
- Lifecycle page: the same doctrine in the Clean Succession section.
- Orca concepts guide: a Beyond This Machine section grounding the remote reach (SSH remote worktrees, headless serve with pairing, mobile companion — pages verified in the docs snapshot) and its two consequences for this runtime.
- Template changelog entry.

No code changes; the check is deliberately a procedure, not new machinery.

## Gates

pytest 429 passed 1 skipped; redaction scan 0 findings; inventory at baseline 257.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clarifies retirement completion as “three measured disappearances” (process, pane, tty) and adds a revival check to prevent frozen sessions from returning after close. Also documents Orca’s remote reach and updates the lifecycle runbook.

- **New Features**
  - Define retirement completion: process, pane, and tty must be gone; do not trust close command return values.
  - Add revival check at boot: scan running agent processes for lineage session ids, recover any pending owner instruction, then terminate and clear the tty.
  - Document remote reach in Orca concepts (SSH remote worktrees, headless `orca serve` with pairing, mobile companion) and its impact on retirement and measurement.
  - Update lifecycle page, succession boot card, and changelog.

<sup>Written for commit 4e6c14a128fcf5d6bcd267a837f9d72c16a9f197. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/baksohyeon/mogui-ADE-orchestrator/pull/51?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

