### PR TITLE
docs: distinguish folder workspace and repository worktree for placement

### DIFF
--- a/docs/public/orca-concepts.md
+++ b/docs/public/orca-concepts.md
@@ -10,8 +10,10 @@ Orca tracks three layers.
 
 **Workspace.** A seat inside a project where terminals and agents live. There are two kinds, and the project's shape decides which you get:
 
-- A *worktree* belongs to a Git repository project: one checked-out branch, created from the Create worktree dialog. This is where workers sit.
-- A *folder workspace* belongs to a folder project: the folder itself is the seat, with no Git checkout of its own, created from the Create Folder Workspace dialog.
+- A *repository worktree* belongs to a Git repository project: one checked-out branch, created from the Create worktree dialog. A terminal opened there starts inside the checkout and git works immediately. This is where workers sit when they need to run git commands.
+- A *folder workspace* belongs to a folder project: the folder itself is the seat, with no Git checkout of its own, created from the Create Folder Workspace dialog. A terminal opened there starts outside any checkout. An empty `worktreePath` is the expected shape for this kind; judge placement by `worktreeId`, which reads as `folder:<uuid>`.
+
+The kind determines what a session can do on its first command, not merely where it appears in the sidebar.
 
 **Terminal.** A live session inside a workspace. Agents, including masters, are terminals.
 

--- a/master-ops/CHANGELOG.md
+++ b/master-ops/CHANGELOG.md
@@ -41,6 +41,11 @@ installation was taken from alongside the tag.
 
 ## Unreleased
 
+Selector kinds and worker placement documentation (2026-08-03):
+
+- `docs/public/orca-concepts.md` adds distinction between folder workspace and repository worktree selector kinds to the object model, with the consequence for what a session can do on its first command.
+- `master-ops/onboarding/04-seat.md` adds a worker placement subsection stating the rule inverse to the master's placement and the verification check.
+
 ONBOARDING.md installer UX pass from the 2026-08-03 mogui founding run
 (feedback tracked as maintainer backlog on that install):
 

--- a/master-ops/onboarding/04-seat.md
+++ b/master-ops/onboarding/04-seat.md
@@ -19,6 +19,10 @@ Load rule: read this file only when Step 3.5 begins. Router: [`../ONBOARDING.md`
 
 Only after the owner has heard that sequence, ask them to perform steps 2–4.
 
+## Worker Placement
+
+The master's seat is workspace-level because the master coordinates every repository and must not hang under one of them. A worker that runs git needs a repository worktree, because that is where a checkout exists. Placing a worker at a folder seat is allowed only when its first command changes directory into a checkout; otherwise the worker starts outside every repository and fails on its first git call. After delivery, read the terminal and confirm the agent is at its prompt in the intended directory, because a created terminal is not a working one.
+
 ## Run
 
 Resolve `ORCA` exactly as Step 0's preflight does, then run:


### PR DESCRIPTION
## Summary

Adds documentation of the two selector kinds (folder workspace vs repository worktree) to the object model and worker placement rules to the onboarding step.

- Clarifies that a terminal in a folder workspace starts outside any checkout, while a terminal in a repository worktree starts inside it
- Documents that workers needing git must use repository worktrees; the master uses the workspace-level seat
- Explains the verification check: after terminal delivery, confirm the agent is at its prompt in the intended directory

Addresses the 2026-08-03 gap where worker terminals created in folder workspaces failed on their first git command.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Document how folder workspaces start outside any checkout and repository worktrees start inside one, and update worker placement rules accordingly. Onboarding now says: place git workers in a repository worktree and confirm the terminal opens in the intended directory.

<sup>Written for commit 76b61b67ae8965c4401694ef1781c8c58a210227. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/baksohyeon/mogui-ADE-orchestrator/pull/63?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

