### PR TITLE
docs: audit tools name their transcript schema and report unsupported agents honestly

### DIFF
--- a/docs/public/master-lifecycle.md
+++ b/docs/public/master-lifecycle.md
@@ -59,6 +59,8 @@ scripts/model-identity-probe \
 
 If the host cannot expose a measured model field, report that as unavailable. Do not infer the actual model from a launch flag.
 
+The same rule covers agents these tools cannot read. The transcript walkers parse the session record schema they were built against (Claude Code's JSONL under its projects directory); Codex, for one, stores sessions under its own directory in a different shape. An agent whose transcript the tool cannot parse is reported as unsupported, never guessed. Across agents the portable session key is the session id in process argv, which is what the revival check in the succession card relies on, not any one CLI's transcript format.
+
 That probe samples recent turns, so it answers what the model is now. It does not answer whether the model changed earlier in the session, and a tail sample reads clean whenever the tail is homogeneous. For that question, walk the whole transcript:
 
 ```bash

--- a/docs/public/master-lifecycle.md
+++ b/docs/public/master-lifecycle.md
@@ -59,7 +59,7 @@ scripts/model-identity-probe \
 
 If the host cannot expose a measured model field, report that as unavailable. Do not infer the actual model from a launch flag.
 
-The same rule covers agents these tools cannot read. The transcript walkers parse the session record schema they were built against (Claude Code's JSONL under its projects directory); Codex, for one, stores sessions under its own directory in a different shape. An agent whose transcript the tool cannot parse is reported as unsupported, never guessed. Across agents the portable session key is the session id in process argv, which is what the revival check in the succession card relies on, not any one CLI's transcript format.
+The same rule covers agents these tools cannot read. The transcript walkers parse the session record schema they were built against (Claude Code's JSONL under its projects directory); Codex, for one, stores sessions under its own directory in a different shape. An agent whose transcript the tool cannot parse comes back as exit 2, undecidable, the same refusal the tools give any unreadable input; the master then reports the agent as unsupported instead of guessing, which is the operating rule the Step 9 wording (measured, unavailable, or unsupported) already sets for humans. Across agents the portable session key is the session id in process argv, which is what the revival check in the succession card relies on, not any one CLI's transcript format.
 
 That probe samples recent turns, so it answers what the model is now. It does not answer whether the model changed earlier in the session, and a tail sample reads clean whenever the tail is homogeneous. For that question, walk the whole transcript:
 


### PR DESCRIPTION
One paragraph in the lifecycle page: the transcript walkers parse the Claude Code session schema they were built against; an agent whose transcript they cannot parse is reported as unsupported, never guessed, extending the existing unavailable rule. The portable key across agent CLIs is the session id in process argv, which the succession card's revival check already relies on. Closes the documentation half of the agent compatibility track; the owner ruled out code additions (YAGNI, a capable master reports honestly instead of being fenced).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clarifies audit tool docs: transcript walkers only parse the schemas they support (e.g., `Claude Code` JSONL) and exit 2 (undecidable) on unreadable transcripts; the master reports those agents as unsupported, never guessed. Notes the cross‑agent key is the session id in process argv, used by the succession card’s revival check, not any CLI’s transcript format.

<sup>Written for commit 5b0b5c1240f68fe6f58897b9299e7cfc9f9b1ec8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/baksohyeon/mogui-ADE-orchestrator/pull/54?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified that transcript parsing depends on the agent.
  * Documented how unsupported transcript formats are reported.
  * Specified the session identifier used by revival checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->