### PR TITLE
tests: remove the permanently skipped lineage dry run

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,14 @@ you build on it.
 
 ## [Unreleased]
 
+### Removed
+
+- The permanently skipped lineage test. It dry ran the append against a real
+  operations ledger at a path the publication sweep replaced with a fictional
+  one, so it could never run on any machine, and the property it checked
+  (append preserves existing bytes) is already covered twice on the same code
+  path by the synthetic fixtures. The suite now reports zero skips.
+
 ## [0.4.0] - 2026-08-03
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -244,7 +244,7 @@ Documentation in this repository is English. `master-ops/` is a template that ge
 
 ## Status
 
-Working and exercised, as of 2026-08-03: 434 unit tests pass, 1 skipped. Every
+Working and exercised, as of 2026-08-03: 434 unit tests pass, none skipped. Every
 unit listed below exists in `src/master_runtime/core/`. The succession,
 dispatch-gate, acceptance, and compaction paths have run against real
 workspaces, and onboarding has been run start to finish by someone other than

--- a/tests/test_lineage.py
+++ b/tests/test_lineage.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import shutil
 import tempfile
 import unittest
 from pathlib import Path
@@ -106,34 +105,6 @@ class LineageRecorderTests(unittest.TestCase):
             append_entry(self.path, entry)
 
         self.assertEqual(original, self.path.read_bytes())
-
-    def test_real_lineage_copy_dry_run_preserves_original_prefix(self) -> None:
-        source = Path("/Users/dev/workspace/example-product/example-ops/docs/lineage/MASTER-LINEAGE.md")
-        if not source.exists():
-            self.skipTest("real MASTER-LINEAGE.md source is unavailable")
-
-        dry_run_path = Path(self.tempdir.name) / "MASTER-LINEAGE-copy.md"
-        shutil.copyfile(source, dry_run_path)
-        original = dry_run_path.read_bytes()
-
-        append_entry(
-            dry_run_path,
-            valid_entry(generation=_next_generation(dry_run_path)),
-        )
-
-        self.assertEqual(original, dry_run_path.read_bytes()[: len(original)])
-        self.assertEqual(original, source.read_bytes())
-
-
-def _next_generation(path: Path) -> int:
-    generations: list[int] = []
-    for line in path.read_text(encoding="utf-8").splitlines():
-        if not line.startswith("- **Generation**: "):
-            continue
-        value = line.rsplit(":", maxsplit=1)[1].strip()
-        if value.isdigit():
-            generations.append(int(value))
-    return max(generations, default=0) + 1
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
The test copied a real operations ledger from a hardcoded path that the publication sweep replaced with a fictional one, so it has skipped on every machine since; a test that can never run is noise wearing a test's name. The property it checked, append preserves the existing bytes, is covered twice on the same code path by the synthetic fixtures. Removes the test, its now unused helper and import, and updates the README status line: 434 pass, zero skips.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Remove the permanently skipped lineage dry-run test that depended on a real file path and could never execute. Coverage for "append preserves existing bytes" remains via synthetic fixtures; removed the unused helper/import, updated README to 434 passing and 0 skipped, and documented the change in CHANGELOG.

<sup>Written for commit da0d7ab4d17cd544a1aa2d7e65722f65e735efed. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/baksohyeon/mogui-ADE-orchestrator/pull/56?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

