### PR TITLE
fix(runbook): resolve PR 72 cubic review findings in release runbook and next-version

### DIFF
--- a/docs/internal/release-runbook.md
+++ b/docs/internal/release-runbook.md
@@ -8,12 +8,15 @@ MAJOR and MINOR are owner-managed milestones; automation must never bump them.
 If the repository is shallow, unshallow first:
 
 ```console
-git fetch --unshallow origin main --tags
+if [ "$(git rev-parse --is-shallow-repository)" = "true" ]; then
+  git fetch --unshallow origin main --tags || exit $?
+fi
 ```
 
 Sync origin main and derive the version:
 
 ```console
+set -e
 git fetch origin main --tags
 version="$(./scripts/next-version)"
 printf '%s\n' "$version"

--- a/docs/internal/release-runbook.md
+++ b/docs/internal/release-runbook.md
@@ -5,17 +5,18 @@ MAJOR and MINOR are owner-managed milestones; automation must never bump them.
 
 ## 1) Sync and derive the build number
 
-```console
-git fetch origin main --tags
-build="$(git rev-list --count origin/main)"
-version="0.5.${build}"
-printf '%s\n' "$version"
-```
-
 If the repository is shallow, unshallow first:
 
 ```console
 git fetch --unshallow origin main --tags
+```
+
+Sync origin main and derive the version:
+
+```console
+git fetch origin main --tags
+version="$(./scripts/next-version)"
+printf '%s\n' "$version"
 ```
 
 ## 2) Stage new files before redaction checks
@@ -29,9 +30,12 @@ The scanners read tracked content, so an unstaged new file is invisible.
 ## 3) Run release gates
 
 ```console
+set -e
 PYTHONPATH=src uv run pytest tests -q
 ./scripts/redaction-scan.sh
-if ! ./scripts/redaction-inventory; then rc=$?; [ "$rc" -eq 1 ] || exit "$rc"; fi
+rc=0
+./scripts/redaction-inventory || rc=$?
+if [ "$rc" -ne 0 ]; then [ "$rc" -eq 1 ] || exit "$rc"; fi
 ```
 
 `redaction-inventory` exit 1 is the normal triage state. Exit 2 means cannot
@@ -39,7 +43,7 @@ decide and should block a release cut until resolved.
 
 ## 4) Finalize release metadata
 
-- Ensure `CHANGELOG.md` has the release notes for `v0.5.<build>`.
+- Ensure `CHANGELOG.md` has the release notes for `v${version}`.
 - Verify links and release date text.
 
 ## 5) Tagging is owner-approved and manual
@@ -47,7 +51,7 @@ decide and should block a release cut until resolved.
 Use the command below only after explicit owner approval:
 
 ```console
-git tag "v0.5.${build}"
+git tag "v${version}"
 ```
 
 Never automate tag creation or tag push. Do not push tags unless the owner asks

--- a/docs/internal/release-runbook.md
+++ b/docs/internal/release-runbook.md
@@ -54,6 +54,7 @@ decide and should block a release cut until resolved.
 Use the command below only after explicit owner approval:
 
 ```console
+[ -n "${version:-}" ] || exit 1
 git tag "v${version}"
 ```
 

--- a/scripts/next-version
+++ b/scripts/next-version
@@ -9,7 +9,7 @@ usage() {
 Usage: scripts/next-version [--help]
 
 Prints the release version that would be cut right now.
-BUILD is derived from: git rev-list --count origin/main
+BUILD is derived from: git rev-list --count refs/remotes/origin/main
 EOF
 }
 

--- a/scripts/next-version
+++ b/scripts/next-version
@@ -23,7 +23,7 @@ if [[ "$#" -ne 0 ]]; then
   exit 2
 fi
 
-if ! git rev-parse --verify origin/main >/dev/null 2>&1; then
+if ! git rev-parse --verify refs/remotes/origin/main >/dev/null 2>&1; then
   echo "next-version: origin/main is unavailable; run: git fetch origin main --tags" >&2
   exit 2
 fi
@@ -33,5 +33,5 @@ if [[ "$(git rev-parse --is-shallow-repository)" == "true" ]]; then
   exit 2
 fi
 
-build="$(git rev-list --count origin/main)"
+build="$(git rev-list --count refs/remotes/origin/main)"
 printf '%s.%s\n' "$OWNER_MANAGED_MAJOR_MINOR" "$build"


### PR DESCRIPTION
## Problem

PR #72 (build-number versioning) merged before its cubic review findings were read. Five verified findings were identified:
1. §1 in `docs/internal/release-runbook.md` derived `build` via `git rev-list --count` before the unshallow note, causing shallow clones to produce truncated build numbers.
2. The runbook hardcoded `0.5` in §1 and §5 while `scripts/next-version` owns `OWNER_MANAGED_MAJOR_MINOR`.
3. §3 console block in `release-runbook.md` lacked fail-fast (`set -e`), allowing failed pytest or redaction-scan commands to be ignored when pasted.
4. `if ! ./scripts/redaction-inventory; then rc=$?; ...` in §3 inverted exit status because `$?` after `!` evaluated to 0, collapsing exit 2 (must block) into `rc=0` and exiting with 0.
5. `scripts/next-version` used `origin/main` without qualification, which could be shadowed by a local branch named `origin/main`.

## Why this approach

Directly address each of the 5 verified cubic review findings from PR #72 in place. Alternative of adding extra wrapper scripts was rejected to keep the runbook and single version-derivation script minimal and self-contained.

## What this changes

- Moved shallow clone check before version derivation in `docs/internal/release-runbook.md` §1.
- Updated `docs/internal/release-runbook.md` to call `./scripts/next-version` for version derivation and use `v${version}` for tagging.
- Added `set -e` fail-fast in `docs/internal/release-runbook.md` §3.
- Removed `!` from `redaction-inventory` invocation in §3, capturing `$?` correctly into `rc` so exit 1 continues and exit 2 aborts.
- Qualified `origin/main` as `refs/remotes/origin/main` in `scripts/next-version`.

## Expected effect

`scripts/next-version` reliably outputs `0.5.<build>` without ambiguity (`refs/remotes/origin/main`). `docs/internal/release-runbook.md` provides clear fail-fast instructions, proper status handling, and single-source versioning.

## Testing

- [x] `PYTHONPATH=src python -m pytest tests -q` — 450 passed, 13 subtests passed in 32.95s
- [x] `./scripts/redaction-scan.sh` — 0 findings (mode=tracked, files=177, commit-messages=not-scanned, org-rules=0)
- [x] Tested stub runs for redaction-inventory status handling: exit 1 continued (0), exit 2 aborted (2).
- [x] Verified `scripts/next-version` output before/after: `0.5.152` -> `0.5.152`.

## Review

Addresses 5 verified cubic review findings from PR #72.

## Changelog

Internal documentation and script fix; no change to orchestrator runtime feature set.

## Template impact

none

## Notes

Provenance: Citing cubic review on PR #72.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the release runbook and `scripts/next-version` to resolve findings from PR #72 and follow-ups from PR #74. Improves version derivation, fail-fast behavior, redaction inventory handling, and tag safety.

- **Bug Fixes**
  - Guarded unshallow with a shallow-repo check; corrected fetch order before deriving the version.
  - Added `set -e` to the sync and release-gates blocks for fail-fast behavior.
  - Runbook now uses `./scripts/next-version`; tags use `v${version}` and are guarded by a version null check.
  - Fixed `redaction-inventory` exit handling (no `!`; exit 2 blocks, exit 1 continues).
  - Qualified `origin/main` as `refs/remotes/origin/main` in `scripts/next-version` and updated help text.

<sup>Written for commit 77f3e04d88ccb7583e07931b5732ef34ca756768. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/baksohyeon/mogui-ADE-orchestrator/pull/74?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the release runbook with clearer repository preparation, versioning, and release-gate guidance.
  * Improved handling of release checks so expected redaction-inventory warnings are distinguished from blocking failures.

* **Chores**
  * Improved automated version detection and release tagging to consistently use the latest main branch reference.
  * Increased reliability when preparing releases from shallow repository checkouts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->