### PR TITLE
ci: bump checkout/setup-python to node24 action runtimes

### DIFF
--- a/.github/workflows/gates.yml
+++ b/.github/workflows/gates.yml
@@ -27,8 +27,8 @@ jobs:
         os: [ubuntu-latest, macos-latest]
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v7.0.1
+      - uses: actions/setup-python@v7.0.0
         with:
           python-version: "3.12"
       - name: Install gitleaks (pinned, checksum verified)
@@ -49,7 +49,7 @@ jobs:
   redaction:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7.0.1
       - name: Install gitleaks (pinned, checksum verified)
         shell: bash
         run: |


### PR DESCRIPTION
## Summary

Pin GitHub Actions versions in `.github/workflows/gates.yml` so both actions run on node24 runtimes without relying on GitHub's compatibility remap.

- `actions/checkout@v4` -> `actions/checkout@v7.0.1` (tests + redaction jobs)
- `actions/setup-python@v5` -> `actions/setup-python@v7.0.0` (tests job)
- Input compatibility verification before commit:
  - `actions/checkout` inputs used: none (both steps pass no `with:` inputs). Verdict: no migration required; no explicit input contract changed.
  - `actions/setup-python` input `python-version: \"3.12\"`. Verdict: input still exists in `v7.0.0` and retains the same SemVer version-selection meaning as `v5`.

## Testing

- [x] `PYTHONPATH=src python3 -m pytest tests -q` — local host `python3` is 3.9 and fails collection (`ModuleNotFoundError: tomllib`); equivalent run on 3.12 passed: `448 passed, 13 subtests passed in 32.03s`.
- [x] A test that fails without this change, or a note on why none was needed — none needed; this change only updates action tags and does not modify workflow logic or test code.
- [x] New files staged before running any scan. The scanners read tracked files, so an unstaged addition is invisible to them and the run comes back green without having looked at it. — no new files added in this PR.

## Review

Automated review (`code-reviewer`) reported no findings (0 critical/high/medium/low); I reproduced that scope check manually by confirming the diff touches only three action version references in `gates.yml`.

## Changelog

No changelog update needed. This is a CI maintenance bump in workflow action references and does not change user-visible orchestrator behavior.

## Template impact

none

## Notes

Major-version compatibility check was done against each action's `action.yml` at old/new tags (`checkout`: v4 -> v7.0.1, `setup-python`: v5 -> v7.0.0); no used input changed meaning.

Provenance: implemented under contract `~/dev/personal/mogui/mogui-master-ops/contracts/2026-08-03-actions-node24-bump.md` in Orca dispatched worker task `task_f0b0306c259e` (dispatch `ctx_41f153eeb37a`).

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Pin `actions/checkout` and `actions/setup-python` to Node 24-based tags so our gate workflows run on supported runtimes and avoid GitHub’s compatibility remap. No workflow logic changes.

- **Dependencies**
  - `actions/checkout`: `v4` → `v7.0.1` (tests, redaction)
  - `actions/setup-python`: `v5` → `v7.0.0` (tests)
  - Existing input `python-version: "3.12"` remains valid; no migration needed

<sup>Written for commit 4810bfa389c76fef3e272cd8d21f99908d4760d8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/baksohyeon/mogui-ADE-orchestrator/pull/69?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->


