### PR TITLE
docs: charter countermeasure for host-injected autonomy defaults

### DIFF
--- a/master-ops/CHANGELOG.md
+++ b/master-ops/CHANGELOG.md
@@ -41,6 +41,18 @@ installation was taken from alongside the tag.
 
 ## Unreleased
 
+Charter countermeasure for host-injected autonomy defaults (2026-08-03,
+instance-validated, promotion per staging→production loop):
+
+- UserPromptSubmit hook now couples the role-state injection with the
+  `Proposal -> Approval -> Execution` rule in every turn, establishing a
+  mechanical guard against host defaults that override the charter. See
+  MASTER-OPERATIONS §7 hook spec and §8 incident-derived rules for motivation
+  and measurement.
+- New §8 rule "Host-injected autonomy defaults override the charter unless
+  mechanically countered," with observation from 2026-08-03 founding run,
+  measurement via hook wiring and transcript audit.
+
 ## v0.4.1
 
 No template changes in this release; the version string moves so an

--- a/master-ops/docs/MASTER-OPERATIONS.md
+++ b/master-ops/docs/MASTER-OPERATIONS.md
@@ -225,7 +225,7 @@ Recommended hook spec:
 - SessionStart: load master operations context, role state, and issue-tracker memory
 - SessionStart on compact: run `scripts/compaction-probe.sh`
 - PreCompact: reload or export issue-tracker memory
-- UserPromptSubmit: inject the current role-state line from `docs/runbooks/role-state.md`
+- UserPromptSubmit: inject the current role-state line from `docs/runbooks/role-state.md` and the `Proposal -> Approval -> Execution` rule. This pairing mechanically counters the host's autonomy defaults, which can override the charter unless the execution rule is present in every turn's context. See §8 for the incident that motivated this coupling.
 - PreToolUse: warn when supervised dispatch is bypassed
 - PostToolUse: collect non-sensitive audit markers when locally approved
 - SessionStart: warn when the issue tracker is not reachable from `{{WORKSPACE_ROOT}}`, or when an environment variable points its database outside the workspace
@@ -309,6 +309,10 @@ Measure: after the base merges, `git rebase --onto origin/main <old-base-sha>`, 
 **Reverting a file discards work that was never committed.**
 Observed: `git checkout --` was used to undo a deliberate mutation during testing, and it also removed uncommitted work in the same file, which had to be reconstructed.
 Measure: before reverting a path, run `git status --porcelain <path>` and read it. Every line there is work the revert will discard, so an empty result is the only state in which revert is safe. The same procedure was safe an hour earlier because that result was empty then; the safety belonged to the state, not to the procedure.
+
+**Host-injected autonomy defaults override the charter unless mechanically countered.**
+Observed: on 2026-08-03 a master on a hook-rich host repeatedly implemented product changes inline and executed without proposals, despite §1 and §2. Each time the owner interrupted with an explicit instruction to propose first. The host's instruction surface provided a default behaviour — act autonomously, do not ask, keep going — that outweighed the charter in context. Host defaults are agent-neutral and apply to any high-compliance model; the charter is paper without the mechanical coupling.
+Measure: wire the UserPromptSubmit hook to inject both the role-state line and the `Proposal -> Approval -> Execution` rule into every user turn; feed each hook a case it must object to and watch it object before trusting any quiet run. Until the UserPromptSubmit pairing is wired, audit sessions by counting explicit owner corrections of unproposed execution in the transcript — the pass is that count staying zero.
 
 ## 9. Closed Principles Pointer
 


### PR DESCRIPTION
## Summary

- Extend UserPromptSubmit hook to mechanically counter host autonomy defaults
- Couple role-state injection with `Proposal -> Approval -> Execution` rule in every turn
- Add §8 incident-derived rule documenting the 2026-08-03 founding run observation
- Measurement: hook wiring + transcript audit for explicit owner corrections

## Test plan

✓ Redaction scan (generic patterns): 0 findings
✓ Commit message format verified
✓ Single-file scope maintained (master-ops/docs/MASTER-OPERATIONS.md + CHANGELOG)

## Provenance

Instance-validated 2026-08-03, promotion per staging→production loop

🤖 Generated with Claude Code

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a mechanical guard against host autonomy defaults by pairing the `UserPromptSubmit` hook with the `Proposal -> Approval -> Execution` rule. Documents an incident-derived rule in §8 with clear measurement and audit steps to enforce the charter each turn.

- **New Features**
  - `UserPromptSubmit` now injects the current role-state and the `Proposal -> Approval -> Execution` rule on every user turn.
  - Documented the 2026-08-03 incident as a new §8 rule with measurement via hook wiring and transcript audit; updated `MASTER-OPERATIONS.md` and `CHANGELOG` accordingly.

<sup>Written for commit 830becf91dbbff53281c66b8911684ae228da44a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/baksohyeon/mogui-ADE-orchestrator/pull/59?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

