### PR TITLE
fix: register completes sentinel-log dispatches instead of demanding an orchestration record

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,12 @@ you build on it.
 
 ## [Unreleased]
 
+### Fixed
+
+- `dispatch-gate register` accepts a verified `sentinel-log` dispatch without
+  requiring an Orca orchestration record, and records the completion channel in
+  the ledger. `orchestration` dispatches still require Orca verification.
+
 ## [0.4.0] - 2026-08-03
 
 ### Added

--- a/scripts/dispatch-gate
+++ b/scripts/dispatch-gate
@@ -173,6 +173,7 @@ def _register(args: argparse.Namespace) -> int:
         declared_model=args.declared_model,
         measured_model=measured_model,
         model_probe_failed=model_probe_failed,
+        expected_completion_channel=completion_channel,
     )
     _print_decision(decision)
     if decision.allow:

--- a/scripts/dispatch-gate
+++ b/scripts/dispatch-gate
@@ -147,14 +147,24 @@ def _check(args: argparse.Namespace) -> int:
 
 
 def _register(args: argparse.Namespace) -> int:
-    if not args.orchestration_task:
-        return _deny_unverified_orchestration(args, ProbeFailure.TASK_OMITTED)
-    probe_failure = _probe_orchestration_task(args.orchestration_task)
-    if probe_failure is not None:
-        return _deny_unverified_orchestration(args, probe_failure)
+    gate = _gate(args)
+    completion_channel = gate.completion_channel_for_registration(
+        contract_sha=args.contract_sha,
+        runtime=args.runtime,
+    )
+    if completion_channel != "sentinel-log":
+        if not args.orchestration_task:
+            return _deny_unverified_orchestration(
+                args,
+                gate,
+                ProbeFailure.TASK_OMITTED,
+            )
+        probe_failure = _probe_orchestration_task(args.orchestration_task)
+        if probe_failure is not None:
+            return _deny_unverified_orchestration(args, gate, probe_failure)
 
     measured_model, model_probe_failed = _measure_worker_model(args.model_probe_cmd)
-    decision = _gate(args).register_job(
+    decision = gate.register_job(
         args.job_id,
         lambda job_id: _probe_contains_job_id(args.probe_cmd, job_id),
         contract_sha=args.contract_sha,
@@ -465,6 +475,7 @@ def _probe_orchestration_task(orchestration_task: str) -> ProbeFailure | None:
 
 def _deny_unverified_orchestration(
     args: argparse.Namespace,
+    gate: DispatchGate,
     probe_failure: ProbeFailure,
 ) -> int:
     decision = GateDecision(False, ReasonCode.ORCHESTRATION_UNVERIFIED)
@@ -477,7 +488,7 @@ def _deny_unverified_orchestration(
     }
     if args.orchestration_task:
         entry["orchestration_task"] = args.orchestration_task
-    ledger_path = Path(_gate(args).config.ledger_path)
+    ledger_path = Path(gate.config.ledger_path)
     ledger_path.parent.mkdir(parents=True, exist_ok=True)
     with ledger_path.open("a", encoding="utf-8") as ledger:
         ledger.write(json.dumps(entry, sort_keys=True, separators=(",", ":")))

--- a/src/master_runtime/core/dispatch_gate.py
+++ b/src/master_runtime/core/dispatch_gate.py
@@ -397,6 +397,7 @@ class DispatchGate:
         declared_model: str | None = None,
         measured_model: str | None = None,
         model_probe_failed: bool = False,
+        expected_completion_channel: str | None = None,
     ) -> GateDecision:
         """Register a job only after independent probe verification succeeds."""
 
@@ -443,6 +444,23 @@ class DispatchGate:
             assert candidate is not None
             pending = candidate.pending
             selected_ticket = candidate.selected_ticket
+            completion_channel = _string_or_none(pending.get("completion_channel"))
+
+            if (
+                expected_completion_channel is not None
+                and completion_channel != expected_completion_channel
+            ):
+                actual_channel = (
+                    completion_channel if completion_channel is not None else "<none>"
+                )
+                return GateDecision(
+                    False,
+                    ReasonCode.INVALID_REQUEST,
+                    message=(
+                        f"expected_completion_channel={expected_completion_channel} "
+                        f"actual_completion_channel={actual_channel}"
+                    ),
+                )
 
             if contract_sha is not None and selected_ticket is not None:
                 try:
@@ -470,9 +488,7 @@ class DispatchGate:
                 "decision": "ALLOW",
                 "reason": ReasonCode.OK.value,
                 "job_id": job_id,
-                "completion_channel": _string_or_none(
-                    pending.get("completion_channel")
-                ),
+                "completion_channel": completion_channel,
             }
             if orchestration_task is not None:
                 entry["orchestration_task"] = orchestration_task

--- a/src/master_runtime/core/dispatch_gate.py
+++ b/src/master_runtime/core/dispatch_gate.py
@@ -144,6 +144,14 @@ class DispatchTicket:
 
 
 @dataclass(frozen=True)
+class RegistrationCandidate:
+    """Pending dispatch selected for registration."""
+
+    pending: Mapping[str, object]
+    selected_ticket: DispatchTicket | None
+
+
+@dataclass(frozen=True)
 class ModelTierPolicy:
     """Validated per-installation worker model policy.
 
@@ -426,90 +434,15 @@ class DispatchGate:
             return GateDecision(False, ReasonCode.INVALID_REQUEST)
 
         with _ticket_lock(Path(self.config.ticket_dir)):
-            tickets = self._valid_dispatch_tickets(runtime_filter=runtime_filter)
-            if contract_sha is not None:
-                contract_sha_filter = _normalize_contract_sha_filter(contract_sha)
-                if contract_sha_filter is None:
-                    return GateDecision(False, ReasonCode.INVALID_REQUEST)
-                all_tickets = self._dispatch_tickets(
-                    runtime_filter=runtime_filter,
-                    include_expired=True,
-                )
-                matching_tickets = tuple(
-                    ticket
-                    for ticket in all_tickets
-                    if ticket.contract_sha.lower().startswith(contract_sha_filter)
-                )
-                if len(matching_tickets) > 1:
-                    return GateDecision(
-                        False,
-                        ReasonCode.AMBIGUOUS_TICKET,
-                        message=_candidate_sha_message(matching_tickets),
-                    )
-                selected_ticket = matching_tickets[0] if matching_tickets else None
-                pending_dispatches = self._pending_dispatches()
-                if selected_ticket is not None:
-                    matching_pending = tuple(
-                        entry
-                        for entry in pending_dispatches
-                        if entry.get("contract_sha") == selected_ticket.contract_sha
-                        and entry.get("runtime") == selected_ticket.runtime
-                    )
-                else:
-                    if all_tickets:
-                        return GateDecision(
-                            False,
-                            ReasonCode.NO_MATCHING_TICKET,
-                            message=_candidate_sha_message(all_tickets),
-                        )
-                    matching_pending = tuple(
-                        entry
-                        for entry in pending_dispatches
-                        if _contract_sha_matches(entry.get("contract_sha"), contract_sha_filter)
-                        and (
-                            runtime_filter is None
-                            or _string_or_none(entry.get("runtime")) == runtime_filter
-                        )
-                    )
-                    if len(matching_pending) > 1:
-                        return GateDecision(
-                            False,
-                            ReasonCode.AMBIGUOUS_TICKET,
-                            message=_candidate_sha_message_from_entries(matching_pending),
-                        )
-                    if not matching_pending:
-                        return GateDecision(
-                            False,
-                            ReasonCode.NO_MATCHING_TICKET,
-                            message=_candidate_sha_message(all_tickets),
-                        )
-            else:
-                if not tickets:
-                    return GateDecision(
-                        False,
-                        ReasonCode.NO_MATCHING_TICKET,
-                        message=_candidate_sha_message(tickets),
-                    )
-                if len(tickets) > 1:
-                    return GateDecision(
-                        False,
-                        ReasonCode.AMBIGUOUS_TICKET,
-                        message=_candidate_sha_message(tickets),
-                    )
-                selected_ticket = tickets[0]
-                matching_pending = tuple(
-                    entry
-                    for entry in self._pending_dispatches()
-                    if entry.get("contract_sha") == selected_ticket.contract_sha
-                    and entry.get("runtime") == selected_ticket.runtime
-                )
-                if not matching_pending:
-                    return GateDecision(
-                        False,
-                        ReasonCode.NO_MATCHING_TICKET,
-                        message=_candidate_sha_message(tickets),
-                    )
-            pending = matching_pending[0]
+            candidate, denial = self._registration_candidate(
+                contract_sha,
+                runtime_filter,
+            )
+            if denial is not None:
+                return denial
+            assert candidate is not None
+            pending = candidate.pending
+            selected_ticket = candidate.selected_ticket
 
             if contract_sha is not None and selected_ticket is not None:
                 try:
@@ -537,6 +470,9 @@ class DispatchGate:
                 "decision": "ALLOW",
                 "reason": ReasonCode.OK.value,
                 "job_id": job_id,
+                "completion_channel": _string_or_none(
+                    pending.get("completion_channel")
+                ),
             }
             if orchestration_task is not None:
                 entry["orchestration_task"] = orchestration_task
@@ -564,6 +500,120 @@ class DispatchGate:
                 tier_override=decision.tier_override,
             )
         return decision
+
+    def completion_channel_for_registration(
+        self,
+        contract_sha: str | None = None,
+        runtime: str | None = None,
+    ) -> str | None:
+        """Return the check channel for the pending dispatch register would use."""
+
+        runtime_filter = _normalize_runtime_filter(runtime)
+        if runtime is not None and runtime_filter is None:
+            return None
+
+        with _ticket_lock(Path(self.config.ticket_dir)):
+            candidate, denial = self._registration_candidate(
+                contract_sha,
+                runtime_filter,
+            )
+        if denial is not None or candidate is None:
+            return None
+        return _string_or_none(candidate.pending.get("completion_channel"))
+
+    def _registration_candidate(
+        self,
+        contract_sha: str | None,
+        runtime_filter: str | None,
+    ) -> tuple[RegistrationCandidate | None, GateDecision | None]:
+        tickets = self._valid_dispatch_tickets(runtime_filter=runtime_filter)
+        if contract_sha is not None:
+            contract_sha_filter = _normalize_contract_sha_filter(contract_sha)
+            if contract_sha_filter is None:
+                return None, GateDecision(False, ReasonCode.INVALID_REQUEST)
+            all_tickets = self._dispatch_tickets(
+                runtime_filter=runtime_filter,
+                include_expired=True,
+            )
+            matching_tickets = tuple(
+                ticket
+                for ticket in all_tickets
+                if ticket.contract_sha.lower().startswith(contract_sha_filter)
+            )
+            if len(matching_tickets) > 1:
+                return None, GateDecision(
+                    False,
+                    ReasonCode.AMBIGUOUS_TICKET,
+                    message=_candidate_sha_message(matching_tickets),
+                )
+            selected_ticket = matching_tickets[0] if matching_tickets else None
+            pending_dispatches = self._pending_dispatches()
+            if selected_ticket is not None:
+                matching_pending = tuple(
+                    entry
+                    for entry in pending_dispatches
+                    if entry.get("contract_sha") == selected_ticket.contract_sha
+                    and entry.get("runtime") == selected_ticket.runtime
+                )
+            else:
+                if all_tickets:
+                    return None, GateDecision(
+                        False,
+                        ReasonCode.NO_MATCHING_TICKET,
+                        message=_candidate_sha_message(all_tickets),
+                    )
+                matching_pending = tuple(
+                    entry
+                    for entry in pending_dispatches
+                    if _contract_sha_matches(
+                        entry.get("contract_sha"),
+                        contract_sha_filter,
+                    )
+                    and (
+                        runtime_filter is None
+                        or _string_or_none(entry.get("runtime")) == runtime_filter
+                    )
+                )
+                if len(matching_pending) > 1:
+                    return None, GateDecision(
+                        False,
+                        ReasonCode.AMBIGUOUS_TICKET,
+                        message=_candidate_sha_message_from_entries(matching_pending),
+                    )
+                if not matching_pending:
+                    return None, GateDecision(
+                        False,
+                        ReasonCode.NO_MATCHING_TICKET,
+                        message=_candidate_sha_message(all_tickets),
+                    )
+        else:
+            if not tickets:
+                return None, GateDecision(
+                    False,
+                    ReasonCode.NO_MATCHING_TICKET,
+                    message=_candidate_sha_message(tickets),
+                )
+            if len(tickets) > 1:
+                return None, GateDecision(
+                    False,
+                    ReasonCode.AMBIGUOUS_TICKET,
+                    message=_candidate_sha_message(tickets),
+                )
+            selected_ticket = tickets[0]
+            matching_pending = tuple(
+                entry
+                for entry in self._pending_dispatches()
+                if entry.get("contract_sha") == selected_ticket.contract_sha
+                and entry.get("runtime") == selected_ticket.runtime
+            )
+            if not matching_pending:
+                return None, GateDecision(
+                    False,
+                    ReasonCode.NO_MATCHING_TICKET,
+                    message=_candidate_sha_message(tickets),
+                )
+
+        return RegistrationCandidate(matching_pending[0], selected_ticket), None
 
     def ledger_entries(self) -> tuple[Mapping[str, object], ...]:
         """Return parsed ledger entries in append order."""

--- a/tests/test_dispatch_gate.py
+++ b/tests/test_dispatch_gate.py
@@ -888,6 +888,83 @@ def test_cli_register_allows_sentinel_log_without_orchestration_task(
     assert "orchestration_task" not in entry
 
 
+def test_cli_register_rechecks_expected_completion_channel_under_register_lock(
+    tmp_path: Path,
+    monkeypatch,
+    capsys,
+) -> None:
+    contract = _contract(tmp_path, "stale sentinel channel decision")
+    ledger = tmp_path / "ledger.jsonl"
+    home = tmp_path / "home"
+    script = runpy.run_path(str(_script()), run_name="dispatch_gate_test")
+    monkeypatch.setenv("HOME", str(home))
+    monkeypatch.setenv("ORCA_CLI_COMMAND", str(tmp_path / "missing-orca"))
+
+    assert (
+        script["main"](
+            [
+                "--ledger",
+                str(ledger),
+                "check",
+                "--runtime",
+                "codex",
+                "--model",
+                "gpt-5.6-luna",
+                "--contract",
+                str(contract),
+                "--agents",
+                "1",
+                "--est-chars",
+                "1000",
+                "--completion-channel",
+                "orchestration",
+            ]
+        )
+        == 0
+    )
+    capsys.readouterr()
+
+    contract_sha = _sha256(contract)
+    ticket = home / ".mogui" / "dispatch-tickets" / f"codex-{contract_sha[:12]}.json"
+    assert ticket.exists()
+
+    def stale_channel(self, contract_sha=None, runtime=None):
+        return "sentinel-log"
+
+    monkeypatch.setattr(
+        script["DispatchGate"],
+        "completion_channel_for_registration",
+        stale_channel,
+    )
+
+    assert (
+        script["main"](
+            [
+                "--ledger",
+                str(ledger),
+                "register",
+                "--job-id",
+                "job-channel-race",
+                "--probe-cmd",
+                "printf job-channel-race",
+            ]
+        )
+        == 2
+    )
+    output = capsys.readouterr()
+    assert '"reason":"INVALID_REQUEST"' in output.out
+    assert "expected_completion_channel=sentinel-log" in output.err
+    assert "actual_completion_channel=orchestration" in output.err
+    entries = _ledger_entries(tmp_path)
+    assert len(entries) == 1
+    assert not any(
+        entry.get("job_id") == "job-channel-race"
+        and entry.get("decision") == "ALLOW"
+        for entry in entries
+    )
+    assert ticket.exists()
+
+
 def test_cli_register_sentinel_log_denies_failing_probe(
     tmp_path: Path,
     monkeypatch,
@@ -1250,6 +1327,88 @@ def test_register_consumes_matching_pending_dispatch_by_contract_sha(
     assert decision.allow is True
     assert decision.reason == ReasonCode.OK
     assert _ledger_entries(tmp_path)[-1]["contract_sha"] == first_sha
+
+
+def test_register_with_expected_completion_channel_matches(
+    tmp_path: Path,
+) -> None:
+    contract = _contract(tmp_path, "expected sentinel channel")
+    gate = _gate(tmp_path, now=1_000)
+    gate.check(DispatchRequest("codex", contract, est_input_chars=10_000, n_agents=1))
+
+    decision = gate.register_job(
+        "job-expected-channel",
+        lambda job_id: job_id == "job-expected-channel",
+        expected_completion_channel="sentinel-log",
+    )
+
+    assert decision.allow is True
+    assert decision.reason == ReasonCode.OK
+    entry = _ledger_entries(tmp_path)[-1]
+    assert entry["job_id"] == "job-expected-channel"
+    assert entry["completion_channel"] == "sentinel-log"
+
+
+def test_register_expected_completion_channel_mismatch_denies_before_write(
+    tmp_path: Path,
+) -> None:
+    contract = _contract(tmp_path, "expected channel mismatch")
+    gate = _gate(tmp_path, now=1_000)
+    gate.check(
+        _DispatchRequest(
+            runtime="codex",
+            contract_path=contract,
+            est_input_chars=10_000,
+            n_agents=1,
+            completion_channel="orchestration",
+            model="gpt-5.6-luna",
+        )
+    )
+    ticket = tmp_path / "dispatch-tickets" / f"codex-{_sha256(contract)[:12]}.json"
+    assert ticket.exists()
+
+    decision = gate.register_job(
+        "job-channel-mismatch",
+        lambda job_id: job_id == "job-channel-mismatch",
+        expected_completion_channel="sentinel-log",
+    )
+
+    assert decision.allow is False
+    assert decision.reason == ReasonCode.INVALID_REQUEST
+    assert "expected_completion_channel=sentinel-log" in decision.message
+    assert "actual_completion_channel=orchestration" in decision.message
+    entries = _ledger_entries(tmp_path)
+    assert len(entries) == 1
+    assert all(entry.get("job_id") != "job-channel-mismatch" for entry in entries)
+    assert ticket.exists()
+
+
+def test_register_without_expected_completion_channel_keeps_current_behavior(
+    tmp_path: Path,
+) -> None:
+    contract = _contract(tmp_path, "omitted expected channel")
+    gate = _gate(tmp_path, now=1_000)
+    gate.check(
+        _DispatchRequest(
+            runtime="codex",
+            contract_path=contract,
+            est_input_chars=10_000,
+            n_agents=1,
+            completion_channel="orchestration",
+            model="gpt-5.6-luna",
+        )
+    )
+
+    decision = gate.register_job(
+        "job-no-expected-channel",
+        lambda job_id: job_id == "job-no-expected-channel",
+    )
+
+    assert decision.allow is True
+    assert decision.reason == ReasonCode.OK
+    entry = _ledger_entries(tmp_path)[-1]
+    assert entry["job_id"] == "job-no-expected-channel"
+    assert entry["completion_channel"] == "orchestration"
 
 
 def test_register_denies_ambiguous_pending_dispatch_without_contract_sha(

--- a/tests/test_dispatch_gate.py
+++ b/tests/test_dispatch_gate.py
@@ -705,6 +705,7 @@ def test_r4_registers_verified_job_id(tmp_path: Path) -> None:
     assert decision.allow is True
     assert decision.reason == ReasonCode.OK
     assert _ledger_entries(tmp_path)[-1]["job_id"] == "job-123"
+    assert _ledger_entries(tmp_path)[-1]["completion_channel"] == "sentinel-log"
 
 
 def test_cli_register_with_verified_orchestration_task_records_task(
@@ -776,9 +777,39 @@ def test_cli_register_with_verified_orchestration_task_records_task(
     assert _ledger_entries(tmp_path)[-1]["orchestration_task"] == "task-orch-123"
 
 
-def test_cli_register_requires_orchestration_task(tmp_path: Path, capsys) -> None:
+def test_cli_register_requires_orchestration_task(
+    tmp_path: Path,
+    monkeypatch,
+    capsys,
+) -> None:
+    contract = _contract(tmp_path, "orchestration task required")
     script = runpy.run_path(str(_script()), run_name="dispatch_gate_test")
     ledger = tmp_path / "ledger.jsonl"
+    monkeypatch.setenv("HOME", str(tmp_path / "home"))
+
+    assert (
+        script["main"](
+            [
+                "--ledger",
+                str(ledger),
+                "check",
+                "--runtime",
+                "codex",
+                "--model",
+                "gpt-5.6-luna",
+                "--contract",
+                str(contract),
+                "--agents",
+                "1",
+                "--est-chars",
+                "1000",
+                "--completion-channel",
+                "orchestration",
+            ]
+        )
+        == 0
+    )
+    capsys.readouterr()
 
     assert (
         script["main"](
@@ -797,9 +828,159 @@ def test_cli_register_requires_orchestration_task(tmp_path: Path, capsys) -> Non
     output = capsys.readouterr()
     assert '"reason":"ORCHESTRATION_UNVERIFIED"' in output.out
     assert "ORCHESTRATION_UNVERIFIED" in output.err
-    ledger_entry = json.loads(ledger.read_text(encoding="utf-8"))
+    ledger_entry = _ledger_entries(tmp_path)[-1]
     assert ledger_entry["reason"] == "ORCHESTRATION_UNVERIFIED"
     assert ledger_entry["probe_failure"] == "task_omitted"
+
+
+def test_cli_register_allows_sentinel_log_without_orchestration_task(
+    tmp_path: Path,
+    monkeypatch,
+    capsys,
+) -> None:
+    contract = _contract(tmp_path, "sentinel log registration")
+    ledger = tmp_path / "ledger.jsonl"
+    script = runpy.run_path(str(_script()), run_name="dispatch_gate_test")
+    monkeypatch.setenv("HOME", str(tmp_path / "home"))
+    monkeypatch.setenv("ORCA_CLI_COMMAND", str(tmp_path / "missing-orca"))
+
+    assert (
+        script["main"](
+            [
+                "--ledger",
+                str(ledger),
+                "check",
+                "--runtime",
+                "codex",
+                "--model",
+                "gpt-5.6-luna",
+                "--contract",
+                str(contract),
+                "--agents",
+                "1",
+                "--est-chars",
+                "1000",
+                "--completion-channel",
+                "sentinel-log",
+            ]
+        )
+        == 0
+    )
+    capsys.readouterr()
+
+    assert (
+        script["main"](
+            [
+                "--ledger",
+                str(ledger),
+                "register",
+                "--job-id",
+                "job-sentinel",
+                "--probe-cmd",
+                "printf job-sentinel",
+            ]
+        )
+        == 0
+    )
+    entry = _ledger_entries(tmp_path)[-1]
+    assert entry["job_id"] == "job-sentinel"
+    assert entry["completion_channel"] == "sentinel-log"
+    assert "orchestration_task" not in entry
+
+
+def test_cli_register_sentinel_log_denies_failing_probe(
+    tmp_path: Path,
+    monkeypatch,
+    capsys,
+) -> None:
+    contract = _contract(tmp_path, "sentinel log failing probe")
+    ledger = tmp_path / "ledger.jsonl"
+    script = runpy.run_path(str(_script()), run_name="dispatch_gate_test")
+    monkeypatch.setenv("HOME", str(tmp_path / "home"))
+    monkeypatch.setenv("ORCA_CLI_COMMAND", str(tmp_path / "missing-orca"))
+
+    assert (
+        script["main"](
+            [
+                "--ledger",
+                str(ledger),
+                "check",
+                "--runtime",
+                "codex",
+                "--model",
+                "gpt-5.6-luna",
+                "--contract",
+                str(contract),
+                "--agents",
+                "1",
+                "--est-chars",
+                "1000",
+                "--completion-channel",
+                "sentinel-log",
+            ]
+        )
+        == 0
+    )
+    capsys.readouterr()
+
+    assert (
+        script["main"](
+            [
+                "--ledger",
+                str(ledger),
+                "register",
+                "--job-id",
+                "job-sentinel-missing",
+                "--probe-cmd",
+                "printf different-job",
+            ]
+        )
+        == 2
+    )
+    output = capsys.readouterr()
+    assert '"reason":"UNVERIFIED_JOB"' in output.out
+    assert "UNVERIFIED_JOB" in output.err
+    assert all(
+        entry.get("job_id") != "job-sentinel-missing"
+        for entry in _ledger_entries(tmp_path)
+    )
+
+
+def test_cli_register_without_matching_ticket_keeps_no_matching_ticket_denial(
+    tmp_path: Path,
+    monkeypatch,
+    capsys,
+) -> None:
+    ledger = tmp_path / "ledger.jsonl"
+    script = runpy.run_path(str(_script()), run_name="dispatch_gate_test")
+    monkeypatch.setenv("HOME", str(tmp_path / "home"))
+    orca = tmp_path / "orca"
+    orca.write_text(
+        '#!/bin/sh\nprintf \'%s\\n\' \'{"ok":true,"result":{"dispatch":{"id":"d1"}}}\'\n',
+        encoding="utf-8",
+    )
+    orca.chmod(0o755)
+    monkeypatch.setenv("ORCA_CLI_COMMAND", str(orca))
+
+    assert (
+        script["main"](
+            [
+                "--ledger",
+                str(ledger),
+                "register",
+                "--job-id",
+                "job-missing-ticket",
+                "--probe-cmd",
+                "printf job-missing-ticket",
+                "--orchestration-task",
+                "task-missing-ticket",
+            ]
+        )
+        == 2
+    )
+    output = capsys.readouterr()
+    assert '"reason":"NO_MATCHING_TICKET"' in output.out
+    assert "NO_MATCHING_TICKET: candidate_contract_shas=<none>" in output.err
 
 
 def test_cli_register_denies_unverified_orchestration_task_with_ledger_entry(


### PR DESCRIPTION
## Why

`check` accepts `--completion-channel sentinel-log` and writes the ticket, but `register` unconditionally demanded an orchestration task and its probe, so every dispatch on the sentinel channel (headless agents, terminal driven workers) died with ORCHESTRATION_UNVERIFIED after the work was already done and proven. Reproduced twice in the field on 2026-08-03. The owner ruled the fix goes in the direction of removing the excess requirement, not adding machinery.

## What

- `register` resolves the pending dispatch's declared completion channel (new `completion_channel_for_registration`, reusing the same candidate selection as registration itself). Only a channel other than sentinel-log keeps the orchestration task requirement; the mandatory artifact probe (UNVERIFIED_JOB on failure) remains the verification for sentinel-log.
- The ledger row records the completion channel, so a reader can tell which verification applied.
- The candidate selection logic is extracted into one helper used by both paths; behavior for orchestration dispatches, ambiguous tickets, and missing tickets is unchanged and covered by the existing tests.

## Acceptance (master, independent)

Reproduced the field scenario against this branch: sentinel-log check then register with a passing artifact probe returns ALLOW and writes the channel to the ledger; an orchestration dispatch registered without a task is still denied ORCHESTRATION_UNVERIFIED. Full suite: 437 passed, 1 skipped.

## Provenance

Implemented by a Codex worker (gpt-5.5 xhigh) under contract dzgao-register-sentinel-20260803; the failing path and the fix direction were measured and approved before dispatch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Accepts verified `sentinel-log` dispatches in `register` without requiring an Orca orchestration task, records the completion channel, and rechecks it under the registration lock. `orchestration` dispatches still require Orca verification.

- **Bug Fixes**
  - `register` resolves the pending dispatch’s completion channel and only requires `--orchestration-task` when the channel is not `sentinel-log`.
  - Passes `expected_completion_channel` to `register_job`; rechecks under the lock and denies with `INVALID_REQUEST` (including expected vs actual) if it changed, without writing to the ledger or consuming the ticket.
  - Ledger now records `"completion_channel"` for each registration.

- **Refactors**
  - Extracted candidate selection into `_registration_candidate`, used by registration and `DispatchGate.completion_channel_for_registration()`.
  - Updated `scripts/dispatch-gate` to reuse a single gate instance, query the completion channel before probing Orca, and pass the gate to denial paths.

<sup>Written for commit b0a1d26887755cd37d2d2303f8fac7a6e6249706. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/baksohyeon/mogui-ADE-orchestrator/pull/55?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

