### PR TITLE
docs: progressive-load onboarding router and step files (mgm-ed3)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,4 +4,4 @@ If a session opens in a fresh clone with no task given, you are this system's on
 
 This repository contains the workspace/orchestrator runtime and the Stage 2 master-ops onboarding guide. Keep agent-host wording neutral: `claude` is an example CLI, and `AGENTS.md` exists for hosts that read that filename. Orca is not optional for the onboarding flow; it is the execution substrate this system requires.
 
-When onboarding is active, read `master-ops/ONBOARDING.md` and walk the user through it step by step in their language, starting with its Orientation section — the system, the three layers, the step map, and the end state come before the first question. Use a structured question tool when the host provides one; otherwise ask in plain conversation.
+When onboarding is active, read only the router `master-ops/ONBOARDING.md`, ask its session-mode question, then open `master-ops/onboarding/00-orientation.md`. Load one step file per turn and finish its Verify before opening the next. Never read the step files all at once.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,4 +4,4 @@ If a session opens in a fresh clone with no task given, you are this system's on
 
 This repository contains the workspace/orchestrator runtime and the Stage 2 master-ops onboarding guide. Keep agent-host wording neutral: `claude` is an example CLI, and `AGENTS.md` exists for hosts that read that filename. Orca is not optional for the onboarding flow; it is the execution substrate this system requires.
 
-When onboarding is active, read only the router `master-ops/ONBOARDING.md`, ask its session-mode question, then open `master-ops/onboarding/00-orientation.md`. Load one step file per turn and finish its Verify before opening the next. Never read the step files all at once.
+When onboarding is active, read only the router `master-ops/ONBOARDING.md`, ask its session-mode question, then follow the router's path for the answered mode. Load one step file per turn and finish its Verify before opening the next. Never read the step files all at once.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,4 +4,4 @@ If a session opens in a fresh clone with no task given, you are this system's on
 
 This repository contains the workspace/orchestrator runtime and the Stage 2 master-ops onboarding guide. Keep agent-host wording neutral: `claude` is an example CLI, and `AGENTS.md` exists for hosts that read that filename. Orca is not optional for the onboarding flow; it is the execution substrate this system requires.
 
-When onboarding is active, read `master-ops/ONBOARDING.md` and walk the user through it step by step in their language, starting with its Orientation section — the system, the three layers, the step map, and the end state come before the first question. Use a structured question tool when the host provides one; otherwise ask in plain conversation.
+When onboarding is active, read only the router `master-ops/ONBOARDING.md`, ask its session-mode question, then open `master-ops/onboarding/00-orientation.md`. Load one step file per turn and finish its Verify before opening the next. Never read the step files all at once.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,4 +4,4 @@ If a session opens in a fresh clone with no task given, you are this system's on
 
 This repository contains the workspace/orchestrator runtime and the Stage 2 master-ops onboarding guide. Keep agent-host wording neutral: `claude` is an example CLI, and `AGENTS.md` exists for hosts that read that filename. Orca is not optional for the onboarding flow; it is the execution substrate this system requires.
 
-When onboarding is active, read only the router `master-ops/ONBOARDING.md`, ask its session-mode question, then open `master-ops/onboarding/00-orientation.md`. Load one step file per turn and finish its Verify before opening the next. Never read the step files all at once.
+When onboarding is active, read only the router `master-ops/ONBOARDING.md`, ask its session-mode question, then follow the router's path for the answered mode. Load one step file per turn and finish its Verify before opening the next. Never read the step files all at once.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,7 +14,7 @@ Answer these five before proposing any tool, and put the answers in the pull req
 
 The first three are usually disqualifying on their own: a component that fails them is a subscription presenting itself as a dependency. A component that passes them and answers nothing for the fifth is a preference. Preferences are allowed, and they get labelled as preferences, and nothing gates on them.
 
-This is a maintainer question rather than an operator one. An installation does not choose the stack; it receives one, and `master-ops/ONBOARDING.md` carries the same five questions for the narrower decision an installer does make, which is what to install of what is offered.
+This is a maintainer question rather than an operator one. An installation does not choose the stack; it receives one, and the onboarding flow (`master-ops/onboarding/08-settings-and-skills.md`, routed from `master-ops/ONBOARDING.md`) carries the same five questions for the narrower decision an installer does make, which is what to install of what is offered.
 
 ## Running it
 

--- a/INSTALL-PROMPT.txt
+++ b/INSTALL-PROMPT.txt
@@ -2,7 +2,7 @@ You are onboarding a workspace/orchestrator operations layer.
 
 Use this prompt only on agent hosts that do not automatically read `CLAUDE.md` or `AGENTS.md` from the cloned repository root. If the host already loaded one of those files, follow the automatic router there instead.
 
-This repository (mogui-ADE-orchestrator) is cloned locally. Read `master-ops/ONBOARDING.md` in this repository and walk the user through it step by step, in their language. Do not skip steps. Use a structured question tool if your host provides one; otherwise ask in plain conversation. Explain why each step matters before asking anything.
+This repository (mogui-ADE-orchestrator) is cloned locally. Read only the router `master-ops/ONBOARDING.md`, ask its session-mode question, then follow the router's path for the answered mode, in the user's language. Load one step file per turn and finish its Verify before opening the next; never read the step files all at once, and do not skip steps. Use a structured question tool if your host provides one; otherwise ask in plain conversation. Explain why each step matters before asking anything.
 
 Orca ADE is a hard prerequisite for this flow. If `orca status` does not show a usable runtime, explain that requirement, guide the user to install and start Orca, and stop until Orca is available.
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Nothing to configure and nothing to read first. Clone it, start an agent inside 
 
 It runs the fleet on [Orca](https://www.onorca.dev/download). A session has to outlive its window and be addressable by handle before anything can orchestrate it. Built and run on macOS; Orca also ships Linux and Windows. Python 3, stdlib-only core, MIT. No API key.
 
-The orchestrating session is called the master, for lack of a better word. It has no name yet. Suggestions welcome.
+The orchestrating session is called the master in the docs — that is a temporary role label, not a permanent name. At install you pick a **callsign** for the living session (examples people have used or floated: 자비스 / Jarvis, Friday, Alfred, HAL-but-nice, or anything short you will say out loud). Suggestions still welcome.
 
 
 ## Why these tools

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Five questions decided the stack, and they are the bar for anything proposed lat
 
 Failing the first three usually means a subscription presenting itself as a dependency. Passing them while answering nothing for the fifth means a preference, which is allowed and labelled as one, and nothing gates on it.
 
-The maintainer-facing version of this bar is in `CONTRIBUTING.md`; the installer-facing one is in `master-ops/ONBOARDING.md`.
+The maintainer-facing version of this bar is in `CONTRIBUTING.md`; the installer-facing one is in `master-ops/onboarding/08-settings-and-skills.md`, routed from `master-ops/ONBOARDING.md`.
 
 ## Quickstart
 

--- a/master-ops/CHANGELOG.md
+++ b/master-ops/CHANGELOG.md
@@ -78,7 +78,7 @@ worse; this pass cuts the load unit itself:
   Template improve (not installation; route as an ordinary task). Mixing modes
   in one session is what the 2026-08-03 run measured going wrong.
 - Every numbered founding step file carries an "Owner script (3–6 sentences)" block;
-  `reverify.md` is a mode file with `Checklist` and `Report` sections instead;
+  `reverify.md` keeps an Owner script and adds `Checklist` and `Report` sections;
   owner-facing turns are capped at that plus one or two questions. Verify lists, the Orca
   charter, and the Step 8 command sequence are agent-only sections; Step 8
   commands are folded under "do not paste to the owner" and lose the `$`

--- a/master-ops/CHANGELOG.md
+++ b/master-ops/CHANGELOG.md
@@ -77,8 +77,9 @@ worse; this pass cuts the load unit itself:
   (`onboarding/reverify.md`, read-only health checklist, spawn blocked), and
   Template improve (not installation; route as an ordinary task). Mixing modes
   in one session is what the 2026-08-03 run measured going wrong.
-- Every step file carries an "Owner script (3–6 sentences)" block; owner-facing
-  turns are capped at that plus one or two questions. Verify lists, the Orca
+- Every numbered founding step file carries an "Owner script (3–6 sentences)" block;
+  `reverify.md` is a mode file with `Checklist` and `Report` sections instead;
+  owner-facing turns are capped at that plus one or two questions. Verify lists, the Orca
   charter, and the Step 8 command sequence are agent-only sections; Step 8
   commands are folded under "do not paste to the owner" and lose the `$`
   owner-prompt prefix.

--- a/master-ops/CHANGELOG.md
+++ b/master-ops/CHANGELOG.md
@@ -64,6 +64,33 @@ ONBOARDING.md installer UX pass from the 2026-08-03 mogui founding run
 - Step 7.6 drops the comprehension-quiz verify; explain the gate gap and continue.
 - README notes that callsign is chosen at install and lists example names.
 
+ONBOARDING progressive-load split (mgm-ed3), same 2026-08-03 feedback, second
+pass — the first pass added rules to the monolith, which made the overload
+worse; this pass cuts the load unit itself:
+
+- `ONBOARDING.md` becomes a router: session-mode question, agent load rules,
+  standing owner-language rules, placeholder list, and a step index. Everything
+  else moves to one file per step under `onboarding/` (`00-orientation.md` …
+  `10-card-and-retire.md`), loaded one file per turn, next file only after the
+  current step's Verify passes.
+- Session-mode triad at the top of the router: Founding (00→10), Reverify
+  (`onboarding/reverify.md`, read-only health checklist, spawn blocked), and
+  Template improve (not installation; route as an ordinary task). Mixing modes
+  in one session is what the 2026-08-03 run measured going wrong.
+- Every step file carries an "Owner script (3–6 sentences)" block; owner-facing
+  turns are capped at that plus one or two questions. Verify lists, the Orca
+  charter, and the Step 8 command sequence are agent-only sections; Step 8
+  commands are folded under "do not paste to the owner" and lose the `$`
+  owner-prompt prefix.
+- Progressive loading is host- and model-agnostic by rule: a stronger model does
+  not earn monolith reading, and a model that summarizes well does not earn
+  skipping a step file.
+- Step 3's skeleton copy and its verify now also exclude the `onboarding/`
+  directory alongside `TEMPLATE-VERSION`, `CHANGELOG.md`, and `ONBOARDING.md`.
+- Entry files (`CLAUDE.md`/`AGENTS.md`) now instruct: read the router only, ask
+  the mode question, open `00-orientation.md`, one step file per turn, never all
+  step files at once.
+
 ## v0.4.1
 
 No template changes in this release; the version string moves so an

--- a/master-ops/CHANGELOG.md
+++ b/master-ops/CHANGELOG.md
@@ -41,6 +41,29 @@ installation was taken from alongside the tag.
 
 ## Unreleased
 
+ONBOARDING.md installer UX pass from the 2026-08-03 mogui founding run
+(feedback tracked as maintainer backlog on that install):
+
+- Standing owner-facing language rules: no jargon quizzes; plain glosses for
+  probe/placement/selector; shell examples the owner sees use a `$ ` prefix.
+- Pacing and context diet: ship one step chunk at a time; start path is
+  Orientation → Step 0 only; re-read the step from disk if the transcript drifts.
+- Step 1 splits into purpose (with examples) → root → full-child inventory by
+  default → name/monitor/model. Outside repositories lead with "move or clone
+  under the root"; external lane is secondary opt-in. Monitor namespace is
+  explicitly not the issue-tracker prefix.
+- Step 1A no longer measures or ranks workspace-root folder candidates (that
+  felt intrusive). The installer explains terms, gives pick criteria, asks the
+  owner to choose the folder and paste an absolute path (prefer Orca **Copy
+  path**), then validates only what was pasted.
+- Step 3.5 explains the full open-measure-close temporary-terminal flow before
+  any UI action; owner speech says "temporary terminal," not "probe."
+- Step 5 byte-only CLAUDE.md/AGENTS.md drift is announce-and-proceed with an
+  ELI5 line; only substantive divergence asks the owner.
+- Step 6 asks for a master callsign; "master" stays the doc role label.
+- Step 7.6 drops the comprehension-quiz verify; explain the gate gap and continue.
+- README notes that callsign is chosen at install and lists example names.
+
 ## v0.4.1
 
 No template changes in this release; the version string moves so an

--- a/master-ops/ONBOARDING.md
+++ b/master-ops/ONBOARDING.md
@@ -32,7 +32,7 @@ These bind every step. Technical labels stay in these files and in agent notes; 
 - Plain words only in owner speech. Forbidden in owner-facing dialogue (use the plain gloss instead): "probe" / "탐침" → temporary terminal or seat-check terminal; "placement" → where the master sits in Orca; "selector" → the durable seat id we record; "dispatch" on first use → hand work to a worker session; "Role Lock" on first use → one active role, other roles frozen until the owner unlocks.
 - Do not quiz the owner to prove they understood. Explain once, confirm decisions with measured options, and move on.
 - Say a tracker issue as "<title> (<id>)", never a bare ID.
-- Shell commands the owner is expected to run or to recognize in the transcript use a `$ ` prompt prefix inside ```console``` blocks (match the repository README). Agent-only command sequences may omit `$` only when they are not shown as something the owner types.
+- Shell commands the owner is expected to run or to recognize in the transcript use a `$` prompt prefix inside ```console``` blocks (match the repository README). Agent-only command sequences may omit `$` only when they are not shown as something the owner types.
 - Pacing: ship the install in small chunks — one step's orientation, one measured fact block, then that step's questions. Never the whole map plus a stack of questions in one turn. Open each step with a one-line "where we are" and a one-line "what we will decide next," then act or ask. When a question-tool screen would pack more than three decisions, split into separate turns.
 
 ## Template placeholders

--- a/master-ops/ONBOARDING.md
+++ b/master-ops/ONBOARDING.md
@@ -8,19 +8,19 @@ This Stage 2 flow turns the Stage 1 skeleton into a working workspace/orchestrat
 
 Before anything else — before orientation, before any measurement — ask the owner which of these this session is, with a one-line gloss each. A session that mixes modes loses its role; exactly this was measured on the 2026-08-03 install run.
 
-1. **Founding** — a new workspace: build the ops repository and spawn a Generation 1 master. Path: step files `00` → `10`.
+1. **Founding** — a genuinely new workspace: build the ops repository and spawn a Generation 1 master. Path: step files `00` → `10`.
 2. **Reverify** — a workspace that already has an ops repository and a master: check health only. Path: `onboarding/reverify.md` alone. **Spawning is blocked in this mode**; a second master is an incident, not a convenience.
 3. **Template improve** — work on this orchestrator repository's own documents or code. That is not installation at all: stop this flow and route the work as an ordinary task (master or worker lane).
 
-If evidence contradicts the chosen mode (for example the owner says Founding but a live master already exists), stop and re-ask with the evidence — do not improvise a hybrid.
+If evidence contradicts the chosen mode, stop and re-ask with the evidence — do not improvise a hybrid. The Founding guard triggers on an existing ops repository or lineage file, not only on a live master: a workspace whose master died, or a half-finished install, is **not** Founding — that is recovery or succession, owned by the ops repository's `docs/runbooks/succession-boot-card.md`, and re-running Founding against it corrupts lineage and governance records.
 
 ## How to run this flow (agent rules)
 
 1. Read one step file per turn: the file for the step you are on, nothing else. Never read all step files at once.
 2. Do not open the next step file until the current step's Verify list passes.
 3. Owner-facing turns are short: a 3–6 sentence explanation plus at most one or two questions. Never dump command blocks or charter text at the owner; agent-only commands stay in agent notes. Each step file carries an "Owner script" block as the template for that step's opening turn.
-4. On failure or a branch, re-read only the current step's "If fail" section from disk. If quality or encoding drift appears in the transcript, re-read the step file from disk rather than improvising from a stale summary.
-5. Ask through the host's structured question tool when available; otherwise ask in normal conversation. Either way: numbered options from measured candidates when they exist, one marked recommendation with a reason, and a free-form option. Explain why before every question. Never ask the user to simply provide a value when measurable candidates exist — with one standing exception: the workspace root is chosen and pasted by the owner, never scanned or shortlisted (see `02-workspace-facts.md`).
+4. On failure or a branch, re-read the current step's "If fail" section from disk where the step has one; a step without an "If fail" section has no scripted recovery, so stop and ask rather than improvise. If quality or encoding drift appears in the transcript, re-read the step file from disk rather than working from a stale summary.
+5. Ask through the host's structured question tool when available; otherwise ask in normal conversation. Either way: numbered options from measured candidates when they exist, one marked recommendation with a reason, and a free-form option. Explain why before every question. Never ask the user to simply provide a value when measurable candidates exist — with one standing exception: the workspace root is chosen and pasted by the owner, never scanned or shortlisted (see `onboarding/02-workspace-facts.md`).
 6. Progressive loading is mandatory for every host and every model. A stronger model does not earn monolith reading, and a model that summarizes well does not earn skipping a step file; both failure modes were observed on 2026-08-03 (one model drowned, one improvised).
 
 The step files are terse to save agent tokens; user-facing dialogue must NOT be terse. Speak to the user warmly, as a helpful collaborator, in full sentences, with reasons and cautions.

--- a/master-ops/ONBOARDING.md
+++ b/master-ops/ONBOARDING.md
@@ -2,13 +2,30 @@
 
 > The master exists to maximize Orca infrastructure productivity. Orca is REQUIRED infrastructure. Supervised dispatch = orca orchestration only.
 
-Use this Stage 2 guide to turn the Stage 1 skeleton into a working workspace/orchestrator operations repository. Ask through the host's structured question tool when available; otherwise ask in normal conversation. The prose fallback must match the structured path in quality: for every question, show measured candidate values as numbered options when available, mark one recommendation and explain why, and include a free-form option; never ask the user to simply provide a value when measurable candidates exist. Explain why before every question. This file is terse to save agent tokens; user-facing dialogue must NOT be terse. Speak to the user warmly, in full sentences, with reasons and cautions.
+Use this Stage 2 guide to turn the Stage 1 skeleton into a working workspace/orchestrator operations repository. Ask through the host's structured question tool when available; otherwise ask in normal conversation. The prose fallback must match the structured path in quality: for every question, show measured candidate values as numbered options when available, mark one recommendation and explain why, and include a free-form option; never ask the user to simply provide a value when measurable candidates exist. Explain why before every question. This file is terse to save agent tokens; user-facing dialogue must NOT be terse. Speak to the user warmly, as a helpful collaborator, in full sentences, with reasons and cautions.
+
+## Owner-facing language (standing)
+
+In speech to the owner, plain words only. Technical labels stay in this file and in agent notes; they do not become the owner's vocabulary unless the owner asks.
+
+- Forbidden in owner-facing dialogue (use the plain gloss instead): "probe" / "탐침" → temporary terminal or seat-check terminal; "placement" → where the master sits in Orca; "selector" → the durable seat id we record; "dispatch" on first use → hand work to a worker session; "Role Lock" on first use → one active role, other roles frozen until the owner unlocks.
+- Do not quiz the owner to prove they understood. Explain once, confirm decisions with measured options, and move on.
+- Shell commands the owner is expected to run or to recognize in the transcript use a `$ ` prompt prefix inside ```console``` blocks (match the repository README). Agent-only command sequences may omit `$` only when they are not shown as something the owner types.
+
+## Pacing and context diet
+
+Ship the install in small chunks. One step's orientation, one measured fact block, then that step's questions — never dump the whole map and a stack of questions in one turn.
+
+- Open each step with a one-line "where we are" and a one-line "what we will decide next," then act or ask. Finish the step's verify list before starting the next step's questions.
+- When a step has several independent facts (for example workspace root, then name, then model), ask in separate turns if the host's question tool would otherwise pack more than three decisions into one screen.
+- Do not load this entire file into working memory at once when a step only needs its own section, and do not open unrelated large docs during early steps. Prefer the step section, then fetch the next. If quality or encoding drift appears in the transcript, re-read the step from disk rather than improvising from a stale summary.
+- The installer start path is Orientation → Step 0 only. Defer later step text until that step begins.
 
 ## Orientation, Before Step 0
 
 Tell the user, in their language and before asking anything:
 
-1. This system runs one master session per workspace to coordinate its repositories; Orca spawns and placement-verifies it, and a dedicated ops repository keeps governance state.
+1. This system runs one master session per workspace to coordinate its repositories; Orca spawns it and checks that it sits in the right place, and a dedicated ops repository keeps governance state.
 2. Three layers are involved: this maintainer-owned orchestrator repository is the runtime and template; the new ops repository is the workspace's governance record; the master session is its operator. This installer session is none of them and retires after Step 8.
 3. Steps 0 through 7.5 measure facts and build the ops repository; Step 8 spawns the master; Step 9 is the master's first-boot smoke in its own session.
 4. The end state is an ops repository with a completed operations document, an issue tracker reachable from the workspace root, seeded user rules, and exactly one verified Generation 1 master.
@@ -49,13 +66,13 @@ Two standing duties come with the charter. First, whenever the user signals they
 
 Ask whether the user is ready for local read-only checks and which agent CLI they expect to use, such as `claude`.
 
-Run:
+Run (show the owner-facing form with `$` when you narrate the check; the agent may run the same lines without asking the owner to type them):
 
 ```console
-cd "{{RUNTIME_ROOT}}"
-ORCA_AGENT_CLI="<user-named agent CLI>" bash scripts/onboarding-preflight.sh
-command -v "<user-named agent CLI>"
-command -v git
+$ cd "{{RUNTIME_ROOT}}"
+$ ORCA_AGENT_CLI="<user-named agent CLI>" bash scripts/onboarding-preflight.sh
+$ command -v "<user-named agent CLI>"
+$ command -v git
 ```
 
 Use `bash scripts/onboarding-preflight.sh --fix` only with approval; it may add or refresh the global Orca skills, while application installs remain manual.
@@ -73,18 +90,30 @@ Verify:
 
 ## Step 1. Collect Workspace Facts
 
-**Position and action:** Step 1 begins after prerequisites pass: collect and measure the workspace facts before routing any work.
+**Position and action:** Step 1 begins after prerequisites pass: collect and measure the workspace facts before routing any work. Pace this step in three short turns when needed: (A) purpose and workspace root, (B) repository inventory, (C) name, monitor namespace, and model.
 
-**Why/caution:** The master operates above repositories and needs a confirmed absolute root and inventory.
+**Why/caution:** The master operates above repositories and needs a confirmed absolute root, a purpose, and an inventory.
 
 Before asking, say these plain definitions in the user's language:
 
 - “Workspace (root)” is the folder that groups the repositories this master will manage, nothing more.
 - “Workspace name” is a display label; by default, it is that folder's name.
-- “Monitor namespace” is a short tag that keeps this workspace's session artifacts separate from other workspaces.
+- “Monitor namespace” is a short tag that keeps this workspace's session artifacts separate from other workspaces. It is not the issue-tracker prefix (that comes in Step 5).
 - “Default model identifier” is the model the master session is expected to run as; use the chosen agent CLI's table row below as the recommended candidate and measure the actual model at boot rather than guessing.
 
-Master model criteria:
+### Step 1A. Purpose, then root
+
+Ask what this master is for, with concrete examples so the owner can recognize a fit rather than invent a category. Examples to offer (adapt language; keep the range):
+
+- Coordinate several product repositories under one owner (multi-repo product workspace).
+- Maintain one open-source or internal library and its docs, issues, and release path.
+- Run a personal or experimental sandbox that may be thrown away.
+- Operate a platform or harness repository (like this orchestrator) while keeping product checkouts separate.
+- Something else — free-form is always valid.
+
+Explain why: purpose shapes which folder is the right root, which repositories belong in the inventory, and how aggressive the master should be about outside checkouts. Record the answer in the operations document later; do not invent a purpose if the owner defers.
+
+Master model criteria (for the later model question in 1C; do not ask model yet):
 
 | Agent CLI | Master-session top-tier candidate |
 | --- | --- |
@@ -93,39 +122,53 @@ Master model criteria:
 | `grok` | `grok-4.5` |
 | `cursor-agent` | measured at boot; no fixed identifier yet |
 
-The master session runs the top tier of its agent family. Worker and dispatch models use task-based tier selection instead: choose the lowest sufficient tier and state the exact model explicitly in every dispatch. For the `{{MODEL_ID}}` question, recommend the row for the chosen agent CLI; for `cursor-agent`, recommend measuring at boot and confirming the candidate with the owner.
+The master session runs the top tier of its agent family. Worker and dispatch models use task-based tier selection instead: choose the lowest sufficient tier and state the exact model explicitly in every dispatch. For the `{{MODEL_ID}}` question in 1C, recommend the row for the chosen agent CLI; for `cursor-agent`, recommend measuring at boot and confirming the candidate with the owner.
 
-Selection criteria for the workspace-root candidates, in plain language:
+**Workspace root — guide, then ask. Do not scan the disk for candidates and do not present a ranked shortlist of folders the agent discovered.** That pattern feels like the installer is choosing the owner's house for them. The owner chooses; the installer only validates what they paste.
 
-- If you are coordinating multiple product repositories, choose the folder that contains those repositories.
-- If you are maintaining a single repository, choose that repository's parent folder.
-- If this is an experiment or disposable work, choose a new temporary folder.
-- When an existing grouping folder is present, it wins over a new or broader candidate.
+Give a short setup guide in the owner's language (terms first, then how to pick, then how to send the path):
 
-Measure and offer numbered workspace-root candidates before asking: the parent directory of `{{RUNTIME_ROOT}}`, `{{RUNTIME_ROOT}}`'s grandparent when it groups repositories, and a user-named new folder. Make creating that new workspace folder and placing or cloning repositories into it a first-class option when no suitable folder exists; apply the criteria above, recommend the existing grouping candidate when present, and explain why. Then ask for the absolute workspace root, workspace name (default: confirmed root basename), monitor namespace, and default model identifier to measure at boot, with measured candidate values, a recommendation and reason, and a free-form option for each when available; explain why each is needed.
+1. **What it is:** the folder that *groups* the repositories this master will manage — not one product repo inside it, and not a broad home folder that mixes unrelated projects.
+2. **How to pick (owner criteria, not agent measurement):**
+   - Several product repos → the folder that already contains them.
+   - One repo only → that repo's *parent* folder (so the master sits above it).
+   - Experiment / disposable → a new empty folder is fine; create it first if needed.
+   - Prefer an existing grouping folder over inventing a wider one.
+3. **How to send the absolute path (prefer Orca):** In Orca, select the project or folder that should be the workspace root and use **Copy path** (or the equivalent path-copy action in the project/folder UI). Paste that absolute path into the chat. Alternatives if they are not in Orca yet: Finder → folder → Get Info / copy path, or a terminal `pwd` after `cd` into the folder. Relative paths and `~` alone are not enough; we need a full absolute path.
+4. **What happens next:** only after they paste a path, the installer checks that it exists and is a directory — never before, and never by fishing nearby parents.
 
-Run:
+Then ask once: please set or confirm that folder, copy its absolute path, and paste it here. Wait for their answer. Do not invent or "helpfully default" a path from `{{RUNTIME_ROOT}}`'s parent tree.
+
+Only after the owner provides a path, validate:
 
 ```console
-test "${WORKSPACE_ROOT#/}" != "$WORKSPACE_ROOT" && test -d "$WORKSPACE_ROOT"
-ls -la "$WORKSPACE_ROOT"
+$ test "${WORKSPACE_ROOT#/}" != "$WORKSPACE_ROOT" && test -d "$WORKSPACE_ROOT"
+$ ls -la "$WORKSPACE_ROOT"
 ```
 
-Read current files first, detect immediate child repositories, read the measured list back for confirmation or exclusions, and ask again rather than inventing uncertain values.
+If the path is missing, not absolute, or not a directory, say so plainly and ask them to paste again. Do not substitute a measured fallback.
 
-When the user names a repository that lives outside the confirmed workspace root, ask which of two homes it gets, and explain why the question matters: the master holds the repository inventory (`{{REPO_LIST}}`) and measures code across it (for example through a review graph indexed at the workspace root), so a repository outside the root is invisible to that measurement and fragments the sidebar in Orca. The two homes:
+### Step 1B. Repository inventory
 
-- Move or clone it under the workspace root (recommend this when the master will route real work into it); then it joins `{{REPO_LIST}}` as an ordinary member.
-- Record it as an external lane: it stays where it is, enters the operations document by absolute path with its access rules (who may write, which gates run before pushing), and the master treats every claim about it as needing its own measurement, because none of the workspace-level tooling sees it. Some repositories legitimately stay outside (a public lane maintained for open source, another owner's checkout), so ask the question as a real choice.
+Read current files first. Detect every immediate child Git repository under the confirmed root. **Default: register all of them into `{{REPO_LIST}}`.** Read the full measured list back for confirmation. Do not open with exclusion hunting; the owner may drop a child only by explicit opt-out after seeing the full list. Never invent repositories that were not measured.
 
-Do not move anything yourself; moving repositories is the user's action.
+When the user names a repository that lives outside the confirmed workspace root, lead with the default path and plain language: **please move or clone it under the workspace root** so the master can see it and Orca's sidebar stays one workspace. Explain why: the master holds the inventory (`{{REPO_LIST}}`) and measures code across it (for example a review graph indexed at the workspace root); a path outside the root is invisible to that measurement and splits the sidebar. Only if the owner refuses to move it, offer the secondary home:
+
+- **Default / recommended:** move or clone under the workspace root; it joins `{{REPO_LIST}}` as an ordinary member. The installer does not move anything; the owner does.
+- **Secondary (opt-in):** record it as an external lane — absolute path, who may write, which gates run before push. Every claim about it needs its own measurement. Legitimate cases include a public open-source lane or another owner's checkout.
+
+### Step 1C. Name, monitor namespace, model
+
+Ask for workspace name (default: confirmed root basename), monitor namespace, and default model identifier to measure at boot, with measured candidates, a recommendation and reason, and a free-form option for each when available; explain why each is needed. Remind once that monitor namespace is not the Beads/issue prefix.
 
 Verify:
 
-- `{{WORKSPACE_ROOT}}` is absolute and exists
+- the master's purpose was asked with examples and recorded or explicitly deferred
+- the owner was guided with definitions and path-copy instructions; the agent did **not** present measured folder candidates
+- `{{WORKSPACE_ROOT}}` was provided by the owner (absolute path), then validated as an existing directory
 - `{{WORKSPACE_NAME}}` is explicit or is the confirmed root basename approved by the user
-- `{{REPO_LIST}}` matches measured repositories after user confirmation
-- every repository the user named that lives outside the root is either moved/cloned in by the user or recorded as an external lane with access rules; none is left implicit
+- `{{REPO_LIST}}` defaults to every measured immediate child repository, with only explicit opt-outs removed
+- every repository the user named that lives outside the root was offered move/clone first; if still outside, it is recorded as an external lane with access rules; none is left implicit
 
 ## Step 2. Choose The Ops Repository
 
@@ -165,22 +208,32 @@ Verify:
 
 **Why/caution:** The master coordinates every repository, so its seat is the workspace-level workspace, never one repository's worktree inside a multi-repository workspace. A master seated in a repository worktree binds correctly (cwd, hooks, session files) yet hangs under that one repository in the owner's sidebar and occupies a seat shaped for a worker; exactly this shipped as a measured misplacement on 2026-08-03. The folder route is verified from the CLI with the `id:folder:<uuid>` selector form: precheck listing, terminal create, and spawn placement match all pass (measured 2026-08-03). Bare `folder:<uuid>` is accepted by `terminal create` but rejected by `terminal list` (a measured subcommand asymmetry), and `path:` selectors are rejected by the placement comparison, so the durable record must use the `id:` prefixed form, which every consumer accepts. [docs/public/orca-concepts.md](../docs/public/orca-concepts.md) holds the object model.
 
-Ask the user to add `{{WORKSPACE_ROOT}}` as an Orca project (the Add a project dialog's Browse folder accepts a folder with many repositories), create or open its folder workspace, open a plain terminal there as a placement probe, and provide its runtime-issued terminal handle. The probe is not the master: its only job is to prove the seat, Step 8's spawn creates the actual master terminal, and exactly one master may exist. Resolve `ORCA` exactly as Step 0's preflight does, then run:
+**Before any UI action, explain the whole short flow to the owner in plain language.** Do not start mid-step. Say, in substance:
+
+1. We register the ops repository with Orca (so workers can get worktrees from it later).
+2. You add `{{WORKSPACE_ROOT}}` as an Orca project if needed (Browse folder accepts a folder that holds many repositories), and open that folder workspace.
+3. You open one **temporary plain terminal** there — not the master. We only need its seat id. It will feel like "open, we measure, then close."
+4. You paste or send us that terminal's runtime handle so we can read where it sits.
+5. We record the durable seat id in the ops repository.
+6. **You close that temporary terminal** (or we close it if it is ours). Leaving it open means Step 8 would create a second terminal in the same seat. The real master is created only in Step 8, and exactly one master may exist.
+
+Only after the owner has heard that sequence, ask them to perform steps 2–4. Resolve `ORCA` exactly as Step 0's preflight does, then run:
 
 ```console
-ORCA repo add --path "{{OPS_REPO}}" --json
-ORCA terminal show --terminal <terminal handle> --json
+$ ORCA repo add --path "{{OPS_REPO}}" --json
+$ ORCA terminal show --terminal <terminal handle> --json
 ```
 
-Capture the returned selector only when the terminal metadata proves the workspace-level seat: a folder workspace reports `worktreeId` as `folder:<uuid>` with an empty `worktreePath`, and that emptiness is the expected shape, so judge by `worktreeId`. Before continuing, persist a durable placement result in an ops-repository file containing the selector in `id:` prefixed form, `{{WORKSPACE_ROOT}}`, and the `terminal show` proof; do not rely on conversation state, and do not treat the probe's terminal handle as durable, because handles are scoped to the app runtime and die with restarts. The durable identity is the selector. After persisting, ask the user to close the probe terminal (or close it yourself if it is yours): leaving it open means Step 8 creates a second terminal in the same seat. Step 5 initializes the issue tracker independently and does not require a second placement copy; it may record a pointer to this result. Do not substitute a filesystem path for the measured selector, and do not infer the seat from a shell's cwd.
+Capture the returned selector only when the terminal metadata proves the workspace-level seat: a folder workspace reports `worktreeId` as `folder:<uuid>` with an empty `worktreePath`, and that emptiness is the expected shape, so judge by `worktreeId`. Before continuing, persist a durable placement result in an ops-repository file containing the selector in `id:` prefixed form, `{{WORKSPACE_ROOT}}`, and the `terminal show` proof; do not rely on conversation state, and do not treat the temporary terminal's handle as durable, because handles are scoped to the app runtime and die with restarts. The durable identity is the selector. After persisting, ask the user to close the temporary seat-check terminal (or close it yourself if it is yours). Step 5 initializes the issue tracker independently and does not require a second placement copy; it may record a pointer to this result. Do not substitute a filesystem path for the measured selector, and do not infer the seat from a shell's cwd.
 
 Verify:
 
+- the full open-measure-close sequence was explained before any temporary terminal was requested
 - `orca repo add --path "{{OPS_REPO}}" --json` succeeds or confirms the ops repository is already registered (worker worktrees are created from this registration)
 - `terminal show` measured the terminal metadata
 - the selector points at the workspace-level seat, never an individual repository worktree inside a multi-repository workspace
 - the durable placement result exists in `id:` prefixed selector form before founding spawn
-- the placement probe terminal is closed, so the founding spawn will be the only terminal in that seat
+- the temporary seat-check terminal is closed, so the founding spawn will be the only terminal in that seat
 
 ## Step 4. Replace Template Placeholders
 
@@ -193,8 +246,8 @@ Ask for each unresolved value and any coordination exclusions. Fill `{{RUNTIME_R
 Verify:
 
 ```console
-! rg '\{\{[^}]+\}\}' "{{OPS_REPO}}"
-cmp "{{OPS_REPO}}/CLAUDE.md" "{{OPS_REPO}}/AGENTS.md"
+$ ! rg '\{\{[^}]+\}\}' "{{OPS_REPO}}"
+$ cmp "{{OPS_REPO}}/CLAUDE.md" "{{OPS_REPO}}/AGENTS.md"
 ```
 
 Also verify no source workspace's private names were copied accidentally.
@@ -205,21 +258,24 @@ Also verify no source workspace's private names were copied accidentally.
 
 **Why/caution:** Execution state belongs in the tracker, but upward resolution can silently select a database above the workspace or stop at the wrong Git root.
 
-Explain that the tracker is working-state SSOT reloaded at boot and after compaction. Ask which tracker to use, whether to initialize it now, and which short issue prefix to use; propose a two- or three-character prefix beside the default and explain that IDs are spoken to the owner.
+Explain that the tracker is working-state SSOT reloaded at boot and after compaction. Ask which tracker to use, whether to initialize it now, and which short issue prefix to use; propose a two- or three-character prefix beside the default and explain that IDs are spoken to the owner. Remind that this prefix is not the monitor namespace from Step 1.
 
 For Beads, run only after approval:
 
 ```console
-cd "{{OPS_REPO}}" && bd init --prefix <approved prefix>
-{ [ -e "{{WORKSPACE_ROOT}}/.beads" ] || [ -L "{{WORKSPACE_ROOT}}/.beads" ]; } \
+$ cd "{{OPS_REPO}}" && bd init --prefix <approved prefix>
+$ { [ -e "{{WORKSPACE_ROOT}}/.beads" ] || [ -L "{{WORKSPACE_ROOT}}/.beads" ]; } \
     && echo "already exists, inspect before linking" \
     || ln -s "$(cd "{{OPS_REPO}}" && pwd)/.beads" "{{WORKSPACE_ROOT}}/.beads"
-cd "{{WORKSPACE_ROOT}}" && bd where
+$ cd "{{WORKSPACE_ROOT}}" && bd where
 ```
 
-Immediately after `bd init`, perform the byte/semantic comparison before continuing. If `CLAUDE.md` and `AGENTS.md` differ only at the byte level (whitespace or block order) while their semantic content is the same, normalize the shared blocks, write the same resulting common block to both files, and say once: `CLAUDE.md and AGENTS.md differed only byte-wise; re-unified automatically.` Do not ask the user in that case. If any substantive line or block is present in only one file, stop and ask the user whether to accept host-specific divergence before proceeding.
+Immediately after `bd init`, compare `CLAUDE.md` and `AGENTS.md` before continuing. **Announce-and-proceed — do not open a choice for the byte-only case.**
 
-Ask before creating the link. If the prefix is wrong, `bd rename-prefix` rewrites database IDs and references but not Markdown. For another tracker, measure its resolution rules. Record active work in the tracker and seed only load-bearing memory pointers and rules.
+- If they differ only at the byte level (whitespace, blank lines, or block order) while the semantic content is the same: re-unify automatically, write the same common block to both files, and tell the owner in ELI5 once, for example: "Two instruction files for different agent hosts had drifted in formatting only; I made them match again so both hosts see the same rules. No decision needed from you." Then continue.
+- If any substantive line or block exists in only one file: stop and ask whether to accept host-specific divergence before proceeding. That is the only branch that needs a question.
+
+Ask before creating the workspace → ops `.beads` link. If the prefix is wrong, `bd rename-prefix` rewrites database IDs and references but not Markdown. For another tracker, measure its resolution rules. Record active work in the tracker and seed only load-bearing memory pointers and rules.
 
 Verify from `{{WORKSPACE_ROOT}}`, not inside the ops repository:
 
@@ -232,11 +288,19 @@ Verify from `{{WORKSPACE_ROOT}}`, not inside the ops repository:
 
 **Position and action:** Step 6 begins with execution state reachable: store the user's durable, workspace-wide operating rules in the selected memory system.
 
-**Why/caution:** Keep private details out of public documents and product conventions out of the master layer.
+**Why/caution:** Keep private details out of public documents and product conventions out of the master layer. The word "master" in this template is a temporary role name, not the session's permanent callsign.
 
-Ask for preferred address, primary response language, approval requirements before execution/dispatch/branch/commit/push/deploy, and standing prohibitions. Write short actionable rules without narrative duplication.
+Ask for:
 
-Verify that memory lookup returns the seeded rules and that the rules are concise and not duplicated in Git documents.
+- preferred address for the owner (how the session should speak to them)
+- **master callsign** — a short name the owner will use for this session (examples: 자비스 / Jarvis, Friday, Alfred, or a free-form name). Explain that "master" is the role label in docs; the living session gets a callsign the owner chose. Record it in tracker memory and in the founding kickoff notes
+- primary response language
+- approval requirements before execution / handoff to workers / branch / commit / push / deploy
+- standing prohibitions
+
+Write short actionable rules without narrative duplication.
+
+Verify that memory lookup returns the seeded rules (including callsign and owner address), and that the rules are concise and not duplicated in Git documents.
 
 ## Step 7. Explain The Settings Layer
 
@@ -326,7 +390,13 @@ None of those are in the repository, so no scanner in this template sees them. T
 
 Tell the user that organization-specific patterns live in a file outside version control, that the gates fail closed without it, and that its format is one rule per line as `id|description|regex`. That file is what makes the gates able to catch a workspace name; the shipped rules only catch generic provider secrets.
 
-Verify the user can state one surface the gates do not cover, and that the organization rules file exists or its absence is recorded as a known gap.
+Do **not** run a comprehension quiz or ask the owner to recite a surface back. Explain the gap once, in plain language, then continue. A quiz reads as condescension and adds no durable record.
+
+Verify:
+
+- the uncovered surfaces were named in conversation
+- the organization rules file exists, or its absence is recorded as a known gap
+- no quiz or "prove you understood" prompt was used
 
 ## Step 8. Spawn The Founding Master Through Orchestration
 
@@ -334,7 +404,7 @@ Verify the user can state one surface the gates do not cover, and that the organ
 
 **Why/caution:** Supervised dispatch is Orca orchestration only; raw terminal polling and vendor-direct CLIs are non-compliant, and failures remain closed.
 
-Ask for confirmation to spawn now or defer, reload the durable placement result from Step 3.5 and confirm the selector still resolves on the host (`ORCA terminal list --worktree <selector> --json`); the probe terminal is already closed, so there is no handle to check, and the spawn itself verifies placement against this selector again. Write a kickoff file containing Generation 1, this installer as founding origin, the boot sequence (rehydrate ops docs, declare Role State, measure model and placement), the initial queue, and the requirement to report the orchestration Task complete.
+Ask for confirmation to spawn now or defer, reload the durable placement result from Step 3.5 and confirm the selector still resolves on the host (`ORCA terminal list --worktree <selector> --json`); the temporary seat-check terminal from Step 3.5 is already closed, so there is no handle to check, and the spawn itself verifies placement against this selector again. Write a kickoff file containing Generation 1, this installer as founding origin, the callsign from Step 6, the boot sequence (rehydrate ops docs, declare Role State, measure model and placement), the initial queue, and the requirement to report the orchestration Task complete.
 
 Before launching any worker, follow `docs/MASTER-OPERATIONS.md` §3: MEASURE the installed agent CLI's non-interactive approval flags from `--help` and never guess them.
 
@@ -343,31 +413,31 @@ Before attaching a Codex worker, run `{{RUNTIME_ROOT}}/scripts/codex-worker-pret
 Run this supervised path with the resolved `ORCA` executable:
 
 ```console
-G={{RUNTIME_ROOT}}/scripts/dispatch-gate
-L=~/.mogui/dispatch-ledger.jsonl
-"$G" --ledger "$L" check \
+$ G={{RUNTIME_ROOT}}/scripts/dispatch-gate
+$ L=~/.mogui/dispatch-ledger.jsonl
+$ "$G" --ledger "$L" check \
     --runtime <runtime> \
     --model "{{MODEL_ID}}" \
     --contract <contract file> \
     --agents 1 \
     --est-chars <estimated input chars> \
     --completion-channel orchestration
-ORCA orchestration run-create --objective "Found and verify the Generation 1 master" --json
-ORCA orchestration task-create --spec "Run the byte-identical founding kickoff file and complete Step 9 boot smoke" --json
-"{{RUNTIME_ROOT}}/scripts/master-succeed" spawn \
+$ ORCA orchestration run-create --objective "Found and verify the Generation 1 master" --json
+$ ORCA orchestration task-create --spec "Run the byte-identical founding kickoff file and complete Step 9 boot smoke" --json
+$ "{{RUNTIME_ROOT}}/scripts/master-succeed" spawn \
     --workspace-selector <durable placement selector from Step 3.5, id: prefixed> \
     --kickoff-file <kickoff file> \
     --root "{{WORKSPACE_ROOT}}" \
     --model "{{MODEL_ID}}" \
     --title "Gen-1 founding boot" \
     --json
-ORCA terminal wait --terminal <verified live handle> --for tui-idle --timeout-ms 60000 --json
-ORCA orchestration dispatch --task <task id> --to <verified live handle> --inject --json
-"$G" --ledger "$L" register \
+$ ORCA terminal wait --terminal <verified live handle> --for tui-idle --timeout-ms 60000 --json
+$ ORCA orchestration dispatch --task <task id> --to <verified live handle> --inject --json
+$ "$G" --ledger "$L" register \
     --job-id <job id> \
     --probe-cmd "<command proving the job-id appears in an artifact>" \
     --orchestration-task <task id>
-ORCA orchestration check --wait --types worker_done,escalation,question --timeout-ms 900000 --json
+$ ORCA orchestration check --wait --types worker_done,escalation,question --timeout-ms 900000 --json
 ```
 
 Require the gate `check` to return `allow: true` before spawning or attaching the worker. After the Dispatch artifact exists, run `register` with that exact orchestration Task ID before waiting for final completion evidence.
@@ -388,7 +458,7 @@ Verify:
 
 **Why/caution:** Model identity is measured, unavailable, or unsupported, never guessed, and the installer does not perform this boot on the master's behalf.
 
-Ask for the initial role or approval to start in Maintenance, plus permission for local read-only model and placement probes. Update `docs/runbooks/role-state.md` for Generation 1, declare Role State in conversation, measure configured and actual model when exposed, capture placement evidence, append Generation 1 to `docs/lineage/MASTER-LINEAGE.md`, then send `worker_done` exactly once for the active Dispatch.
+Ask for the initial role or approval to start in Maintenance, plus permission for local read-only model and seat checks. Update `docs/runbooks/role-state.md` for Generation 1, declare Role State in conversation (include the callsign), measure configured and actual model when exposed, capture placement evidence, append Generation 1 to `docs/lineage/MASTER-LINEAGE.md`, then send `worker_done` exactly once for the active Dispatch.
 
 Verify:
 

--- a/master-ops/ONBOARDING.md
+++ b/master-ops/ONBOARDING.md
@@ -1,524 +1,59 @@
-# Master-Ops Onboarding
+# Master-Ops Onboarding — Router
 
 > The master exists to maximize Orca infrastructure productivity. Orca is REQUIRED infrastructure. Supervised dispatch = orca orchestration only.
 
-Use this Stage 2 guide to turn the Stage 1 skeleton into a working workspace/orchestrator operations repository. Ask through the host's structured question tool when available; otherwise ask in normal conversation. The prose fallback must match the structured path in quality: for every question, show measured candidate values as numbered options when available, mark one recommendation and explain why, and include a free-form option; never ask the user to simply provide a value when measurable candidates exist. Explain why before every question. This file is terse to save agent tokens; user-facing dialogue must NOT be terse. Speak to the user warmly, as a helpful collaborator, in full sentences, with reasons and cautions.
+This Stage 2 flow turns the Stage 1 skeleton into a working workspace/orchestrator operations repository. The flow is split into one file per step under `onboarding/`. This router is the only file that stays loaded for the whole install; everything else is loaded one step at a time.
 
-## Owner-facing language (standing)
+## First: classify the session mode
 
-In speech to the owner, plain words only. Technical labels stay in this file and in agent notes; they do not become the owner's vocabulary unless the owner asks.
+Before anything else — before orientation, before any measurement — ask the owner which of these this session is, with a one-line gloss each. A session that mixes modes loses its role; exactly this was measured on the 2026-08-03 install run.
 
-- Forbidden in owner-facing dialogue (use the plain gloss instead): "probe" / "탐침" → temporary terminal or seat-check terminal; "placement" → where the master sits in Orca; "selector" → the durable seat id we record; "dispatch" on first use → hand work to a worker session; "Role Lock" on first use → one active role, other roles frozen until the owner unlocks.
+1. **Founding** — a new workspace: build the ops repository and spawn a Generation 1 master. Path: step files `00` → `10`.
+2. **Reverify** — a workspace that already has an ops repository and a master: check health only. Path: `onboarding/reverify.md` alone. **Spawning is blocked in this mode**; a second master is an incident, not a convenience.
+3. **Template improve** — work on this orchestrator repository's own documents or code. That is not installation at all: stop this flow and route the work as an ordinary task (master or worker lane).
+
+If evidence contradicts the chosen mode (for example the owner says Founding but a live master already exists), stop and re-ask with the evidence — do not improvise a hybrid.
+
+## How to run this flow (agent rules)
+
+1. Read one step file per turn: the file for the step you are on, nothing else. Never read all step files at once.
+2. Do not open the next step file until the current step's Verify list passes.
+3. Owner-facing turns are short: a 3–6 sentence explanation plus at most one or two questions. Never dump command blocks or charter text at the owner; agent-only commands stay in agent notes. Each step file carries an "Owner script" block as the template for that step's opening turn.
+4. On failure or a branch, re-read only the current step's "If fail" section from disk. If quality or encoding drift appears in the transcript, re-read the step file from disk rather than improvising from a stale summary.
+5. Ask through the host's structured question tool when available; otherwise ask in normal conversation. Either way: numbered options from measured candidates when they exist, one marked recommendation with a reason, and a free-form option. Explain why before every question. Never ask the user to simply provide a value when measurable candidates exist — with one standing exception: the workspace root is chosen and pasted by the owner, never scanned or shortlisted (see `02-workspace-facts.md`).
+6. Progressive loading is mandatory for every host and every model. A stronger model does not earn monolith reading, and a model that summarizes well does not earn skipping a step file; both failure modes were observed on 2026-08-03 (one model drowned, one improvised).
+
+The step files are terse to save agent tokens; user-facing dialogue must NOT be terse. Speak to the user warmly, as a helpful collaborator, in full sentences, with reasons and cautions.
+
+## Standing rules — owner-facing language
+
+These bind every step. Technical labels stay in these files and in agent notes; they do not become the owner's vocabulary unless the owner asks.
+
+- Plain words only in owner speech. Forbidden in owner-facing dialogue (use the plain gloss instead): "probe" / "탐침" → temporary terminal or seat-check terminal; "placement" → where the master sits in Orca; "selector" → the durable seat id we record; "dispatch" on first use → hand work to a worker session; "Role Lock" on first use → one active role, other roles frozen until the owner unlocks.
 - Do not quiz the owner to prove they understood. Explain once, confirm decisions with measured options, and move on.
+- Say a tracker issue as "<title> (<id>)", never a bare ID.
 - Shell commands the owner is expected to run or to recognize in the transcript use a `$ ` prompt prefix inside ```console``` blocks (match the repository README). Agent-only command sequences may omit `$` only when they are not shown as something the owner types.
-
-## Pacing and context diet
-
-Ship the install in small chunks. One step's orientation, one measured fact block, then that step's questions — never dump the whole map and a stack of questions in one turn.
-
-- Open each step with a one-line "where we are" and a one-line "what we will decide next," then act or ask. Finish the step's verify list before starting the next step's questions.
-- When a step has several independent facts (for example workspace root, then name, then model), ask in separate turns if the host's question tool would otherwise pack more than three decisions into one screen.
-- Do not load this entire file into working memory at once when a step only needs its own section, and do not open unrelated large docs during early steps. Prefer the step section, then fetch the next. If quality or encoding drift appears in the transcript, re-read the step from disk rather than improvising from a stale summary.
-- The installer start path is Orientation → Step 0 only. Defer later step text until that step begins.
-
-## Orientation, Before Step 0
-
-Tell the user, in their language and before asking anything:
-
-1. This system runs one master session per workspace to coordinate its repositories; Orca spawns it and checks that it sits in the right place, and a dedicated ops repository keeps governance state.
-2. Three layers are involved: this maintainer-owned orchestrator repository is the runtime and template; the new ops repository is the workspace's governance record; the master session is its operator. This installer session is none of them and retires after Step 8.
-3. Steps 0 through 7.5 measure facts and build the ops repository; Step 8 spawns the master; Step 9 is the master's first-boot smoke in its own session.
-4. The end state is an ops repository with a completed operations document, an issue tracker reachable from the workspace root, seeded user rules, and exactly one verified Generation 1 master.
-
-Keep the user oriented with the opening line in every step. In owner-facing conversation, say a tracker issue as "<title> (<id>)", never a bare ID, and explain charter terms such as Role Lock in one plain clause on first use.
-
-Use only these template placeholders: `{{WORKSPACE_NAME}}`, `{{WORKSPACE_ROOT}}`, `{{OPS_REPO}}`, `{{MONITOR_NS}}`, `{{MODEL_ID}}`, `{{REPO_LIST}}`, `{{RUNTIME_ROOT}}`, and `{{TEMPLATE_VERSION}}`. The installer measures the last two in Step 4 rather than asking the user.
-
-## Map
-
-- Orchestrator layer: this repository owns the runtime, template, and onboarding flow.
-- Ops layer: the generated operations repository owns workspace governance records.
-- Session layer: one Orca-hosted master operates the workspace and retires through succession.
-- `docs/MASTER-OPERATIONS.md` owns durable rules as the master-operations SSOT.
-- `docs/runbooks/role-state.md` owns the master's current role and Role Lock state.
-- `docs/runbooks/succession-boot-card.md` owns boot and recovery order.
-- `bd` owns execution state; follow the `bd prime` caution only after `bd where` proves the ops repository.
-- `contracts/` owns bounded worker briefs; it is not the execution-state tracker.
-- Agents: ground Orca claims in the [Orca documentation](https://www.onorca.dev/) before improvising; resolve the current snapshot agent index at onboarding rather than relying on a hash that may change.
-
-## Orca Context Charter, Installer Scope
-
-This charter binds the installer session only; it is not copied into the master's operating documents. Use the Orca docs snapshot as source-grounded context for every Orca claim made during onboarding:
-
-- Agent index, read first: the snapshot's `llms.txt` page map (current link in the runtime repository README under "Why Orca is required").
-- Fetch the smallest relevant page from that index first, and load the full Markdown only when a task genuinely needs the whole documentation at once.
-- Treat the snapshot as read-only and generated. Prefer source-grounded claims, cite the page or source file used, and check the live Orca repository when freshness or code changes matter.
-- Keep provider assumptions out of plans; use whatever fetch, file, and shell tools this session provides.
-- After reading, state in one line what was relied on, then proceed.
-
-Two standing duties come with the charter. First, whenever the user signals they are new to Orca or asks what a project, workspace, worktree, or terminal is, answer in place from these sources and [docs/public/orca-concepts.md](../docs/public/orca-concepts.md) rather than deferring them to a link. Second, expected UI labels that look alarming (for example the "Unavailable worktree" chip on folder workspace sessions) get explained as normal before the user has to ask.
-
-## Step 0. Pass The Required Preflight
-
-**Position and action:** Step 0 starts after orientation, with no workspace state changed: run `bash scripts/onboarding-preflight.sh` from `{{RUNTIME_ROOT}}` and fix every FAIL before continuing.
-
-**Why/caution:** Orca, an orchestration Run bound to this terminal, the Orca skills, Beads, Python, the named agent CLI, at least one worker runtime to dispatch to, Git, and the organization rules file are all required; do not offer a non-Orca fallback. A host that legitimately cannot satisfy one required check sets `PREFLIGHT_WAIVE=<check-label>`, which downgrades that FAIL to a printed and counted waiver; the summary then reads READY WITH WAIVERS and names them, because a required check that was waived was not satisfied. Never suggest skipping the preflight itself: that discards every other check with it. Orchestration is measured by capability rather than reachability. Two states measured on real hosts: a retained legacy coordinator answers reads and drops writes with `effectsApplied:false`, and an unbound coordinator fails the whole task family with `run_required`. A binding can also drop later without any signal, after which `check` returns `count:0`, so an empty mailbox and a missing binding look identical. If the preflight reports either state, bind a fresh Run with `orca orchestration run-create` and measure again; restarting the app does not clear the legacy one. Do not attribute a lost injection to binding state without a control: a lost task and a delivered task inside the same Run were measured on 2026-08-02, which rules binding out as that discriminator.
-
-Ask whether the user is ready for local read-only checks and which agent CLI they expect to use, such as `claude`.
-
-Run (show the owner-facing form with `$` when you narrate the check; the agent may run the same lines without asking the owner to type them):
-
-```console
-$ cd "{{RUNTIME_ROOT}}"
-$ ORCA_AGENT_CLI="<user-named agent CLI>" bash scripts/onboarding-preflight.sh
-$ command -v "<user-named agent CLI>"
-$ command -v git
-```
-
-Use `bash scripts/onboarding-preflight.sh --fix` only with approval; it may add or refresh the global Orca skills, while application installs remain manual.
-
-Verify:
-
-- the preflight exits zero, Orca status was measured, a non-legacy orchestration Run is bound to this terminal, required skills resolve, `bd` is present and resolves to the ops repo when one exists, and Python is present
-- the named agent CLI is set and resolves on `PATH`; an unset selection is a FAIL, because it silently downgrades the agent-specific checks to INFO
-- at least one of the worker runtimes this master dispatches to resolves on `PATH`; the others are reported as warnings, since routing every lane through one executor is a normal setup
-- `gitleaks` was measured: present passes, absent warns without blocking, because publishing needs it (the redaction gate exits 2 without its engine) while running a master does not. Treat the warning as a real install item on any host that will publish
-- `ctx` was measured: present with a reachable index passes, absent or unreachable warns without blocking, because the records practice cannot query cross-provider history without it while a master still runs. Ignore the warning only on a host that does no history work
-- Git is present, and `gh` state was reported: a missing binary blocks, while unauthenticated or a missing `workflow` scope warns, because local-only work needs no forge credentials
-- every waiver in the summary was intended, and `PREFLIGHT_WAIVE` entries that matched no check are corrected rather than left, since a misspelled waiver leaves the check enforced
-- the organization rules file loads at least one rule and no rule is malformed; the preflight reports counts only and never the file's contents
-
-## Step 1. Collect Workspace Facts
-
-**Position and action:** Step 1 begins after prerequisites pass: collect and measure the workspace facts before routing any work. Pace this step in three short turns when needed: (A) purpose and workspace root, (B) repository inventory, (C) name, monitor namespace, and model.
-
-**Why/caution:** The master operates above repositories and needs a confirmed absolute root, a purpose, and an inventory.
-
-Before asking, say these plain definitions in the user's language:
-
-- “Workspace (root)” is the folder that groups the repositories this master will manage, nothing more.
-- “Workspace name” is a display label; by default, it is that folder's name.
-- “Monitor namespace” is a short tag that keeps this workspace's session artifacts separate from other workspaces. It is not the issue-tracker prefix (that comes in Step 5).
-- “Default model identifier” is the model the master session is expected to run as; use the chosen agent CLI's table row below as the recommended candidate and measure the actual model at boot rather than guessing.
-
-### Step 1A. Purpose, then root
-
-Ask what this master is for, with concrete examples so the owner can recognize a fit rather than invent a category. Examples to offer (adapt language; keep the range):
-
-- Coordinate several product repositories under one owner (multi-repo product workspace).
-- Maintain one open-source or internal library and its docs, issues, and release path.
-- Run a personal or experimental sandbox that may be thrown away.
-- Operate a platform or harness repository (like this orchestrator) while keeping product checkouts separate.
-- Something else — free-form is always valid.
-
-Explain why: purpose shapes which folder is the right root, which repositories belong in the inventory, and how aggressive the master should be about outside checkouts. Record the answer in the operations document later; do not invent a purpose if the owner defers.
-
-Master model criteria (for the later model question in 1C; do not ask model yet):
-
-| Agent CLI | Master-session top-tier candidate |
-| --- | --- |
-| `claude` | `claude-fable-5` |
-| `codex` | `gpt-5.6-sol` |
-| `grok` | `grok-4.5` |
-| `cursor-agent` | measured at boot; no fixed identifier yet |
-
-The master session runs the top tier of its agent family. Worker and dispatch models use task-based tier selection instead: choose the lowest sufficient tier and state the exact model explicitly in every dispatch. For the `{{MODEL_ID}}` question in 1C, recommend the row for the chosen agent CLI; for `cursor-agent`, recommend measuring at boot and confirming the candidate with the owner.
-
-**Workspace root — guide, then ask. Do not scan the disk for candidates and do not present a ranked shortlist of folders the agent discovered.** That pattern feels like the installer is choosing the owner's house for them. The owner chooses; the installer only validates what they paste.
-
-Give a short setup guide in the owner's language (terms first, then how to pick, then how to send the path):
-
-1. **What it is:** the folder that *groups* the repositories this master will manage — not one product repo inside it, and not a broad home folder that mixes unrelated projects.
-2. **How to pick (owner criteria, not agent measurement):**
-   - Several product repos → the folder that already contains them.
-   - One repo only → that repo's *parent* folder (so the master sits above it).
-   - Experiment / disposable → a new empty folder is fine; create it first if needed.
-   - Prefer an existing grouping folder over inventing a wider one.
-3. **How to send the absolute path (prefer Orca):** In Orca, select the project or folder that should be the workspace root and use **Copy path** (or the equivalent path-copy action in the project/folder UI). Paste that absolute path into the chat. Alternatives if they are not in Orca yet: Finder → folder → Get Info / copy path, or a terminal `pwd` after `cd` into the folder. Relative paths and `~` alone are not enough; we need a full absolute path.
-4. **What happens next:** only after they paste a path, the installer checks that it exists and is a directory — never before, and never by fishing nearby parents.
-
-Then ask once: please set or confirm that folder, copy its absolute path, and paste it here. Wait for their answer. Do not invent or "helpfully default" a path from `{{RUNTIME_ROOT}}`'s parent tree.
-
-Only after the owner provides a path, validate:
-
-```console
-$ test "${WORKSPACE_ROOT#/}" != "$WORKSPACE_ROOT" && test -d "$WORKSPACE_ROOT"
-$ ls -la "$WORKSPACE_ROOT"
-```
-
-If the path is missing, not absolute, or not a directory, say so plainly and ask them to paste again. Do not substitute a measured fallback.
-
-### Step 1B. Repository inventory
-
-Read current files first. Detect every immediate child Git repository under the confirmed root. **Default: register all of them into `{{REPO_LIST}}`.** Read the full measured list back for confirmation. Do not open with exclusion hunting; the owner may drop a child only by explicit opt-out after seeing the full list. Never invent repositories that were not measured.
-
-When the user names a repository that lives outside the confirmed workspace root, lead with the default path and plain language: **please move or clone it under the workspace root** so the master can see it and Orca's sidebar stays one workspace. Explain why: the master holds the inventory (`{{REPO_LIST}}`) and measures code across it (for example a review graph indexed at the workspace root); a path outside the root is invisible to that measurement and splits the sidebar. Only if the owner refuses to move it, offer the secondary home:
-
-- **Default / recommended:** move or clone under the workspace root; it joins `{{REPO_LIST}}` as an ordinary member. The installer does not move anything; the owner does.
-- **Secondary (opt-in):** record it as an external lane — absolute path, who may write, which gates run before push. Every claim about it needs its own measurement. Legitimate cases include a public open-source lane or another owner's checkout.
-
-### Step 1C. Name, monitor namespace, model
-
-Ask for workspace name (default: confirmed root basename), monitor namespace, and default model identifier to measure at boot, with measured candidates, a recommendation and reason, and a free-form option for each when available; explain why each is needed. Remind once that monitor namespace is not the Beads/issue prefix.
-
-Verify:
-
-- the master's purpose was asked with examples and recorded or explicitly deferred
-- the owner was guided with definitions and path-copy instructions; the agent did **not** present measured folder candidates
-- `{{WORKSPACE_ROOT}}` was provided by the owner (absolute path), then validated as an existing directory
-- `{{WORKSPACE_NAME}}` is explicit or is the confirmed root basename approved by the user
-- `{{REPO_LIST}}` defaults to every measured immediate child repository, with only explicit opt-outs removed
-- every repository the user named that lives outside the root was offered move/clone first; if still outside, it is recorded as an external lane with access rules; none is left implicit
-
-## Step 2. Choose The Ops Repository
-
-**Position and action:** Step 2 begins with a confirmed workspace inventory: recommend and obtain approval for the ops repository.
-
-**Why/caution:** Governance needs a visible ownership boundary that cannot be confused with product code.
-
-Ask whether to create a new repository or reuse an existing operations repository, and whether local Git initialization is allowed for a new ops repository; this choice applies only to `{{OPS_REPO}}`, never to `{{WORKSPACE_ROOT}}`.
-
-Inspect the confirmed names; propose two or three candidates with pros and cons; recommend `<workspace>-ops`; evaluate governance clarity, separation from product scope, and shell-title ambiguity; use a structured choice when available.
-
-Verify:
-
-- `{{OPS_REPO}}` is an approved absolute path or repository name
-- the selection was evaluated against the confirmed inventory
-- no product repository name was reused
-
-## Step 3. Create The Ops Repository
-
-**Position and action:** Step 3 begins with an approved name: create or deliberately reuse the ops repository before registering it in Orca.
-
-**Why/caution:** Read and merge existing files; never overwrite operations records or initialize Git without approval.
-
-Ask for confirmation to create or reuse `{{OPS_REPO}}` and separate confirmation before local Git initialization of that ops repository.
-
-If new or empty, copy the Stage 1 skeleton from `{{RUNTIME_ROOT}}/master-ops/`, excluding `TEMPLATE-VERSION`, `CHANGELOG.md`, and `ONBOARDING.md`; if existing, merge deliberately after reading it. Do not push unless explicitly asked.
-
-Verify:
-
-- the ops repository exists with `CLAUDE.md`, `AGENTS.md`, `docs/MASTER-OPERATIONS.md`, and the Stage 1 skeleton
-- only the allowed remaining placeholders are present
-- `TEMPLATE-VERSION`, `CHANGELOG.md`, and `ONBOARDING.md` are absent from the generated repository
-
-## Step 3.5. Register The Ops Repository And Seat The Master
-
-**Position and action:** Step 3.5 begins after Step 3: register `{{WORKSPACE_ROOT}}` and the already-Git `{{OPS_REPO}}` with Orca, then seat the master terminal at the workspace level: the folder workspace of `{{WORKSPACE_ROOT}}` when the root is a folder containing repositories, or the repository's primary worktree when the workspace is a single repository.
-
-**Why/caution:** The master coordinates every repository, so its seat is the workspace-level workspace, never one repository's worktree inside a multi-repository workspace. A master seated in a repository worktree binds correctly (cwd, hooks, session files) yet hangs under that one repository in the owner's sidebar and occupies a seat shaped for a worker; exactly this shipped as a measured misplacement on 2026-08-03. The folder route is verified from the CLI with the `id:folder:<uuid>` selector form: precheck listing, terminal create, and spawn placement match all pass (measured 2026-08-03). Bare `folder:<uuid>` is accepted by `terminal create` but rejected by `terminal list` (a measured subcommand asymmetry), and `path:` selectors are rejected by the placement comparison, so the durable record must use the `id:` prefixed form, which every consumer accepts. [docs/public/orca-concepts.md](../docs/public/orca-concepts.md) holds the object model.
-
-**Before any UI action, explain the whole short flow to the owner in plain language.** Do not start mid-step. Say, in substance:
-
-1. We register the ops repository with Orca (so workers can get worktrees from it later).
-2. You add `{{WORKSPACE_ROOT}}` as an Orca project if needed (Browse folder accepts a folder that holds many repositories), and open that folder workspace.
-3. You open one **temporary plain terminal** there — not the master. We only need its seat id. It will feel like "open, we measure, then close."
-4. You paste or send us that terminal's runtime handle so we can read where it sits.
-5. We record the durable seat id in the ops repository.
-6. **You close that temporary terminal** (or we close it if it is ours). Leaving it open means Step 8 would create a second terminal in the same seat. The real master is created only in Step 8, and exactly one master may exist.
-
-Only after the owner has heard that sequence, ask them to perform steps 2–4. Resolve `ORCA` exactly as Step 0's preflight does, then run:
-
-```console
-$ ORCA repo add --path "{{OPS_REPO}}" --json
-$ ORCA terminal show --terminal <terminal handle> --json
-```
-
-Capture the returned selector only when the terminal metadata proves the workspace-level seat: a folder workspace reports `worktreeId` as `folder:<uuid>` with an empty `worktreePath`, and that emptiness is the expected shape, so judge by `worktreeId`. Before continuing, persist a durable placement result in an ops-repository file containing the selector in `id:` prefixed form, `{{WORKSPACE_ROOT}}`, and the `terminal show` proof; do not rely on conversation state, and do not treat the temporary terminal's handle as durable, because handles are scoped to the app runtime and die with restarts. The durable identity is the selector. After persisting, ask the user to close the temporary seat-check terminal (or close it yourself if it is yours). Step 5 initializes the issue tracker independently and does not require a second placement copy; it may record a pointer to this result. Do not substitute a filesystem path for the measured selector, and do not infer the seat from a shell's cwd.
-
-Verify:
-
-- the full open-measure-close sequence was explained before any temporary terminal was requested
-- `orca repo add --path "{{OPS_REPO}}" --json` succeeds or confirms the ops repository is already registered (worker worktrees are created from this registration)
-- `terminal show` measured the terminal metadata
-- the selector points at the workspace-level seat, never an individual repository worktree inside a multi-repository workspace
-- the durable placement result exists in `id:` prefixed selector form before founding spawn
-- the temporary seat-check terminal is closed, so the founding spawn will be the only terminal in that seat
-
-## Step 4. Replace Template Placeholders
-
-**Position and action:** Step 4 begins with the skeleton in place: replace every placeholder with confirmed or measured local facts.
-
-**Why/caution:** Keep product-specific rules in product repositories and keep `CLAUDE.md` and `AGENTS.md` byte-identical unless the user accepts host-specific divergence.
-
-Ask for each unresolved value and any coordination exclusions. Fill `{{RUNTIME_ROOT}}` from the current repository root and `{{TEMPLATE_VERSION}}` from its single-line `master-ops/TEMPLATE-VERSION`; do not ask for either. Pass `{{OPS_REPO}}/docs/MASTER-OPERATIONS.md` as `master-bootstrap-live --charter-pointer "Operations SSOT: {{OPS_REPO}}/docs/MASTER-OPERATIONS.md"`. Add no placeholders.
-
-Verify:
-
-```console
-$ ! rg '\{\{[^}]+\}\}' "{{OPS_REPO}}"
-$ cmp "{{OPS_REPO}}/CLAUDE.md" "{{OPS_REPO}}/AGENTS.md"
-```
-
-Also verify no source workspace's private names were copied accidentally.
-
-## Step 5. Initialize The Issue Tracker
-
-**Position and action:** Step 5 begins with a localized ops repository: initialize the chosen tracker there and make it resolve from `{{WORKSPACE_ROOT}}`.
-
-**Why/caution:** Execution state belongs in the tracker, but upward resolution can silently select a database above the workspace or stop at the wrong Git root.
-
-Explain that the tracker is working-state SSOT reloaded at boot and after compaction. Ask which tracker to use, whether to initialize it now, and which short issue prefix to use; propose a two- or three-character prefix beside the default and explain that IDs are spoken to the owner. Remind that this prefix is not the monitor namespace from Step 1.
-
-For Beads, run only after approval:
-
-```console
-$ cd "{{OPS_REPO}}" && bd init --prefix <approved prefix>
-$ { [ -e "{{WORKSPACE_ROOT}}/.beads" ] || [ -L "{{WORKSPACE_ROOT}}/.beads" ]; } \
-    && echo "already exists, inspect before linking" \
-    || ln -s "$(cd "{{OPS_REPO}}" && pwd)/.beads" "{{WORKSPACE_ROOT}}/.beads"
-$ cd "{{WORKSPACE_ROOT}}" && bd where
-```
-
-Immediately after `bd init`, compare `CLAUDE.md` and `AGENTS.md` before continuing. **Announce-and-proceed — do not open a choice for the byte-only case.**
-
-- If they differ only at the byte level (whitespace, blank lines, or block order) while the semantic content is the same: re-unify automatically, write the same common block to both files, and tell the owner in ELI5 once, for example: "Two instruction files for different agent hosts had drifted in formatting only; I made them match again so both hosts see the same rules. No decision needed from you." Then continue.
-- If any substantive line or block exists in only one file: stop and ask whether to accept host-specific divergence before proceeding. That is the only branch that needs a question.
-
-Ask before creating the workspace → ops `.beads` link. If the prefix is wrong, `bd rename-prefix` rewrites database IDs and references but not Markdown. For another tracker, measure its resolution rules. Record active work in the tracker and seed only load-bearing memory pointers and rules.
-
-Verify from `{{WORKSPACE_ROOT}}`, not inside the ops repository:
-
-- `bd where` or its equivalent resolves to the ops repository
-- this workspace database differs from every product repository database
-- no tracker database exists above `{{WORKSPACE_ROOT}}` on the path to the filesystem root
-- any tracker environment override printed from the agent's actual shell is empty or points inside the workspace
-
-## Step 6. Seed Universal User Rules
-
-**Position and action:** Step 6 begins with execution state reachable: store the user's durable, workspace-wide operating rules in the selected memory system.
-
-**Why/caution:** Keep private details out of public documents and product conventions out of the master layer. The word "master" in this template is a temporary role name, not the session's permanent callsign.
-
-Ask for:
-
-- preferred address for the owner (how the session should speak to them)
-- **master callsign** — a short name the owner will use for this session (examples: 자비스 / Jarvis, Friday, Alfred, or a free-form name). Explain that "master" is the role label in docs; the living session gets a callsign the owner chose. Record it in tracker memory and in the founding kickoff notes
-- primary response language
-- approval requirements before execution / handoff to workers / branch / commit / push / deploy
-- standing prohibitions
-
-Write short actionable rules without narrative duplication.
-
-Verify that memory lookup returns the seeded rules (including callsign and owner address), and that the rules are concise and not duplicated in Git documents.
-
-## Step 7. Explain The Settings Layer
-
-**Position and action:** Step 7 begins with durable user rules seeded: identify the host and the owner of settings and sensitive configuration.
-
-**Why/caution:** The template specifies hook behavior but does not ship hidden deny lists, credentials, secret paths, or environment-specific security implementation.
-
-Ask which hosts run the master, who owns hooks/security-sensitive configuration, and whether dispatch warning, role-state injection, and compaction probe hooks should be enabled. Present the hook wiring spec from `docs/MASTER-OPERATIONS.md`; delegate auth, permission, secrets, credentials, and production-data work to a dedicated security/operations session.
-
-Verify the hook spec is documented, no sensitive implementation was added, and its owner is explicit or unresolved.
-
-## Step 7.5. Offer The Skill Layer
-
-**Position and action:** Step 7.5 begins before the master is born: explain the optional stack in README, then ask which parts the user wants.
-
-**Why/caution:** Skills load into the founding session; some installers, especially GSD, modify lifecycle hooks and require deliberate user choice.
-
-Explain each component in one sentence before showing any command. Print approved install commands and stop; do not run them or edit `settings.json`, hooks, or plugin configuration.
-
-These five questions decided what is in the stack, and they are worth repeating when a component is proposed later:
-
-1. does it require an API key
-2. does it force telemetry, or collect more than the job needs
-3. does it add a management point
-4. does it still work if the operation grows past one person
-5. every tool claims to help with agent context. What else does this one actually resolve
-
-A component that fails the first three is usually a subscription pretending to be a dependency. A component that passes them but answers nothing for the fifth is a preference, and should be labelled as one.
-
-The stack this template was built against, with what each one is for and what it is deliberately not used for. Name the role before the install command, because a tool adopted without its boundary becomes the next thing to unwind:
-
-| component | role here | not used for |
-|---|---|---|
-| Orca | execution substrate: worktrees, terminals, sessions, supervised dispatch | required infrastructure, not a swappable preference |
-| tracker (Beads) | execution state that survives a session, as an issue graph | its memory is a short pointer cache toward Git, not the knowledge source of truth |
-| `ctx` | trace archive: cross-provider session history, queryable when handoff, ledger, and Git do not answer | not part of routine boot context |
-| `gitleaks` | matching engine for the publish gate | not the scope decision, which the wrapper keeps |
-| methodology skills | how the master plans and verifies | without them the charter reads as advice rather than procedure |
-| restraint skills | how much the master builds | pairs with the methodology layer rather than competing |
-| review graph | impact radius and review context, locally parsed | optional; its value is token cost, not correctness |
-| spec-driven framework | phase discipline from research through verification | installs lifecycle hooks, so it needs a deliberate yes |
-| worker runtime plugin | lets the master delegate implementation from inside its own session | one wiring of the adapter layer, not a harness requirement |
-
-Claude Code is the recommended host for the master, and a worker runtime such as Codex is a first-class executor rather than a fallback. Expect the preference to split hard between the two camps; the contracts hold either way, which is the point of an agent-neutral template.
-
-One asymmetry to plan around rather than discover: an agent without an interactive query interface cannot run the steps of this document that ask the user a question. Onboarding is a conversation. Run it from an agent that can ask, or supply every answer in the dispatch contract up front and record that the questions were answered in advance rather than asked.
-
-Install commands for the Claude Code case, printed and not run:
-
-```console
-$ /plugin marketplace add openai/codex-plugin-cc
-$ /plugin install codex@openai-codex
-$ /reload-plugins
-$ /codex:setup
-```
-
-Say which of them are optional in name only. The template carries documents and scripts; it cannot carry the host layer that makes a master behave the way the documents describe, so a component listed here as recommended is often load-bearing. State the consequence of declining each one in a sentence, in the same breath as the offer, rather than leaving the user to discover it later:
-
-- a methodology skill layer changes how the master plans and verifies; without it the master still runs, and reads the charter as advice rather than procedure
-- a restraint skill layer keeps the master from over-building; without it, expect larger diffs and more speculative structure. It pairs with the methodology layer rather than competing with it: one decides how to approach work, the other decides how much to build
-- a tracker skill layer is what makes execution state survive a session; without it, state lives only in the transcript
-- a worker runtime is what makes delegation possible at all; without at least one, the master does every task itself
-
-When the user declines a component the preflight treats as essential, ask once more. Not as a nag: restate the specific behaviour that changes, then ask whether to proceed without it. One re-ask, then take the answer as final.
-
-The reason to ask twice is that the first no is usually answering a different question. A component list reads as preferences, so the first pass is "do I want this", while the question that matters is "am I accepting this behaviour". Restating the consequence is what turns one into the other.
-
-Record the confirmed decline together with what is being accepted, in the user's own terms where possible. A declined component is a fact about the installation, and later behaviour that looks like a master defect is often a declined component instead.
-
-Where the agent running onboarding has no interactive query interface, the re-ask cannot happen at all. In that case the dispatch contract carries the confirmed declines up front, and the record says they were confirmed in advance rather than asked.
-
-Verify the explanation preceded commands, nothing was installed or configured by the agent, every essential decline was re-asked once with its consequence restated, and the user's choice, including no installation, is recorded with what it accepts.
-
-## Step 7.6. State What The Publish Gates Do Not Cover
-
-**Position and action:** Step 7.6 follows immediately, while the gates are fresh: tell the user what the redaction gates check and, more importantly, where they are silent.
-
-**Why/caution:** A gate that is trusted beyond its scope is worse than no gate, because it converts an unchecked surface into a believed-clean one.
-
-The gates read repository content. Name the surfaces they do not read, so nobody assumes coverage that does not exist:
-
-- pull request titles, bodies, and review comments
-- release notes and issue text
-- anything typed into a forge web interface
-
-None of those are in the repository, so no scanner in this template sees them. They are also where internal names most easily arrive, because they are written in prose rather than code. The habit that works is to grep your own outgoing text for organization identifiers before posting it, exactly as the scan does for files.
-
-Tell the user that organization-specific patterns live in a file outside version control, that the gates fail closed without it, and that its format is one rule per line as `id|description|regex`. That file is what makes the gates able to catch a workspace name; the shipped rules only catch generic provider secrets.
-
-Do **not** run a comprehension quiz or ask the owner to recite a surface back. Explain the gap once, in plain language, then continue. A quiz reads as condescension and adds no durable record.
-
-Verify:
-
-- the uncovered surfaces were named in conversation
-- the organization rules file exists, or its absence is recorded as a known gap
-- no quiz or "prove you understood" prompt was used
-
-## Step 8. Spawn The Founding Master Through Orchestration
-
-**Position and action:** Step 8 begins with the workspace prepared: create a Run and Task, spawn exactly one placement-verified Generation 1 master, attach its worker Dispatch, and wait for `worker_done`.
-
-**Why/caution:** Supervised dispatch is Orca orchestration only; raw terminal polling and vendor-direct CLIs are non-compliant, and failures remain closed.
-
-Ask for confirmation to spawn now or defer, reload the durable placement result from Step 3.5 and confirm the selector still resolves on the host (`ORCA terminal list --worktree <selector> --json`); the temporary seat-check terminal from Step 3.5 is already closed, so there is no handle to check, and the spawn itself verifies placement against this selector again. Write a kickoff file containing Generation 1, this installer as founding origin, the callsign from Step 6, the boot sequence (rehydrate ops docs, declare Role State, measure model and placement), the initial queue, and the requirement to report the orchestration Task complete.
-
-Before launching any worker, follow `docs/MASTER-OPERATIONS.md` §3: MEASURE the installed agent CLI's non-interactive approval flags from `--help` and never guess them.
-
-Before attaching a Codex worker, run `{{RUNTIME_ROOT}}/scripts/codex-worker-pretrust <worktree-path>` as the pre-trust step.
-
-Run this supervised path with the resolved `ORCA` executable:
-
-```console
-$ G={{RUNTIME_ROOT}}/scripts/dispatch-gate
-$ L=~/.mogui/dispatch-ledger.jsonl
-$ "$G" --ledger "$L" check \
-    --runtime <runtime> \
-    --model "{{MODEL_ID}}" \
-    --contract <contract file> \
-    --agents 1 \
-    --est-chars <estimated input chars> \
-    --completion-channel orchestration
-$ ORCA orchestration run-create --objective "Found and verify the Generation 1 master" --json
-$ ORCA orchestration task-create --spec "Run the byte-identical founding kickoff file and complete Step 9 boot smoke" --json
-$ "{{RUNTIME_ROOT}}/scripts/master-succeed" spawn \
-    --workspace-selector <durable placement selector from Step 3.5, id: prefixed> \
-    --kickoff-file <kickoff file> \
-    --root "{{WORKSPACE_ROOT}}" \
-    --model "{{MODEL_ID}}" \
-    --title "Gen-1 founding boot" \
-    --json
-$ ORCA terminal wait --terminal <verified live handle> --for tui-idle --timeout-ms 60000 --json
-$ ORCA orchestration dispatch --task <task id> --to <verified live handle> --inject --json
-$ "$G" --ledger "$L" register \
-    --job-id <job id> \
-    --probe-cmd "<command proving the job-id appears in an artifact>" \
-    --orchestration-task <task id>
-$ ORCA orchestration check --wait --types worker_done,escalation,question --timeout-ms 900000 --json
-```
-
-Require the gate `check` to return `allow: true` before spawning or attaching the worker. After the Dispatch artifact exists, run `register` with that exact orchestration Task ID before waiting for final completion evidence.
-
-Require placement verification `MATCH` or `MATCH_REISSUED`; the latter must include `handle_reissued: true` and its adopted live handle. On any failure, do not retry with a filesystem path selector, do not boot the master in this installer, and do not create a second session. After settings changes, always spawn a fresh session.
-
-Verify:
-
-- a Run is bound, one Task exists, and its Dispatch is attached to the verified worker
-- exactly one new master process/session exists
-- placement is `MATCH` or valid `MATCH_REISSUED`
-- kickoff content received by the master matches the kickoff file byte-for-byte
-- the coordinator processes and acknowledges deliveries, answers questions through orchestration, and waits until that Task's `worker_done`
-
-## Step 9. Run The First Master Boot Smoke
-
-**Position and action:** Step 9 runs inside the new master session: declare its role, measure identity and placement, record lineage, and report completion.
-
-**Why/caution:** Model identity is measured, unavailable, or unsupported, never guessed, and the installer does not perform this boot on the master's behalf.
-
-Ask for the initial role or approval to start in Maintenance, plus permission for local read-only model and seat checks. Update `docs/runbooks/role-state.md` for Generation 1, declare Role State in conversation (include the callsign), measure configured and actual model when exposed, capture placement evidence, append Generation 1 to `docs/lineage/MASTER-LINEAGE.md`, then send `worker_done` exactly once for the active Dispatch.
-
-Verify:
-
-- Role State has one active role and Role Lock is enabled
-- model measurement is reported as measured, unavailable, or unsupported
-- placement evidence includes the host pane/worktree selector, process cwd under `{{WORKSPACE_ROOT}}`, and session artifact/log namespace
-- no placeholders remain unless the user intentionally deferred them
-- the founding Task and Dispatch complete through `worker_done`
-
-## Step 10. Hand The Human A Card, Then Close The Installer
-
-**Position and action:** Step 10 runs after the master reports a clean boot: verify the conversation actually happened, hand the user something portable, and ask them to close the installer terminal.
-
-**Why/caution:** Everything installed here is worthless if the user does not know the four or five sentences that operate it, and an installer session left running is a second agent holding the same repository.
-
-First verify the conversation, not just the artifacts. The steps above ask questions; a run that produced files without answers is a run that guessed. Check that the workspace facts were confirmed rather than inferred, that the component choices are recorded including declines, and that each essential decline was re-asked once. If any answer is missing, ask now rather than recording an assumption as a decision.
-
-Then write the operating card. Print it, and tell the user to keep it wherever they keep notes, as plain text under a name they will find again, such as `llm.txt`. It is written to be pasted into any agent, so it must not depend on this session existing:
-
-```text
-# Operating this workspace
-
-Master lives in: {{WORKSPACE_ROOT}}          Ops repository: {{OPS_REPO}}
-State: the issue tracker in the ops repository. Long-term decisions: Git.
-
-To start work, tell the master:
-  "Role State?"                     it reports its active role and lock
-  "Propose <goal>"                  it plans, then waits for your approval
-  "Approved, execute"               it executes only what you approved
-
-To delegate, tell the master:
-  "Dispatch <task> to a worker"     it runs the gate, dispatches, and verifies
-                                     the result before accepting it
-
-Before publishing anything, the master runs:
-  the test suite, the redaction scan, the redaction inventory
-  A green scan covers repository content only. Pull request text,
-  release notes, and issue prose are not scanned by anything.
-
-When a session gets long:
-  "Propose succession"              it audits, spawns a clean successor,
-                                     and freezes itself
-
-If the master behaves unlike the documents, check what was declined at
-onboarding before assuming a defect. Declined at install:
-  <declined components, or the word none>
-
-New to Orca? Concepts, and labels that look alarming but are normal:
-  {{RUNTIME_ROOT}}/docs/public/orca-concepts.md
-```
-
-Fill the declined slot (the `<declined components, or the word none>` line) from the recorded choices. If nothing was declined, write the word none rather than leaving it blank, because a blank line reads as unknown. The angle-bracket slots in the card are filled by hand at print time; do not introduce a new `{{...}}` placeholder for them, since Step 4 verifies that only the eight allowed placeholders remain anywhere in this document.
-
-Finally, ask the user to close this installer terminal now that the master is running. Say why in one sentence: two agents holding one repository is how uncommitted work gets lost, and the installer has no further role. Do not close it yourself, and do not close the master's terminal.
-
-If the user lingers with Orca questions instead of closing, answer them here under the Orca Context Charter (grounded in the docs snapshot and the concepts guide) before retiring; a user who leaves onboarding still confused about workspaces will misplace the next master by hand.
-
-Verify:
-
-- the card was printed in full, with placeholders replaced and the declined line filled or explicitly none
-- the user was told where to keep it and that it works when pasted into any agent
-- the user was asked to close the installer terminal, with the reason given
-- the master's terminal was left running
+- Pacing: ship the install in small chunks — one step's orientation, one measured fact block, then that step's questions. Never the whole map plus a stack of questions in one turn. Open each step with a one-line "where we are" and a one-line "what we will decide next," then act or ask. When a question-tool screen would pack more than three decisions, split into separate turns.
+
+## Template placeholders
+
+Use only these: `{{WORKSPACE_NAME}}`, `{{WORKSPACE_ROOT}}`, `{{OPS_REPO}}`, `{{MONITOR_NS}}`, `{{MODEL_ID}}`, `{{REPO_LIST}}`, `{{RUNTIME_ROOT}}`, `{{TEMPLATE_VERSION}}`. The installer measures the last two in the placeholders step rather than asking the user. Add no placeholders.
+
+## Step index
+
+The installer start path is `00-orientation.md` → `01-preflight.md` only. Defer every later file until that step begins.
+
+| # | File | Step | Decides / produces |
+|---|---|---|---|
+| 00 | `onboarding/00-orientation.md` | Orientation | owner knows the system, the three layers, the end state |
+| 01 | `onboarding/01-preflight.md` | Step 0 | preflight passes; agent CLI named |
+| 02 | `onboarding/02-workspace-facts.md` | Step 1 | purpose, root, inventory, name / monitor namespace / model |
+| 03 | `onboarding/03-ops-repo.md` | Steps 2–3 | ops repository chosen and created |
+| 04 | `onboarding/04-seat.md` | Step 3.5 | ops repo registered; durable workspace seat recorded |
+| 05 | `onboarding/05-placeholders.md` | Step 4 | placeholders replaced; entry files identical |
+| 06 | `onboarding/06-tracker.md` | Step 5 | issue tracker resolves from the workspace root |
+| 07 | `onboarding/07-user-rules.md` | Step 6 | owner rules and master callsign seeded |
+| 08 | `onboarding/08-settings-and-skills.md` | Steps 7–7.6 | hook owners, skill stack, publish-gate scope |
+| 09 | `onboarding/09-spawn.md` | Steps 8–9 | Gen-1 master spawned through orchestration; boot smoke |
+| 10 | `onboarding/10-card-and-retire.md` | Step 10 | operating card handed over; installer retires |
+| — | `onboarding/reverify.md` | Reverify mode | health checklist for an already-founded workspace; no spawn |

--- a/master-ops/onboarding/00-orientation.md
+++ b/master-ops/onboarding/00-orientation.md
@@ -1,0 +1,43 @@
+# 00 — Orientation (before Step 0)
+
+Load rule: read this file only when orientation begins. Router: [`../ONBOARDING.md`](../ONBOARDING.md). Next file after Verify passes: `01-preflight.md`.
+
+## Owner script (3–6 sentences, adapt to the owner's language)
+
+Tell the user, in their language and before asking anything:
+
+1. This system runs one master session per workspace to coordinate its repositories; Orca spawns it and checks that it sits in the right place, and a dedicated ops repository keeps governance state.
+2. Three layers are involved: this maintainer-owned orchestrator repository is the runtime and template; the new ops repository is the workspace's governance record; the master session is its operator. This installer session is none of them and retires at the end.
+3. Steps 0 through 7.6 measure facts and build the ops repository; Step 8 spawns the master; Step 9 is the master's first-boot smoke in its own session.
+4. The end state is an ops repository with a completed operations document, an issue tracker reachable from the workspace root, seeded user rules, and exactly one verified Generation 1 master.
+
+Keep the user oriented with the opening line in every step.
+
+## Map (agent notes)
+
+- Orchestrator layer: this repository owns the runtime, template, and onboarding flow.
+- Ops layer: the generated operations repository owns workspace governance records.
+- Session layer: one Orca-hosted master operates the workspace and retires through succession.
+- `docs/MASTER-OPERATIONS.md` owns durable rules as the master-operations SSOT.
+- `docs/runbooks/role-state.md` owns the master's current role and Role Lock state.
+- `docs/runbooks/succession-boot-card.md` owns boot and recovery order.
+- `bd` owns execution state; follow the `bd prime` caution only after `bd where` proves the ops repository.
+- `contracts/` owns bounded worker briefs; it is not the execution-state tracker.
+- Agents: ground Orca claims in the [Orca documentation](https://www.onorca.dev/) before improvising; resolve the current snapshot agent index at onboarding rather than relying on a hash that may change.
+
+## Orca Context Charter, installer scope
+
+This charter binds the installer session only; it is not copied into the master's operating documents. Use the Orca docs snapshot as source-grounded context for every Orca claim made during onboarding:
+
+- Agent index, read first: the snapshot's `llms.txt` page map (current link in the runtime repository README under "Why Orca is required").
+- Fetch the smallest relevant page from that index first, and load the full Markdown only when a task genuinely needs the whole documentation at once.
+- Treat the snapshot as read-only and generated. Prefer source-grounded claims, cite the page or source file used, and check the live Orca repository when freshness or code changes matter.
+- Keep provider assumptions out of plans; use whatever fetch, file, and shell tools this session provides.
+- After reading, state in one line what was relied on, then proceed.
+
+Two standing duties come with the charter. First, whenever the user signals they are new to Orca or asks what a project, workspace, worktree, or terminal is, answer in place from these sources and [docs/public/orca-concepts.md](../../docs/public/orca-concepts.md) rather than deferring them to a link. Second, expected UI labels that look alarming (for example the "Unavailable worktree" chip on folder workspace sessions) get explained as normal before the user has to ask.
+
+## Verify
+
+- the four orientation points were delivered in the owner's language before the first question
+- no step file beyond `01-preflight.md` has been opened

--- a/master-ops/onboarding/00-orientation.md
+++ b/master-ops/onboarding/00-orientation.md
@@ -4,7 +4,7 @@ Load rule: read this file only when orientation begins. Router: [`../ONBOARDING.
 
 ## Owner script (3–6 sentences, adapt to the owner's language)
 
-Tell the user, in their language and before asking anything:
+Tell the user, in their language and before asking anything else (the router's session-mode question has already happened):
 
 1. This system runs one master session per workspace to coordinate its repositories; Orca spawns it and checks that it sits in the right place, and a dedicated ops repository keeps governance state.
 2. Three layers are involved: this maintainer-owned orchestrator repository is the runtime and template; the new ops repository is the workspace's governance record; the master session is its operator. This installer session is none of them and retires at the end.

--- a/master-ops/onboarding/01-preflight.md
+++ b/master-ops/onboarding/01-preflight.md
@@ -1,0 +1,41 @@
+# 01 — Pass The Required Preflight (Step 0)
+
+Load rule: read this file only when Step 0 begins. Router: [`../ONBOARDING.md`](../ONBOARDING.md). Next file after Verify passes: `02-workspace-facts.md`.
+
+**Position and action:** Step 0 starts after orientation, with no workspace state changed: run `bash scripts/onboarding-preflight.sh` from `{{RUNTIME_ROOT}}` and fix every FAIL before continuing.
+
+**Why/caution:** Orca, an orchestration Run bound to this terminal, the Orca skills, Beads, Python, the named agent CLI, at least one worker runtime to dispatch to, Git, and the organization rules file are all required; do not offer a non-Orca fallback. Never suggest skipping the preflight itself: that discards every other check with it.
+
+## Owner script (3–6 sentences, adapt to the owner's language)
+
+Where we are: orientation is done; nothing on the machine has been changed yet. What we decide next: whether this machine has everything the system needs, using read-only checks. Ask whether the user is ready for local read-only checks, and which agent CLI they expect to use (for example `claude`). Explain that if a check fails, we fix it together before moving on — nothing is skipped silently.
+
+## Run
+
+Show the owner-facing form with `$` when you narrate the check; the agent may run the same lines without asking the owner to type them:
+
+```console
+$ cd "{{RUNTIME_ROOT}}"
+$ ORCA_AGENT_CLI="<user-named agent CLI>" bash scripts/onboarding-preflight.sh
+$ command -v "<user-named agent CLI>"
+$ command -v git
+```
+
+Use `bash scripts/onboarding-preflight.sh --fix` only with approval; it may add or refresh the global Orca skills, while application installs remain manual.
+
+## Verify
+
+- the preflight exits zero, Orca status was measured, a non-legacy orchestration Run is bound to this terminal, required skills resolve, `bd` is present and resolves to the ops repo when one exists, and Python is present
+- the named agent CLI is set and resolves on `PATH`; an unset selection is a FAIL, because it silently downgrades the agent-specific checks to INFO
+- at least one of the worker runtimes this master dispatches to resolves on `PATH`; the others are reported as warnings, since routing every lane through one executor is a normal setup
+- `gitleaks` was measured: present passes, absent warns without blocking, because publishing needs it (the redaction gate exits 2 without its engine) while running a master does not. Treat the warning as a real install item on any host that will publish
+- `ctx` was measured: present with a reachable index passes, absent or unreachable warns without blocking, because the records practice cannot query cross-provider history without it while a master still runs. Ignore the warning only on a host that does no history work
+- Git is present, and `gh` state was reported: a missing binary blocks, while unauthenticated or a missing `workflow` scope warns, because local-only work needs no forge credentials
+- every waiver in the summary was intended, and `PREFLIGHT_WAIVE` entries that matched no check are corrected rather than left, since a misspelled waiver leaves the check enforced
+- the organization rules file loads at least one rule and no rule is malformed; the preflight reports counts only and never the file's contents
+
+## If fail
+
+- A host that legitimately cannot satisfy one required check sets `PREFLIGHT_WAIVE=<check-label>`, which downgrades that FAIL to a printed and counted waiver; the summary then reads READY WITH WAIVERS and names them, because a required check that was waived was not satisfied.
+- Orchestration is measured by capability rather than reachability. Two states measured on real hosts: a retained legacy coordinator answers reads and drops writes with `effectsApplied:false`, and an unbound coordinator fails the whole task family with `run_required`. A binding can also drop later without any signal, after which `check` returns `count:0`, so an empty mailbox and a missing binding look identical. If the preflight reports either state, bind a fresh Run with `orca orchestration run-create` and measure again; restarting the app does not clear the legacy one.
+- Do not attribute a lost injection to binding state without a control: a lost task and a delivered task inside the same Run were measured on 2026-08-02, which rules binding out as that discriminator.

--- a/master-ops/onboarding/01-preflight.md
+++ b/master-ops/onboarding/01-preflight.md
@@ -4,7 +4,7 @@ Load rule: read this file only when Step 0 begins. Router: [`../ONBOARDING.md`](
 
 **Position and action:** Step 0 starts after orientation, with no workspace state changed: run `bash scripts/onboarding-preflight.sh` from `{{RUNTIME_ROOT}}` and fix every FAIL before continuing.
 
-**Why/caution:** Orca, an orchestration Run bound to this terminal, the Orca skills, Beads, Python, the named agent CLI, at least one worker runtime to dispatch to, Git, and the organization rules file are all required; do not offer a non-Orca fallback. Never suggest skipping the preflight itself: that discards every other check with it.
+**Why/caution:** Orca, an orchestration Run bound to this terminal, the Orca skills, Beads, Python, the named agent CLI, at least one worker runtime to dispatch to, Git, the GitHub CLI (`gh`), and the organization rules file are all required; do not offer a non-Orca fallback. Never suggest skipping the preflight itself: that discards every other check with it.
 
 ## Owner script (3–6 sentences, adapt to the owner's language)
 

--- a/master-ops/onboarding/02-workspace-facts.md
+++ b/master-ops/onboarding/02-workspace-facts.md
@@ -1,0 +1,87 @@
+# 02 — Collect Workspace Facts (Step 1)
+
+Load rule: read this file only when Step 1 begins. Router: [`../ONBOARDING.md`](../ONBOARDING.md). Next file after Verify passes: `03-ops-repo.md`.
+
+**Position and action:** Step 1 begins after prerequisites pass: collect and measure the workspace facts before routing any work. Pace this step in three short turns when needed: (A) purpose and workspace root, (B) repository inventory, (C) name, monitor namespace, and model.
+
+**Why/caution:** The master operates above repositories and needs a confirmed absolute root, a purpose, and an inventory.
+
+## Owner script (3–6 sentences, adapt to the owner's language)
+
+Where we are: the machine checks passed. What we decide next: what this master is for and which folder it will manage. Before asking, give these plain definitions in the user's language:
+
+- "Workspace (root)" is the folder that groups the repositories this master will manage, nothing more.
+- "Workspace name" is a display label; by default, it is that folder's name.
+- "Monitor namespace" is a short tag that keeps this workspace's session artifacts separate from other workspaces. It is not the issue-tracker prefix (that comes later, in the tracker step).
+- "Default model identifier" is the model the master session is expected to run as; use the chosen agent CLI's table row below as the recommended candidate and measure the actual model at boot rather than guessing.
+
+## Step 1A. Purpose, then root
+
+Ask what this master is for, with concrete examples so the owner can recognize a fit rather than invent a category. Examples to offer (adapt language; keep the range):
+
+- Coordinate several product repositories under one owner (multi-repo product workspace).
+- Maintain one open-source or internal library and its docs, issues, and release path.
+- Run a personal or experimental sandbox that may be thrown away.
+- Operate a platform or harness repository (like this orchestrator) while keeping product checkouts separate.
+- Something else — free-form is always valid.
+
+Explain why: purpose shapes which folder is the right root, which repositories belong in the inventory, and how aggressive the master should be about outside checkouts. Record the answer in the operations document later; do not invent a purpose if the owner defers.
+
+Master model criteria (for the later model question in 1C; do not ask model yet):
+
+| Agent CLI | Master-session top-tier candidate |
+| --- | --- |
+| `claude` | `claude-fable-5` |
+| `codex` | `gpt-5.6-sol` |
+| `grok` | `grok-4.5` |
+| `cursor-agent` | measured at boot; no fixed identifier yet |
+
+The master session runs the top tier of its agent family. Worker and dispatch models use task-based tier selection instead: choose the lowest sufficient tier and state the exact model explicitly in every dispatch. For the `{{MODEL_ID}}` question in 1C, recommend the row for the chosen agent CLI; for `cursor-agent`, recommend measuring at boot and confirming the candidate with the owner.
+
+**Workspace root — guide, then ask. Do not scan the disk for candidates and do not present a ranked shortlist of folders the agent discovered.** That pattern feels like the installer is choosing the owner's house for them. The owner chooses; the installer only validates what they paste.
+
+Give a short setup guide in the owner's language (terms first, then how to pick, then how to send the path):
+
+1. **What it is:** the folder that *groups* the repositories this master will manage — not one product repo inside it, and not a broad home folder that mixes unrelated projects.
+2. **How to pick (owner criteria, not agent measurement):**
+   - Several product repos → the folder that already contains them.
+   - One repo only → that repo's *parent* folder (so the master sits above it).
+   - Experiment / disposable → a new empty folder is fine; create it first if needed.
+   - Prefer an existing grouping folder over inventing a wider one.
+3. **How to send the absolute path (prefer Orca):** In Orca, select the project or folder that should be the workspace root and use **Copy path** (or the equivalent path-copy action in the project/folder UI). Paste that absolute path into the chat. Alternatives if they are not in Orca yet: Finder → folder → Get Info / copy path, or a terminal `pwd` after `cd` into the folder. Relative paths and `~` alone are not enough; we need a full absolute path.
+4. **What happens next:** only after they paste a path, the installer checks that it exists and is a directory — never before, and never by fishing nearby parents.
+
+Then ask once: please set or confirm that folder, copy its absolute path, and paste it here. Wait for their answer. Do not invent or "helpfully default" a path from `{{RUNTIME_ROOT}}`'s parent tree.
+
+Only after the owner provides a path, validate:
+
+```console
+$ test "${WORKSPACE_ROOT#/}" != "$WORKSPACE_ROOT" && test -d "$WORKSPACE_ROOT"
+$ ls -la "$WORKSPACE_ROOT"
+```
+
+## Step 1B. Repository inventory
+
+Read current files first. Detect every immediate child Git repository under the confirmed root. **Default: register all of them into `{{REPO_LIST}}`.** Read the full measured list back for confirmation. Do not open with exclusion hunting; the owner may drop a child only by explicit opt-out after seeing the full list. Never invent repositories that were not measured.
+
+When the user names a repository that lives outside the confirmed workspace root, lead with the default path and plain language: **please move or clone it under the workspace root** so the master can see it and Orca's sidebar stays one workspace. Explain why: the master holds the inventory (`{{REPO_LIST}}`) and measures code across it (for example a review graph indexed at the workspace root); a path outside the root is invisible to that measurement and splits the sidebar. Only if the owner refuses to move it, offer the secondary home:
+
+- **Default / recommended:** move or clone under the workspace root; it joins `{{REPO_LIST}}` as an ordinary member. The installer does not move anything; the owner does.
+- **Secondary (opt-in):** record it as an external lane — absolute path, who may write, which gates run before push. Every claim about it needs its own measurement. Legitimate cases include a public open-source lane or another owner's checkout.
+
+## Step 1C. Name, monitor namespace, model
+
+Ask for workspace name (default: confirmed root basename), monitor namespace, and default model identifier to measure at boot, with measured candidates, a recommendation and reason, and a free-form option for each when available; explain why each is needed. Remind once that monitor namespace is not the Beads/issue prefix.
+
+## Verify
+
+- the master's purpose was asked with examples and recorded or explicitly deferred
+- the owner was guided with definitions and path-copy instructions; the agent did **not** present measured folder candidates
+- `{{WORKSPACE_ROOT}}` was provided by the owner (absolute path), then validated as an existing directory
+- `{{WORKSPACE_NAME}}` is explicit or is the confirmed root basename approved by the user
+- `{{REPO_LIST}}` defaults to every measured immediate child repository, with only explicit opt-outs removed
+- every repository the user named that lives outside the root was offered move/clone first; if still outside, it is recorded as an external lane with access rules; none is left implicit
+
+## If fail
+
+- If the pasted path is missing, not absolute, or not a directory, say so plainly and ask them to paste again. Do not substitute a measured fallback.

--- a/master-ops/onboarding/03-ops-repo.md
+++ b/master-ops/onboarding/03-ops-repo.md
@@ -1,0 +1,37 @@
+# 03 — Choose And Create The Ops Repository (Steps 2–3)
+
+Load rule: read this file only when Step 2 begins. Router: [`../ONBOARDING.md`](../ONBOARDING.md). Next file after Verify passes: `04-seat.md`.
+
+## Step 2. Choose the ops repository
+
+**Position and action:** Step 2 begins with a confirmed workspace inventory: recommend and obtain approval for the ops repository.
+
+**Why/caution:** Governance needs a visible ownership boundary that cannot be confused with product code.
+
+### Owner script (3–6 sentences, adapt to the owner's language)
+
+Where we are: the workspace facts are confirmed. What we decide next: where this workspace's governance records will live — a small repository that is clearly separate from product code. Ask whether to create a new repository or reuse an existing operations repository, and whether local Git initialization is allowed for a new ops repository; this choice applies only to `{{OPS_REPO}}`, never to `{{WORKSPACE_ROOT}}`.
+
+Inspect the confirmed names; propose two or three candidates with pros and cons; recommend `<workspace>-ops`; evaluate governance clarity, separation from product scope, and shell-title ambiguity; use a structured choice when available.
+
+### Verify (Step 2)
+
+- `{{OPS_REPO}}` is an approved absolute path or repository name
+- the selection was evaluated against the confirmed inventory
+- no product repository name was reused
+
+## Step 3. Create the ops repository
+
+**Position and action:** Step 3 begins with an approved name: create or deliberately reuse the ops repository before registering it in Orca.
+
+**Why/caution:** Read and merge existing files; never overwrite operations records or initialize Git without approval.
+
+Ask for confirmation to create or reuse `{{OPS_REPO}}` and separate confirmation before local Git initialization of that ops repository.
+
+If new or empty, copy the Stage 1 skeleton from `{{RUNTIME_ROOT}}/master-ops/`, excluding `TEMPLATE-VERSION`, `CHANGELOG.md`, `ONBOARDING.md`, and the `onboarding/` directory; if existing, merge deliberately after reading it. Do not push unless explicitly asked.
+
+### Verify (Step 3)
+
+- the ops repository exists with `CLAUDE.md`, `AGENTS.md`, `docs/MASTER-OPERATIONS.md`, and the Stage 1 skeleton
+- only the allowed remaining placeholders are present
+- `TEMPLATE-VERSION`, `CHANGELOG.md`, `ONBOARDING.md`, and the `onboarding/` directory are absent from the generated repository

--- a/master-ops/onboarding/04-seat.md
+++ b/master-ops/onboarding/04-seat.md
@@ -1,0 +1,40 @@
+# 04 — Register The Ops Repository And Seat The Master (Step 3.5)
+
+Load rule: read this file only when Step 3.5 begins. Router: [`../ONBOARDING.md`](../ONBOARDING.md). Next file after Verify passes: `05-placeholders.md`.
+
+**Position and action:** Step 3.5 begins after Step 3: register `{{WORKSPACE_ROOT}}` and the already-Git `{{OPS_REPO}}` with Orca, then seat the master terminal at the workspace level: the folder workspace of `{{WORKSPACE_ROOT}}` when the root is a folder containing repositories, or the repository's primary worktree when the workspace is a single repository.
+
+**Why/caution:** The master coordinates every repository, so its seat is the workspace-level workspace, never one repository's worktree inside a multi-repository workspace. A master seated in a repository worktree binds correctly (cwd, hooks, session files) yet hangs under that one repository in the owner's sidebar and occupies a seat shaped for a worker; exactly this shipped as a measured misplacement on 2026-08-03. The folder route is verified from the CLI with the `id:folder:<uuid>` selector form: precheck listing, terminal create, and spawn placement match all pass (measured 2026-08-03). Bare `folder:<uuid>` is accepted by `terminal create` but rejected by `terminal list` (a measured subcommand asymmetry), and `path:` selectors are rejected by the placement comparison, so the durable record must use the `id:` prefixed form, which every consumer accepts. [docs/public/orca-concepts.md](../../docs/public/orca-concepts.md) holds the object model.
+
+## Owner script (3–6 sentences, adapt to the owner's language)
+
+**Before any UI action, explain the whole short flow to the owner in plain language. Do not start mid-step.** Say, in substance:
+
+1. We register the ops repository with Orca (so workers can get worktrees from it later).
+2. You add `{{WORKSPACE_ROOT}}` as an Orca project if needed (Browse folder accepts a folder that holds many repositories), and open that folder workspace.
+3. You open one **temporary plain terminal** there — not the master. We only need its seat id. It will feel like "open, we measure, then close."
+4. You paste or send us that terminal's runtime handle so we can read where it sits.
+5. We record the durable seat id in the ops repository.
+6. **You close that temporary terminal** (or we close it if it is ours). Leaving it open means the spawn step would create a second terminal in the same seat. The real master is created only in the spawn step, and exactly one master may exist.
+
+Only after the owner has heard that sequence, ask them to perform steps 2–4.
+
+## Run
+
+Resolve `ORCA` exactly as Step 0's preflight does, then run:
+
+```console
+$ ORCA repo add --path "{{OPS_REPO}}" --json
+$ ORCA terminal show --terminal <terminal handle> --json
+```
+
+Capture the returned selector only when the terminal metadata proves the workspace-level seat: a folder workspace reports `worktreeId` as `folder:<uuid>` with an empty `worktreePath`, and that emptiness is the expected shape, so judge by `worktreeId`. Before continuing, persist a durable placement result in an ops-repository file containing the selector in `id:` prefixed form, `{{WORKSPACE_ROOT}}`, and the `terminal show` proof; do not rely on conversation state, and do not treat the temporary terminal's handle as durable, because handles are scoped to the app runtime and die with restarts. The durable identity is the selector. After persisting, ask the user to close the temporary seat-check terminal (or close it yourself if it is yours). The tracker step initializes the issue tracker independently and does not require a second placement copy; it may record a pointer to this result. Do not substitute a filesystem path for the measured selector, and do not infer the seat from a shell's cwd.
+
+## Verify
+
+- the full open-measure-close sequence was explained before any temporary terminal was requested
+- `orca repo add --path "{{OPS_REPO}}" --json` succeeds or confirms the ops repository is already registered (worker worktrees are created from this registration)
+- `terminal show` measured the terminal metadata
+- the selector points at the workspace-level seat, never an individual repository worktree inside a multi-repository workspace
+- the durable placement result exists in `id:` prefixed selector form before founding spawn
+- the temporary seat-check terminal is closed, so the founding spawn will be the only terminal in that seat

--- a/master-ops/onboarding/04-seat.md
+++ b/master-ops/onboarding/04-seat.md
@@ -38,3 +38,9 @@ Capture the returned selector only when the terminal metadata proves the workspa
 - the selector points at the workspace-level seat, never an individual repository worktree inside a multi-repository workspace
 - the durable placement result exists in `id:` prefixed selector form before founding spawn
 - the temporary seat-check terminal is closed, so the founding spawn will be the only terminal in that seat
+
+## If fail
+
+- `terminal list` rejects the captured selector: the record is probably in the bare `folder:<uuid>` form — re-capture and persist the `id:` prefixed form, which every consumer accepts (the subcommand asymmetry above is measured behavior, not an error to work around).
+- The placement comparison rejects the selector: it is probably a `path:` form or a filesystem path — never substitute a path for the measured selector; re-run `terminal show` and capture `worktreeId`.
+- The terminal metadata shows a repository worktree instead of the workspace-level seat: the owner opened the temporary terminal in the wrong place; explain, ask them to open it in the folder workspace, and measure again.

--- a/master-ops/onboarding/05-placeholders.md
+++ b/master-ops/onboarding/05-placeholders.md
@@ -1,0 +1,24 @@
+# 05 — Replace Template Placeholders (Step 4)
+
+Load rule: read this file only when Step 4 begins. Router: [`../ONBOARDING.md`](../ONBOARDING.md). Next file after Verify passes: `06-tracker.md`.
+
+**Position and action:** Step 4 begins with the skeleton in place: replace every placeholder with confirmed or measured local facts.
+
+**Why/caution:** Keep product-specific rules in product repositories and keep `CLAUDE.md` and `AGENTS.md` byte-identical unless the user accepts host-specific divergence.
+
+## Owner script (3–6 sentences, adapt to the owner's language)
+
+Where we are: the ops repository skeleton exists. What we decide next: the few remaining blanks that only the owner can confirm. Ask for each unresolved value and any coordination exclusions, one short turn at a time.
+
+## Run
+
+Fill `{{RUNTIME_ROOT}}` from the current repository root and `{{TEMPLATE_VERSION}}` from its single-line `master-ops/TEMPLATE-VERSION`; do not ask for either. Pass `{{OPS_REPO}}/docs/MASTER-OPERATIONS.md` as `master-bootstrap-live --charter-pointer "Operations SSOT: {{OPS_REPO}}/docs/MASTER-OPERATIONS.md"`. Add no placeholders.
+
+## Verify
+
+```console
+$ ! rg '\{\{[^}]+\}\}' "{{OPS_REPO}}"
+$ cmp "{{OPS_REPO}}/CLAUDE.md" "{{OPS_REPO}}/AGENTS.md"
+```
+
+Also verify no source workspace's private names were copied accidentally.

--- a/master-ops/onboarding/05-placeholders.md
+++ b/master-ops/onboarding/05-placeholders.md
@@ -17,7 +17,7 @@ Fill `{{RUNTIME_ROOT}}` from the current repository root and `{{TEMPLATE_VERSION
 ## Verify
 
 ```console
-$ ! rg '\{\{[^}]+\}\}' "{{OPS_REPO}}"
+$ ! rg --hidden --no-ignore -g '!.git/**' -g '!.beads/**' '\{\{[^}]+\}\}' "{{OPS_REPO}}"
 $ cmp "{{OPS_REPO}}/CLAUDE.md" "{{OPS_REPO}}/AGENTS.md"
 ```
 

--- a/master-ops/onboarding/05-placeholders.md
+++ b/master-ops/onboarding/05-placeholders.md
@@ -17,7 +17,7 @@ Fill `{{RUNTIME_ROOT}}` from the current repository root and `{{TEMPLATE_VERSION
 ## Verify
 
 ```console
-$ ! rg --hidden --no-ignore -g '!.git/**' -g '!.beads/**' '\{\{[^}]+\}\}' "{{OPS_REPO}}"
+$ ! rg --hidden -g '!.git/**' -g '!.beads/**' '\{\{[^}]+\}\}' "{{OPS_REPO}}"
 $ cmp "{{OPS_REPO}}/CLAUDE.md" "{{OPS_REPO}}/AGENTS.md"
 ```
 

--- a/master-ops/onboarding/05-placeholders.md
+++ b/master-ops/onboarding/05-placeholders.md
@@ -22,3 +22,8 @@ $ cmp "{{OPS_REPO}}/CLAUDE.md" "{{OPS_REPO}}/AGENTS.md"
 ```
 
 Also verify no source workspace's private names were copied accidentally.
+
+## If fail
+
+- `rg` still finds `{{...}}` tokens: fill each from the confirmed facts, or record the owner's explicit deferral for that value; never delete a placeholder to silence the check.
+- `cmp` shows `CLAUDE.md` and `AGENTS.md` differ: if the divergence is byte-only formatting, re-unify to one common block in both files; if a substantive line exists in only one file, stop and ask whether host-specific divergence is intended.

--- a/master-ops/onboarding/06-tracker.md
+++ b/master-ops/onboarding/06-tracker.md
@@ -1,0 +1,44 @@
+# 06 — Initialize The Issue Tracker (Step 5)
+
+Load rule: read this file only when Step 5 begins. Router: [`../ONBOARDING.md`](../ONBOARDING.md). Next file after Verify passes: `07-user-rules.md`.
+
+**Position and action:** Step 5 begins with a localized ops repository: initialize the chosen tracker there and make it resolve from `{{WORKSPACE_ROOT}}`.
+
+**Why/caution:** Execution state belongs in the tracker, but upward resolution can silently select a database above the workspace or stop at the wrong Git root.
+
+## Owner script (3–6 sentences, adapt to the owner's language)
+
+Where we are: the ops repository is filled in. What we decide next: where day-to-day working state lives. Explain that the tracker is working-state SSOT reloaded at boot and after compaction. Ask which tracker to use, whether to initialize it now, and which short issue prefix to use; propose a two- or three-character prefix beside the default and explain that IDs are spoken to the owner. Remind that this prefix is not the monitor namespace from the workspace-facts step.
+
+## Run
+
+For Beads, run only after approval:
+
+```console
+$ cd "{{OPS_REPO}}" && bd init --prefix <approved prefix>
+$ { [ -e "{{WORKSPACE_ROOT}}/.beads" ] || [ -L "{{WORKSPACE_ROOT}}/.beads" ]; } \
+    && echo "already exists, inspect before linking" \
+    || ln -s "$(cd "{{OPS_REPO}}" && pwd)/.beads" "{{WORKSPACE_ROOT}}/.beads"
+$ cd "{{WORKSPACE_ROOT}}" && bd where
+```
+
+Immediately after `bd init`, compare `CLAUDE.md` and `AGENTS.md` before continuing. **Announce-and-proceed — do not open a choice for the byte-only case.**
+
+- If they differ only at the byte level (whitespace, blank lines, or block order) while the semantic content is the same: re-unify automatically, write the same common block to both files, and tell the owner in ELI5 once, for example: "Two instruction files for different agent hosts had drifted in formatting only; I made them match again so both hosts see the same rules. No decision needed from you." Then continue.
+- If any substantive line or block exists in only one file: stop and ask whether to accept host-specific divergence before proceeding. That is the only branch that needs a question.
+
+Ask before creating the workspace → ops `.beads` link. Record active work in the tracker and seed only load-bearing memory pointers and rules.
+
+## Verify
+
+From `{{WORKSPACE_ROOT}}`, not inside the ops repository:
+
+- `bd where` or its equivalent resolves to the ops repository
+- this workspace database differs from every product repository database
+- no tracker database exists above `{{WORKSPACE_ROOT}}` on the path to the filesystem root
+- any tracker environment override printed from the agent's actual shell is empty or points inside the workspace
+
+## If fail
+
+- If the prefix is wrong, `bd rename-prefix` rewrites database IDs and references but not Markdown.
+- For another tracker, measure its resolution rules.

--- a/master-ops/onboarding/07-user-rules.md
+++ b/master-ops/onboarding/07-user-rules.md
@@ -1,0 +1,26 @@
+# 07 — Seed Universal User Rules (Step 6)
+
+Load rule: read this file only when Step 6 begins. Router: [`../ONBOARDING.md`](../ONBOARDING.md). Next file after Verify passes: `08-settings-and-skills.md`.
+
+**Position and action:** Step 6 begins with execution state reachable: store the user's durable, workspace-wide operating rules in the selected memory system.
+
+**Why/caution:** Keep private details out of public documents and product conventions out of the master layer. The word "master" in this template is a temporary role name, not the session's permanent callsign.
+
+## Owner script (3–6 sentences, adapt to the owner's language)
+
+Where we are: the tracker works. What we decide next: how the master should treat you — how it addresses you, what it may do without asking, and what it must never do. Explain that "master" is just the role label in the documents; the living session gets a callsign the owner chooses (examples: 자비스 / Jarvis, Friday, Alfred, or a free-form name). Ask one or two of these at a time, not all five in one screen.
+
+## Ask
+
+- preferred address for the owner (how the session should speak to them)
+- **master callsign** — a short name the owner will use for this session. Record it in tracker memory and in the founding kickoff notes
+- primary response language
+- approval requirements before execution / handoff to workers / branch / commit / push / deploy
+- standing prohibitions
+
+Write short actionable rules without narrative duplication.
+
+## Verify
+
+- memory lookup returns the seeded rules (including callsign and owner address)
+- the rules are concise and not duplicated in Git documents

--- a/master-ops/onboarding/08-settings-and-skills.md
+++ b/master-ops/onboarding/08-settings-and-skills.md
@@ -1,0 +1,101 @@
+# 08 — Settings Layer, Skill Layer, Gate Scope (Steps 7, 7.5, 7.6)
+
+Load rule: read this file only when Step 7 begins. Router: [`../ONBOARDING.md`](../ONBOARDING.md). Next file after Verify passes: `09-spawn.md`.
+
+## Step 7. Explain the settings layer
+
+**Position and action:** Step 7 begins with durable user rules seeded: identify the host and the owner of settings and sensitive configuration.
+
+**Why/caution:** The template specifies hook behavior but does not ship hidden deny lists, credentials, secret paths, or environment-specific security implementation.
+
+### Owner script (3–6 sentences, adapt to the owner's language)
+
+Where we are: the master's ground rules are saved. What we decide next: who owns the host settings and security-sensitive configuration, and which safety hooks to turn on. Ask which hosts run the master, who owns hooks/security-sensitive configuration, and whether dispatch warning, role-state injection, and compaction probe hooks should be enabled. Present the hook wiring spec from `docs/MASTER-OPERATIONS.md` in agent notes, not as a wall of text at the owner; delegate auth, permission, secrets, credentials, and production-data work to a dedicated security/operations session.
+
+### Verify (Step 7)
+
+- the hook spec is documented, no sensitive implementation was added, and its owner is explicit or unresolved
+
+## Step 7.5. Offer the skill layer
+
+**Position and action:** Step 7.5 begins before the master is born: explain the optional stack in README, then ask which parts the user wants.
+
+**Why/caution:** Skills load into the founding session; some installers, especially GSD, modify lifecycle hooks and require deliberate user choice.
+
+Explain each component in one sentence before showing any command. Print approved install commands and stop; do not run them or edit `settings.json`, hooks, or plugin configuration.
+
+These five questions decided what is in the stack, and they are worth repeating when a component is proposed later:
+
+1. does it require an API key
+2. does it force telemetry, or collect more than the job needs
+3. does it add a management point
+4. does it still work if the operation grows past one person
+5. every tool claims to help with agent context. What else does this one actually resolve
+
+A component that fails the first three is usually a subscription pretending to be a dependency. A component that passes them but answers nothing for the fifth is a preference, and should be labelled as one.
+
+The stack this template was built against, with what each one is for and what it is deliberately not used for. Name the role before the install command, because a tool adopted without its boundary becomes the next thing to unwind:
+
+| component | role here | not used for |
+|---|---|---|
+| Orca | execution substrate: worktrees, terminals, sessions, supervised dispatch | required infrastructure, not a swappable preference |
+| tracker (Beads) | execution state that survives a session, as an issue graph | its memory is a short pointer cache toward Git, not the knowledge source of truth |
+| `ctx` | trace archive: cross-provider session history, queryable when handoff, ledger, and Git do not answer | not part of routine boot context |
+| `gitleaks` | matching engine for the publish gate | not the scope decision, which the wrapper keeps |
+| methodology skills | how the master plans and verifies | without them the charter reads as advice rather than procedure |
+| restraint skills | how much the master builds | pairs with the methodology layer rather than competing |
+| review graph | impact radius and review context, locally parsed | optional; its value is token cost, not correctness |
+| spec-driven framework | phase discipline from research through verification | installs lifecycle hooks, so it needs a deliberate yes |
+| worker runtime plugin | lets the master delegate implementation from inside its own session | one wiring of the adapter layer, not a harness requirement |
+
+Claude Code is the recommended host for the master, and a worker runtime such as Codex is a first-class executor rather than a fallback. Expect the preference to split hard between the two camps; the contracts hold either way, which is the point of an agent-neutral template.
+
+One asymmetry to plan around rather than discover: an agent without an interactive query interface cannot run the steps of this document that ask the user a question. Onboarding is a conversation. Run it from an agent that can ask, or supply every answer in the dispatch contract up front and record that the questions were answered in advance rather than asked.
+
+Install commands for the Claude Code case, printed and not run:
+
+```console
+$ /plugin marketplace add openai/codex-plugin-cc
+$ /plugin install codex@openai-codex
+$ /reload-plugins
+$ /codex:setup
+```
+
+Say which of them are optional in name only. The template carries documents and scripts; it cannot carry the host layer that makes a master behave the way the documents describe, so a component listed here as recommended is often load-bearing. State the consequence of declining each one in a sentence, in the same breath as the offer, rather than leaving the user to discover it later:
+
+- a methodology skill layer changes how the master plans and verifies; without it the master still runs, and reads the charter as advice rather than procedure
+- a restraint skill layer keeps the master from over-building; without it, expect larger diffs and more speculative structure. It pairs with the methodology layer rather than competing with it: one decides how to approach work, the other decides how much to build
+- a tracker skill layer is what makes execution state survive a session; without it, state lives only in the transcript
+- a worker runtime is what makes delegation possible at all; without at least one, the master does every task itself
+
+When the user declines a component the preflight treats as essential, ask once more. Not as a nag: restate the specific behaviour that changes, then ask whether to proceed without it. One re-ask, then take the answer as final.
+
+The reason to ask twice is that the first no is usually answering a different question. A component list reads as preferences, so the first pass is "do I want this", while the question that matters is "am I accepting this behaviour". Restating the consequence is what turns one into the other.
+
+Record the confirmed decline together with what is being accepted, in the user's own terms where possible. A declined component is a fact about the installation, and later behaviour that looks like a master defect is often a declined component instead.
+
+Where the agent running onboarding has no interactive query interface, the re-ask cannot happen at all. In that case the dispatch contract carries the confirmed declines up front, and the record says they were confirmed in advance rather than asked.
+
+### Verify (Step 7.5)
+
+- the explanation preceded commands, nothing was installed or configured by the agent, every essential decline was re-asked once with its consequence restated, and the user's choice, including no installation, is recorded with what it accepts
+
+## Step 7.6. State what the publish gates do not cover
+
+**Position and action:** Step 7.6 follows immediately, while the gates are fresh: tell the user what the redaction gates check and, more importantly, where they are silent.
+
+**Why/caution:** A gate that is trusted beyond its scope is worse than no gate, because it converts an unchecked surface into a believed-clean one.
+
+### Owner script (3–6 sentences, adapt to the owner's language)
+
+The gates read repository content. Name the surfaces they do not read, so nobody assumes coverage that does not exist: pull request titles, bodies, and review comments; release notes and issue text; anything typed into a forge web interface. None of those are in the repository, so no scanner in this template sees them — and they are where internal names most easily arrive, because they are written in prose rather than code. The habit that works is to grep your own outgoing text for organization identifiers before posting it, exactly as the scan does for files. Explain the gap once, in plain language, then continue.
+
+Tell the user that organization-specific patterns live in a file outside version control, that the gates fail closed without it, and that its format is one rule per line as `id|description|regex`. That file is what makes the gates able to catch a workspace name; the shipped rules only catch generic provider secrets.
+
+Do **not** run a comprehension quiz or ask the owner to recite a surface back. A quiz reads as condescension and adds no durable record.
+
+### Verify (Step 7.6)
+
+- the uncovered surfaces were named in conversation
+- the organization rules file exists, or its absence is recorded as a known gap
+- no quiz or "prove you understood" prompt was used

--- a/master-ops/onboarding/08-settings-and-skills.md
+++ b/master-ops/onboarding/08-settings-and-skills.md
@@ -48,7 +48,7 @@ The stack this template was built against, with what each one is for and what it
 | spec-driven framework | phase discipline from research through verification | installs lifecycle hooks, so it needs a deliberate yes |
 | worker runtime plugin | lets the master delegate implementation from inside its own session | one wiring of the adapter layer, not a harness requirement |
 
-Claude Code is the recommended host for the master, and a worker runtime such as Codex is a first-class executor rather than a fallback. Expect the preference to split hard between the two camps; the contracts hold either way, which is the point of an agent-neutral template.
+Each host carries its own agent model and worker runtime plugin ecosystem. A worker runtime such as Codex is a first-class executor rather than a fallback. Expect the preference to split hard between the two camps; the contracts hold either way, which is the point of an agent-neutral template.
 
 One asymmetry to plan around rather than discover: an agent without an interactive query interface cannot run the steps of this document that ask the user a question. Onboarding is a conversation. Run it from an agent that can ask, or supply every answer in the dispatch contract up front and record that the questions were answered in advance rather than asked.
 

--- a/master-ops/onboarding/09-spawn.md
+++ b/master-ops/onboarding/09-spawn.md
@@ -14,7 +14,7 @@ Where we are: everything the master needs is in place. What we decide next: whet
 
 ### Agent-only preparation (not shown to the owner)
 
-Reload the durable placement result from the seat step and confirm the selector still resolves on the host (`ORCA terminal list --worktree <selector> --json`); the temporary seat-check terminal is already closed, so there is no handle to check, and the spawn itself verifies placement against this selector again. Write a kickoff file containing Generation 1, this installer as founding origin, the callsign from the user-rules step, the boot sequence (rehydrate ops docs, declare Role State, measure model and placement), the initial queue, and the requirement to report the orchestration Task complete.
+Reload the durable placement result from the seat step and confirm the selector still resolves on the host (`ORCA terminal list --worktree <selector> --json`). That listing is also the empty-seat gate: it must show **zero terminals in the seat**. Any existing terminal there — a leftover seat-check terminal, or a master from an earlier interrupted run of this step — is a hard stop: report it to the owner and do not spawn, because exactly one master may exist and a re-entered session cannot assume its earlier spawn failed. Only an empty seat proceeds; the spawn itself verifies placement against this selector again. Write a kickoff file containing Generation 1, this installer as founding origin, the callsign from the user-rules step, the boot sequence (rehydrate ops docs, declare Role State, measure model and placement), the initial queue, and the requirement to report the orchestration Task complete.
 
 Before launching any worker, follow `docs/MASTER-OPERATIONS.md` §3: MEASURE the installed agent CLI's non-interactive approval flags from `--help` and never guess them.
 
@@ -58,6 +58,7 @@ Require placement verification `MATCH` or `MATCH_REISSUED`; the latter must incl
 
 ### Verify (Step 8)
 
+- the seat was measured empty before spawning (no pre-existing terminal in the selector's seat)
 - a Run is bound, one Task exists, and its Dispatch is attached to the verified worker
 - exactly one new master process/session exists
 - placement is `MATCH` or valid `MATCH_REISSUED`

--- a/master-ops/onboarding/09-spawn.md
+++ b/master-ops/onboarding/09-spawn.md
@@ -1,0 +1,85 @@
+# 09 — Spawn The Founding Master, Then Its Boot Smoke (Steps 8–9)
+
+Load rule: read this file only when Step 8 begins. Router: [`../ONBOARDING.md`](../ONBOARDING.md). Next file after Verify passes: `10-card-and-retire.md`.
+
+## Step 8. Spawn the founding master through orchestration
+
+**Position and action:** Step 8 begins with the workspace prepared: create a Run and Task, spawn exactly one placement-verified Generation 1 master, attach its worker Dispatch, and wait for `worker_done`.
+
+**Why/caution:** Supervised dispatch is Orca orchestration only; raw terminal polling and vendor-direct CLIs are non-compliant, and failures remain closed.
+
+### Owner script (3–6 sentences, adapt to the owner's language)
+
+Where we are: everything the master needs is in place. What we decide next: whether to create the master now or defer. Explain in plain words: we will open one new terminal in the workspace seat we recorded earlier, hand it a kickoff note, and wait until it reports its first boot went clean; you do not need to type anything during this. Ask for confirmation to spawn now or defer.
+
+### Agent-only preparation (not shown to the owner)
+
+Reload the durable placement result from the seat step and confirm the selector still resolves on the host (`ORCA terminal list --worktree <selector> --json`); the temporary seat-check terminal is already closed, so there is no handle to check, and the spawn itself verifies placement against this selector again. Write a kickoff file containing Generation 1, this installer as founding origin, the callsign from the user-rules step, the boot sequence (rehydrate ops docs, declare Role State, measure model and placement), the initial queue, and the requirement to report the orchestration Task complete.
+
+Before launching any worker, follow `docs/MASTER-OPERATIONS.md` §3: MEASURE the installed agent CLI's non-interactive approval flags from `--help` and never guess them.
+
+Before attaching a Codex worker, run `{{RUNTIME_ROOT}}/scripts/codex-worker-pretrust <worktree-path>` as the pre-trust step.
+
+### Agent-only command sequence (do not paste to the owner)
+
+Run this supervised path with the resolved `ORCA` executable:
+
+```bash
+G={{RUNTIME_ROOT}}/scripts/dispatch-gate
+L=~/.mogui/dispatch-ledger.jsonl
+"$G" --ledger "$L" check \
+    --runtime <runtime> \
+    --model "{{MODEL_ID}}" \
+    --contract <contract file> \
+    --agents 1 \
+    --est-chars <estimated input chars> \
+    --completion-channel orchestration
+ORCA orchestration run-create --objective "Found and verify the Generation 1 master" --json
+ORCA orchestration task-create --spec "Run the byte-identical founding kickoff file and complete Step 9 boot smoke" --json
+"{{RUNTIME_ROOT}}/scripts/master-succeed" spawn \
+    --workspace-selector <durable placement selector from the seat step, id: prefixed> \
+    --kickoff-file <kickoff file> \
+    --root "{{WORKSPACE_ROOT}}" \
+    --model "{{MODEL_ID}}" \
+    --title "Gen-1 founding boot" \
+    --json
+ORCA terminal wait --terminal <verified live handle> --for tui-idle --timeout-ms 60000 --json
+ORCA orchestration dispatch --task <task id> --to <verified live handle> --inject --json
+"$G" --ledger "$L" register \
+    --job-id <job id> \
+    --probe-cmd "<command proving the job-id appears in an artifact>" \
+    --orchestration-task <task id>
+ORCA orchestration check --wait --types worker_done,escalation,question --timeout-ms 900000 --json
+```
+
+Require the gate `check` to return `allow: true` before spawning or attaching the worker. After the Dispatch artifact exists, run `register` with that exact orchestration Task ID before waiting for final completion evidence.
+
+Require placement verification `MATCH` or `MATCH_REISSUED`; the latter must include `handle_reissued: true` and its adopted live handle.
+
+### Verify (Step 8)
+
+- a Run is bound, one Task exists, and its Dispatch is attached to the verified worker
+- exactly one new master process/session exists
+- placement is `MATCH` or valid `MATCH_REISSUED`
+- kickoff content received by the master matches the kickoff file byte-for-byte
+- the coordinator processes and acknowledges deliveries, answers questions through orchestration, and waits until that Task's `worker_done`
+
+### If fail
+
+- On any failure, do not retry with a filesystem path selector, do not boot the master in this installer, and do not create a second session. After settings changes, always spawn a fresh session.
+
+## Step 9. The first master boot smoke (runs inside the new master session)
+
+**Position and action:** Step 9 runs inside the new master session: declare its role, measure identity and placement, record lineage, and report completion. The installer does not perform this boot on the master's behalf; this section is the content the kickoff file points the master at.
+
+**Why/caution:** Model identity is measured, unavailable, or unsupported, never guessed.
+
+The master asks for the initial role or approval to start in Maintenance, plus permission for local read-only model and seat checks. It updates `docs/runbooks/role-state.md` for Generation 1, declares Role State in conversation (including the callsign), measures configured and actual model when exposed, captures placement evidence, appends Generation 1 to `docs/lineage/MASTER-LINEAGE.md`, then sends `worker_done` exactly once for the active Dispatch.
+
+### Verify (Step 9)
+
+- Role State has one active role and Role Lock is enabled
+- model measurement is reported as measured, unavailable, or unsupported
+- placement evidence includes the host pane/worktree selector, process cwd under `{{WORKSPACE_ROOT}}`, and session artifact/log namespace
+- no placeholders remain unless the user intentionally deferred them
+- the founding Task and Dispatch complete through `worker_done`

--- a/master-ops/onboarding/10-card-and-retire.md
+++ b/master-ops/onboarding/10-card-and-retire.md
@@ -50,7 +50,7 @@ New to Orca? Concepts, and labels that look alarming but are normal:
   {{RUNTIME_ROOT}}/docs/public/orca-concepts.md
 ```
 
-Fill the declined slot (the `<declined components, or the word none>` line) from the recorded choices. If nothing was declined, write the word none rather than leaving it blank, because a blank line reads as unknown. The angle-bracket slots in the card are filled by hand at print time; do not introduce a new `{{...}}` placeholder for them, since the placeholders step verifies that only the eight allowed placeholders remain anywhere in the generated repository.
+Fill the declined slot (the `<declined components, or the word none>` line) from the recorded choices. If nothing was declined, write the word none rather than leaving it blank, because a blank line reads as unknown. The angle-bracket slots in the card are filled by hand at print time; do not introduce a new `{{...}}` placeholder for them, since the placeholders step verifies that no `{{...}}` placeholder remains in the generated repository.
 
 If the user lingers with Orca questions instead of closing, answer them here under the Orca Context Charter (grounded in the docs snapshot and the concepts guide) before retiring; a user who leaves onboarding still confused about workspaces will misplace the next master by hand.
 

--- a/master-ops/onboarding/10-card-and-retire.md
+++ b/master-ops/onboarding/10-card-and-retire.md
@@ -30,8 +30,8 @@ To start work, tell the master:
   "Approved, execute"               it executes only what you approved
 
 To delegate, tell the master:
-  "Dispatch <task> to a worker"     it runs the gate, dispatches, and verifies
-                                     the result before accepting it
+  "Dispatch <task> to a worker"     it checks preconditions, sends the work to a
+                                     worker, and reviews the result before accepting
 
 Before publishing anything, the master runs:
   the test suite, the redaction scan, the redaction inventory

--- a/master-ops/onboarding/10-card-and-retire.md
+++ b/master-ops/onboarding/10-card-and-retire.md
@@ -1,0 +1,62 @@
+# 10 — Hand The Human A Card, Then Close The Installer (Step 10)
+
+Load rule: read this file only when Step 10 begins. Router: [`../ONBOARDING.md`](../ONBOARDING.md). This is the last step file.
+
+**Position and action:** Step 10 runs after the master reports a clean boot: verify the conversation actually happened, hand the user something portable, and ask them to close the installer terminal.
+
+**Why/caution:** Everything installed here is worthless if the user does not know the four or five sentences that operate it, and an installer session left running is a second agent holding the same repository.
+
+## Agent-only check first
+
+Verify the conversation, not just the artifacts. The steps above ask questions; a run that produced files without answers is a run that guessed. Check that the workspace facts were confirmed rather than inferred, that the component choices are recorded including declines, and that each essential decline was re-asked once. If any answer is missing, ask now rather than recording an assumption as a decision.
+
+## Owner script (3–6 sentences, adapt to the owner's language)
+
+Where we are: the master booted clean; the installation is done. What happens next: I hand you a short operating card — keep it wherever you keep notes, as plain text under a name you will find again, such as `llm.txt`; it is written to be pasted into any agent, so it does not depend on this session existing. After that, please close this installer terminal: two agents holding one repository is how uncommitted work gets lost, and the installer has no further role. I will not close it myself, and the master's terminal stays running.
+
+## The operating card
+
+Print it in full:
+
+```text
+# Operating this workspace
+
+Master lives in: {{WORKSPACE_ROOT}}          Ops repository: {{OPS_REPO}}
+State: the issue tracker in the ops repository. Long-term decisions: Git.
+
+To start work, tell the master:
+  "Role State?"                     it reports its active role and lock
+  "Propose <goal>"                  it plans, then waits for your approval
+  "Approved, execute"               it executes only what you approved
+
+To delegate, tell the master:
+  "Dispatch <task> to a worker"     it runs the gate, dispatches, and verifies
+                                     the result before accepting it
+
+Before publishing anything, the master runs:
+  the test suite, the redaction scan, the redaction inventory
+  A green scan covers repository content only. Pull request text,
+  release notes, and issue prose are not scanned by anything.
+
+When a session gets long:
+  "Propose succession"              it audits, spawns a clean successor,
+                                     and freezes itself
+
+If the master behaves unlike the documents, check what was declined at
+onboarding before assuming a defect. Declined at install:
+  <declined components, or the word none>
+
+New to Orca? Concepts, and labels that look alarming but are normal:
+  {{RUNTIME_ROOT}}/docs/public/orca-concepts.md
+```
+
+Fill the declined slot (the `<declined components, or the word none>` line) from the recorded choices. If nothing was declined, write the word none rather than leaving it blank, because a blank line reads as unknown. The angle-bracket slots in the card are filled by hand at print time; do not introduce a new `{{...}}` placeholder for them, since the placeholders step verifies that only the eight allowed placeholders remain anywhere in the generated repository.
+
+If the user lingers with Orca questions instead of closing, answer them here under the Orca Context Charter (grounded in the docs snapshot and the concepts guide) before retiring; a user who leaves onboarding still confused about workspaces will misplace the next master by hand.
+
+## Verify
+
+- the card was printed in full, with placeholders replaced and the declined line filled or explicitly none
+- the user was told where to keep it and that it works when pasted into any agent
+- the user was asked to close the installer terminal, with the reason given
+- the master's terminal was left running

--- a/master-ops/onboarding/reverify.md
+++ b/master-ops/onboarding/reverify.md
@@ -18,7 +18,7 @@ Where we are: this workspace was already set up, so nothing will be installed or
 3. **Role state**: `docs/runbooks/role-state.md` names one active role with Role Lock state, and its Generation matches the last entry in `docs/lineage/MASTER-LINEAGE.md`.
 4. **Lineage**: the last lineage entry's session evidence (session id, measured model) is present, and the measured model matches the configured one or the mismatch is explained.
 5. **Operating card**: the owner still has the operating card from installation; if it is lost, reprint it from `10-card-and-retire.md` with current values — that is the one write this mode allows.
-6. **Placeholders**: `rg '\{\{[^}]+\}\}' "{{OPS_REPO}}"` finds nothing, or every hit matches an owner-recorded deferral (same rule as Step 5 Verify); anything else is an installation error — fail reverify and have the owner bring it to the living master as a rescue task.
+6. **Placeholders**: `rg '\{\{[^}]+\}\}' "{{OPS_REPO}}"` finds nothing, or every hit matches an owner-recorded deferral (same rule as the placeholders step (`05-placeholders.md`)); anything else is an installation error — fail reverify and have the owner bring it to the living master as a rescue task.
 
 ## Report
 

--- a/master-ops/onboarding/reverify.md
+++ b/master-ops/onboarding/reverify.md
@@ -1,6 +1,6 @@
 # Reverify — Health Check For An Already-Founded Workspace
 
-Load rule: read this file only when the router's mode question answered **Reverify**. Router: [`../ONBOARDING.md`](../ONBOARDING.md). This mode uses no other step file.
+Load rule: read this file only when the router's mode question answered **Reverify**. Router: [`../ONBOARDING.md`](../ONBOARDING.md). This mode uses no other step file, with one exception: `10-card-and-retire.md` may be opened read-only to reprint a lost operating card (check 5).
 
 **Position and action:** the workspace already has an ops repository and a master. Check health, report, and stop. Running the full founding steps against a founded workspace is time waste at best and a duplicate master at worst.
 
@@ -12,6 +12,7 @@ Where we are: this workspace was already set up, so nothing will be installed or
 
 ## Checklist (all read-only)
 
+0. **Bootstrap the facts first**: this mode never loads the steps that establish the workspace facts, so ask the owner for the workspace root and ops repository path (or the operating card, which carries both), then read the durable placement result from that ops repository. Do not scan the disk for candidate workspaces, and do not substitute this orchestrator clone's paths. Every `{{...}}` value below means the measured value from that ops repository, not a literal.
 1. **Seat**: the durable placement selector recorded in the ops repository still resolves on the host (`ORCA terminal list --worktree <selector> --json`), and exactly one live master terminal sits in it.
 2. **Tracker**: from `{{WORKSPACE_ROOT}}`, `bd where` (or the equivalent) resolves to the ops repository, and no tracker database shadows it from above.
 3. **Role state**: `docs/runbooks/role-state.md` names one active role with Role Lock state, and its Generation matches the last entry in `docs/lineage/MASTER-LINEAGE.md`.

--- a/master-ops/onboarding/reverify.md
+++ b/master-ops/onboarding/reverify.md
@@ -13,12 +13,12 @@ Where we are: this workspace was already set up, so nothing will be installed or
 ## Checklist (all read-only)
 
 0. **Bootstrap the facts first**: this mode never loads the steps that establish the workspace facts, so ask the owner for the workspace root and ops repository path (or the operating card, which carries both), then read the durable placement result from that ops repository. Do not scan the disk for candidate workspaces, and do not substitute this orchestrator clone's paths. Every `{{...}}` value below means the measured value from that ops repository, not a literal.
-1. **Seat**: the durable placement selector recorded in the ops repository still resolves on the host (`ORCA terminal list --worktree <selector> --json`), and exactly one live master terminal sits in it.
+1. **Seat**: the durable placement selector recorded in the ops repository still resolves on the host (`orca terminal list --worktree <selector> --json`), and exactly one live master terminal sits in it.
 2. **Tracker**: from `{{WORKSPACE_ROOT}}`, `bd where` (or the equivalent) resolves to the ops repository, and no tracker database shadows it from above.
 3. **Role state**: `docs/runbooks/role-state.md` names one active role with Role Lock state, and its Generation matches the last entry in `docs/lineage/MASTER-LINEAGE.md`.
 4. **Lineage**: the last lineage entry's session evidence (session id, measured model) is present, and the measured model matches the configured one or the mismatch is explained.
 5. **Operating card**: the owner still has the operating card from installation; if it is lost, reprint it from `10-card-and-retire.md` with current values — that is the one write this mode allows.
-6. **Placeholders**: `rg '\{\{[^}]+\}\}' "{{OPS_REPO}}"` finds nothing, or every hit is an intentionally deferred value the owner can name.
+6. **Placeholders**: `rg '\{\{[^}]+\}\}' "{{OPS_REPO}}"` finds nothing — any remaining {{...}} token is an installation error; fail reverify and have the owner bring it to the living master as a rescue task.
 
 ## Report
 

--- a/master-ops/onboarding/reverify.md
+++ b/master-ops/onboarding/reverify.md
@@ -18,7 +18,7 @@ Where we are: this workspace was already set up, so nothing will be installed or
 3. **Role state**: `docs/runbooks/role-state.md` names one active role with Role Lock state, and its Generation matches the last entry in `docs/lineage/MASTER-LINEAGE.md`.
 4. **Lineage**: the last lineage entry's session evidence (session id, measured model) is present, and the measured model matches the configured one or the mismatch is explained.
 5. **Operating card**: the owner still has the operating card from installation; if it is lost, reprint it from `10-card-and-retire.md` with current values — that is the one write this mode allows.
-6. **Placeholders**: `rg '\{\{[^}]+\}\}' "{{OPS_REPO}}"` finds nothing — any remaining {{...}} token is an installation error; fail reverify and have the owner bring it to the living master as a rescue task.
+6. **Placeholders**: `rg '\{\{[^}]+\}\}' "{{OPS_REPO}}"` finds nothing, or every hit matches an owner-recorded deferral (same rule as Step 5 Verify); anything else is an installation error — fail reverify and have the owner bring it to the living master as a rescue task.
 
 ## Report
 

--- a/master-ops/onboarding/reverify.md
+++ b/master-ops/onboarding/reverify.md
@@ -1,0 +1,24 @@
+# Reverify — Health Check For An Already-Founded Workspace
+
+Load rule: read this file only when the router's mode question answered **Reverify**. Router: [`../ONBOARDING.md`](../ONBOARDING.md). This mode uses no other step file.
+
+**Position and action:** the workspace already has an ops repository and a master. Check health, report, and stop. Running the full founding steps against a founded workspace is time waste at best and a duplicate master at worst.
+
+**Standing block: do not spawn.** No new master terminal, no `master-succeed spawn`, no founding kickoff. If a check fails badly enough that a new master seems needed, that is a succession decision for the owner and the living master — not a reverify outcome.
+
+## Owner script (3–6 sentences, adapt to the owner's language)
+
+Where we are: this workspace was already set up, so nothing will be installed or changed. What happens next: a handful of read-only checks — where the master sits, whether the tracker answers, and whether the governance records are current — and then a short pass/fail report. You do not need to type anything unless a check needs your decision.
+
+## Checklist (all read-only)
+
+1. **Seat**: the durable placement selector recorded in the ops repository still resolves on the host (`ORCA terminal list --worktree <selector> --json`), and exactly one live master terminal sits in it.
+2. **Tracker**: from `{{WORKSPACE_ROOT}}`, `bd where` (or the equivalent) resolves to the ops repository, and no tracker database shadows it from above.
+3. **Role state**: `docs/runbooks/role-state.md` names one active role with Role Lock state, and its Generation matches the last entry in `docs/lineage/MASTER-LINEAGE.md`.
+4. **Lineage**: the last lineage entry's session evidence (session id, measured model) is present, and the measured model matches the configured one or the mismatch is explained.
+5. **Operating card**: the owner still has the operating card from installation; if it is lost, reprint it from `10-card-and-retire.md` with current values — that is the one write this mode allows.
+6. **Placeholders**: `rg '\{\{[^}]+\}\}' "{{OPS_REPO}}"` finds nothing, or every hit is an intentionally deferred value the owner can name.
+
+## Report
+
+State each check as pass or fail with its evidence, in the owner's language, short. A failed check gets one sentence of consequence and one recommended next action (usually: bring it to the living master as a task). Then stop; reverify has no further steps.

--- a/tests/test_onboarding_structure.py
+++ b/tests/test_onboarding_structure.py
@@ -1,0 +1,94 @@
+"""The onboarding router names step files; this pins that structure to the files that exist.
+
+The 2026-08-03 install run showed what a monolithic ONBOARDING.md does to an agent
+mid-install, so the flow was split into a router plus one file per step. The split
+buys progressive loading and pays for it with a cross-reference surface: a step
+index in the router, a next-file pointer in every step file, a placeholder
+allowlist, and required Owner script / Verify sections. Nothing else measures that
+surface, and this repository has already watched an unmeasured doc inventory drift
+in silence (see test_reference_command_table.py), so the inventory is held here.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+ROUTER = REPO_ROOT / "master-ops" / "ONBOARDING.md"
+STEP_DIR = REPO_ROOT / "master-ops" / "onboarding"
+
+ALLOWED_PLACEHOLDERS = {
+    "{{WORKSPACE_NAME}}",
+    "{{WORKSPACE_ROOT}}",
+    "{{OPS_REPO}}",
+    "{{MONITOR_NS}}",
+    "{{MODEL_ID}}",
+    "{{REPO_LIST}}",
+    "{{RUNTIME_ROOT}}",
+    "{{TEMPLATE_VERSION}}",
+}
+
+# 10-card-and-retire.md warns against inventing new placeholders by naming the
+# shape itself; that literal is documentation, not a placeholder.
+PLACEHOLDER_SHAPE_MENTION = "{{...}}"
+
+INDEX_ROW = re.compile(r"^\|\s*(?:\d{2}|—)\s*\|\s*`onboarding/([a-z0-9-]+\.md)`\s*\|")
+NEXT_POINTER = re.compile(r"Next file after Verify passes: `([a-z0-9-]+\.md)`")
+PLACEHOLDER = re.compile(r"\{\{[^}]+\}\}")
+
+
+def indexed_files() -> list[str]:
+    rows = [m.group(1) for m in map(INDEX_ROW.match, ROUTER.read_text().splitlines()) if m]
+    assert rows, "router step index parsed to zero rows; the table format changed"
+    return rows
+
+
+def test_every_indexed_file_exists():
+    for name in indexed_files():
+        assert (STEP_DIR / name).is_file(), f"router index names onboarding/{name}, which does not exist"
+
+
+def test_no_orphan_step_files():
+    on_disk = {p.name for p in STEP_DIR.glob("*.md")}
+    assert on_disk == set(indexed_files()), "step files on disk and the router index disagree"
+
+
+def test_next_pointers_follow_index_order():
+    numbered = [n for n in indexed_files() if n[0].isdigit()]
+    for current, expected_next in zip(numbered, numbered[1:]):
+        text = (STEP_DIR / current).read_text()
+        match = NEXT_POINTER.search(text)
+        assert match, f"{current} has no next-file pointer"
+        assert match.group(1) == expected_next, (
+            f"{current} points to {match.group(1)}, but the router index orders {expected_next} next"
+        )
+    last = numbered[-1]
+    assert NEXT_POINTER.search((STEP_DIR / last).read_text()) is None, (
+        f"{last} is the last step but still carries a next-file pointer"
+    )
+
+
+def test_numbered_steps_carry_required_sections():
+    for name in indexed_files():
+        text = (STEP_DIR / name).read_text()
+        if name[0].isdigit():
+            assert "Verify" in text, f"{name} has no Verify section"
+            assert "Owner script" in text, f"{name} has no Owner script block"
+        else:
+            # reverify.md is a mode file, not a numbered step: its body IS the
+            # verification, structured as Checklist + Report.
+            assert "Checklist" in text and "Report" in text, f"{name} lost its Checklist/Report structure"
+
+
+def test_only_allowed_placeholders():
+    for path in [ROUTER, *STEP_DIR.glob("*.md")]:
+        found = set(PLACEHOLDER.findall(path.read_text())) - {PLACEHOLDER_SHAPE_MENTION}
+        unknown = found - ALLOWED_PLACEHOLDERS
+        assert not unknown, f"{path.name} uses placeholders outside the allowlist: {sorted(unknown)}"
+
+
+def test_entry_files_stay_byte_identical():
+    claude = (REPO_ROOT / "CLAUDE.md").read_bytes()
+    agents = (REPO_ROOT / "AGENTS.md").read_bytes()
+    assert claude == agents, "CLAUDE.md and AGENTS.md diverged; re-unify or record intended divergence"

--- a/tests/test_onboarding_structure.py
+++ b/tests/test_onboarding_structure.py
@@ -54,6 +54,25 @@ def test_no_orphan_step_files():
     assert on_disk == set(indexed_files()), "step files on disk and the router index disagree"
 
 
+def test_onboarding_inventory():
+    """Pin the expected onboarding step files to catch silent drifts."""
+    expected = {
+        "00-orientation.md",
+        "01-preflight.md",
+        "02-workspace-facts.md",
+        "03-ops-repo.md",
+        "04-seat.md",
+        "05-placeholders.md",
+        "06-tracker.md",
+        "07-user-rules.md",
+        "08-settings-and-skills.md",
+        "09-spawn.md",
+        "10-card-and-retire.md",
+        "reverify.md",
+    }
+    assert set(indexed_files()) == expected, f"onboarding inventory drifted; expected {expected}"
+
+
 def test_next_pointers_follow_index_order():
     numbered = [n for n in indexed_files() if n[0].isdigit()]
     for current, expected_next in zip(numbered, numbered[1:]):


### PR DESCRIPTION
## Summary

Monolith ONBOARDING.md → router + one file per step under master-ops/onboarding/. Session-mode triad Founding/Reverify/Template-improve, owner-script blocks, agent-only command folding, entry files router-only. Motivated by the 2026-08-03 install-run failure where agents loading the 524-line monolith lost guide behavior.

## Review

Three independent lenses ran pre-landing: testing specialist, maintainability specialist, red team. 18 CodeRabbit findings identified during review. 10 findings fixed via code changes (commit f696a22), 8 findings deferred to tracked issues (mgm-xtv mid-install resume, mgm-8qm runtime sync, mgm-139 placement gate), with evidence-based replies posted to each thread.

## Gates

**Commit f696a22 (fix: address PR #58 bot review round 1):**
- Pytest: 448 passed, 13 subtests passed in 33.04s (one additional test: test_onboarding_inventory)
- Redaction scan: OK — 0 findings (mode=tracked, files=163, commit-messages=not-scanned, org-rules=10)
- Redaction inventory: 10 rules / scope tracked / 163 files / baseline 445

## Review threads

All 35 review threads (coderabbitai + cubic) are now resolved:
- 10 FIX findings applied and code changed
- 8 DEFER findings with issue references (mgm-xtv, mgm-8qm, mgm-139)
- 1 DESIGN_INTENT finding (tracker choice is owner's)
- 16 obsolete/metadata findings resolved after code fixes

## Deferred

- mid-install resume protocol tracked as ops issue mgm-xtv
- CI monolith-regression gate as mgm-79p
- runtime checkout sync as mgm-8qm
- placement/tui-idle gate as mgm-139