### PR TITLE
fix: make retire CLOSED mean three disappearances

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,16 @@ you build on it.
   `config/instance-runtime.json` (gitignored). Owner decision 2026-08-04:
   onboarding already asked these facts; they needed a durable landing place.
 
+### Changed
+
+- `master-succeed retire` now reports each of the three disappearances
+  (`pane`, `process`, `tty`) as `measured` / `still_present` / `skipped:<why>`.
+  Full `CLOSED` requires all three measured; any skip yields `CLOSED_PARTIAL`
+  so a null `process_id` on a folder-workspace pane can no longer read as a
+  complete retirement. Accepts optional `--target-pid` and `--target-tty` for
+  externally measured targets. Public lifecycle docs name the FIN/ACK
+  handshake and call `master-succeed retire` by name.
+
 ### Fixed
 
 - `dispatch-gate check` no longer denies repeated contract hashes as

--- a/docs/public/master-lifecycle.md
+++ b/docs/public/master-lifecycle.md
@@ -170,7 +170,7 @@ scripts/master-succeed retire \
   --execute
 ```
 
-Each disappearance is reported separately under `disappearances` (`pane`, `process`, `tty`), each valued `measured`, `still_present`, or `skipped:<why>`. `CLOSED` means all three are `measured` and none is `still_present`. When process or tty was skipped, status is `CLOSED_PARTIAL` so a skip cannot read as a full pass. A survivor is a refusal. Without `--execute` the command dry-runs.
+Each disappearance is reported separately under `disappearances`. `pane` is `measured` or `still_present` only. `process` and `tty` may also be `skipped:<why>` when the caller did not supply a usable target. Full `CLOSED` requires all three `measured` and none `still_present`. When process or tty was skipped, status is `CLOSED_PARTIAL` so a skip cannot read as a full pass. A survivor is a refusal. Without `--execute` the command dry-runs.
 
 Sweep the predecessor's scratchpad before CLOSED. It dies with the session and is often the only place uncommitted work had to live. Copy the tree somewhere durable that is not a git repository, then diff each file against the trunk branch and record the verdict — including when salvage value is zero.
 
@@ -178,7 +178,7 @@ Sweep the predecessor's scratchpad before CLOSED. It dies with the session and i
 
 ## Retirement Completion And Revival
 
-Retirement ends with three measured disappearances, never with a close command's return value: process (pid gone), host pane (no live handle in the host's terminal list), and tty (device and login chain gone). Close command return values have been wrong in both directions on real hosts; the measurement decides.
+Full `CLOSED` requires three measured disappearances, never a close command's return value alone: process (pid gone), host pane (no live handle in the host's terminal list), and tty (device and login chain gone). When process or tty could not be measured and was skipped, the tool reports `CLOSED_PARTIAL` instead — pane-only absence is not a full close. Close command return values have been wrong in both directions on real hosts; the measurement decides.
 
 A frozen session also stays resumable forever from any terminal its agent CLI runs in, phones and remote machines included, so the boot card adds a revival check: scan running agent processes for lineage session ids (the session id is the portable key; resume flags differ per CLI), recover any unanswered owner instruction from a revived session, then take the revival through the same three disappearances. Four retired masters revived at once by a mobile resume is the measured incident behind the rule (2026-08-03).
 

--- a/docs/public/master-lifecycle.md
+++ b/docs/public/master-lifecycle.md
@@ -156,14 +156,14 @@ CLOSE_WAIT means these six things (an unstated convention is not a convention):
 
 Send the FIN into the predecessor's live prompt when it is idle; a mailbox the idle agent never reads is not delivery. Send-success is not consumption — verify by reading the pane. Choose a FIN marker the predecessor must produce that does not appear verbatim in the successor's own FIN text, or count occurrences and require at least two; quoting the marker inside the instruction string can put it on screen before the predecessor has answered.
 
-TIME_WAIT is not ceremony. A handle can rotate without a restart, and a session can hold two processes at once (one replaying the other's transcript). Closing the instant a FIN lands can close a pane whose incarnation is being recreated — the same hazard TIME_WAIT exists for in TCP. Wait for measured quiet on both the host's last-output timestamp and a pane read, then close.
+TIME_WAIT is not ceremony. A handle can rotate without a restart, and a session can hold two processes at once (one replaying the other's transcript). Closing the instant a FIN lands can close a pane whose incarnation is being recreated — the same hazard that TIME_WAIT exists to prevent in TCP. Wait for measured quiet on both the host's last-output timestamp and a pane read, then close.
 
-Carry the predecessor's pid and tty yourself. Host terminal lists often report `process_id: null` for the folder-workspace panes a master seat occupies, so the tool cannot invent those checks from the record. Pass what you measured:
+Carry the predecessor's pid and tty yourself. Host terminal lists often report `process_id: null` for the folder-workspace panes a master seat occupies, so the tool cannot invent those checks from the record. Pass what you measured on the live sessions (handles, pid, and tty are not assumed to come from any particular host environment variable):
 
 ```bash
 scripts/master-succeed retire \
-  --self-handle "$ORCA_TERMINAL_HANDLE" \
-  --target-handle predecessor-handle \
+  --self-handle <successor-handle you measured> \
+  --target-handle <predecessor-handle you measured> \
   --target-pid <measured-pid> \
   --target-tty <measured-tty> \
   --json \

--- a/docs/public/master-lifecycle.md
+++ b/docs/public/master-lifecycle.md
@@ -128,18 +128,59 @@ scripts/master-succeed verify-successor \
   --json
 ```
 
-Only after successor verification should the predecessor be retired. The retire command resolves exactly one predecessor candidate and refuses ambiguous matches:
+Only after successor verification should the predecessor be retired. Freezing is not retirement. The tool that closes the predecessor is `scripts/master-succeed retire`; call it by that name. It resolves exactly one predecessor candidate, refuses a self-handle match, refuses ambiguous matches, dry-runs unless `--execute`, and refuses when the pane survives the close. On its own the close is an abortive path (TCP's `RST`): it does not talk to the agent inside the pane. Using it without consent is how a predecessor loses unflushed work.
+
+## Retirement Is A Handshake
+
+Retirement is a connection teardown between two live agents, so it is run as one.
+
+| TCP | Master retirement | Actor |
+|---|---|---|
+| `FIN →` | successor tells the predecessor to stop accepting work and flush | successor |
+| `← ACK` | predecessor acknowledges and enters CLOSE_WAIT | predecessor |
+| half-close | predecessor's send side stays open: it may still commit and report | predecessor |
+| `← FIN` | predecessor declares itself flushed with one exact line | predecessor |
+| `ACK →` | successor acknowledges | successor |
+| TIME_WAIT | successor measures a quiet window before closing anything | successor |
+| CLOSED | `master-succeed retire --execute`, then three disappearances | successor |
+| `RST` | abortive close with no consent — owner approval required | successor |
+
+CLOSE_WAIT means these six things (an unstated convention is not a convention):
+
+1. no new dispatches
+2. no peer-mailbox acks the successor is expected to drain (or both drain twice)
+3. send nothing further to orchestration; let CLOSED drop the Run binding by closing the pane. Do not invent a detach verb — the binding is per terminal and keyed to the pane, so the close is the release. Until then the predecessor's silence prevents a double ack.
+4. commit uncommitted state, or report its path and content when it cannot
+5. list the live workers it owns and every unfinished track by name
+6. emit the agreed FIN line and nothing after it
+
+Send the FIN into the predecessor's live prompt when it is idle; a mailbox the idle agent never reads is not delivery. Send-success is not consumption — verify by reading the pane. Choose a FIN marker the predecessor must produce that does not appear verbatim in the successor's own FIN text, or count occurrences and require at least two; quoting the marker inside the instruction string can put it on screen before the predecessor has answered.
+
+TIME_WAIT is not ceremony. A handle can rotate without a restart, and a session can hold two processes at once (one replaying the other's transcript). Closing the instant a FIN lands can close a pane whose incarnation is being recreated — the same hazard TIME_WAIT exists for in TCP. Wait for measured quiet on both the host's last-output timestamp and a pane read, then close.
+
+Carry the predecessor's pid and tty yourself. Host terminal lists often report `process_id: null` for the folder-workspace panes a master seat occupies, so the tool cannot invent those checks from the record. Pass what you measured:
 
 ```bash
 scripts/master-succeed retire \
-  --self-handle successor-handle \
+  --self-handle "$ORCA_TERMINAL_HANDLE" \
   --target-handle predecessor-handle \
-  --json
+  --target-pid <measured-pid> \
+  --target-tty <measured-tty> \
+  --json \
+  --execute
 ```
 
-Add `--execute` only when the operator intends to close the predecessor terminal.
+Each disappearance is reported separately under `disappearances` (`pane`, `process`, `tty`), each valued `measured`, `still_present`, or `skipped:<why>`. `CLOSED` means all three are `measured` and none is `still_present`. When process or tty was skipped, status is `CLOSED_PARTIAL` so a skip cannot read as a full pass. A survivor is a refusal. Without `--execute` the command dry-runs.
 
-Retiring a predecessor ends with three measured disappearances, never with a close command's return value: process, host pane, and tty. A frozen session also stays resumable forever from any terminal its agent CLI runs in, phones and remote machines included, so the boot card adds a revival check: scan running agent processes for lineage session ids (the session id is the portable key; resume flags differ per CLI), recover any unanswered owner instruction from a revived session, then take the revival through the same three disappearances. Four retired masters revived at once by a mobile resume is the measured incident behind the rule (2026-08-03).
+Sweep the predecessor's scratchpad before CLOSED. It dies with the session and is often the only place uncommitted work had to live. Copy the tree somewhere durable that is not a git repository, then diff each file against the trunk branch and record the verdict — including when salvage value is zero.
+
+`RST` is the only path that skips consent, and it needs owner approval. Before reaching for it, classify the pane by reading it: a limit condition, a start-screen gate, and a dead process are three different things with three different answers.
+
+## Retirement Completion And Revival
+
+Retirement ends with three measured disappearances, never with a close command's return value: process (pid gone), host pane (no live handle in the host's terminal list), and tty (device and login chain gone). Close command return values have been wrong in both directions on real hosts; the measurement decides.
+
+A frozen session also stays resumable forever from any terminal its agent CLI runs in, phones and remote machines included, so the boot card adds a revival check: scan running agent processes for lineage session ids (the session id is the portable key; resume flags differ per CLI), recover any unanswered owner instruction from a revived session, then take the revival through the same three disappearances. Four retired masters revived at once by a mobile resume is the measured incident behind the rule (2026-08-03).
 
 Early planned successions changed the procedure. One handoff described the predecessor as gone while the process was still alive, so runtime state is now checked separately from handoff text. Later successions added command-line and session-path matching before retirement, plus explicit cleanup and restart of monitors under the successor's ownership. A clean succession is therefore not only "the successor read the handoff"; it is a measured transfer of role, track, process ownership, and verification responsibility.
 

--- a/docs/public/master-lifecycle.md
+++ b/docs/public/master-lifecycle.md
@@ -162,8 +162,8 @@ Carry the predecessor's pid and tty yourself. Host terminal lists often report `
 
 ```bash
 scripts/master-succeed retire \
-  --self-handle <successor-handle you measured> \
-  --target-handle <predecessor-handle you measured> \
+  --self-handle <successor-handle-you-measured> \
+  --target-handle <predecessor-handle-you-measured> \
   --target-pid <measured-pid> \
   --target-tty <measured-tty> \
   --json \

--- a/scripts/master-succeed
+++ b/scripts/master-succeed
@@ -76,6 +76,8 @@ def _dispatch(args, runner):
             target_handle=args.target_handle,
             target_pty_id=args.target_pty_id,
             target_session_id=args.target_session_id,
+            target_pid=args.target_pid,
+            target_tty=args.target_tty,
             orca_runner=runner,
             execute=args.execute,
         )
@@ -132,6 +134,22 @@ def _build_parser() -> argparse.ArgumentParser:
     retire.add_argument("--target-handle")
     retire.add_argument("--target-pty-id")
     retire.add_argument("--target-session-id")
+    retire.add_argument(
+        "--target-pid",
+        type=int,
+        help=(
+            "Externally measured predecessor pid. When the terminal record "
+            "reports process_id null (common for folder-workspace panes), pass "
+            "the pid you measured so CLOSED can include process disappearance."
+        ),
+    )
+    retire.add_argument(
+        "--target-tty",
+        help=(
+            "Externally measured predecessor tty (e.g. /dev/ttys147 or ttys147). "
+            "When omitted, the tty check is skipped and cannot count toward CLOSED."
+        ),
+    )
     retire.add_argument("--execute", action="store_true")
 
     spawn = subparsers.add_parser("spawn", parents=[common])

--- a/src/master_runtime/core/succession.py
+++ b/src/master_runtime/core/succession.py
@@ -7,7 +7,7 @@ import os
 import re
 import shlex
 import subprocess
-from dataclasses import asdict, dataclass
+from dataclasses import asdict, dataclass, field
 from typing import Callable, Mapping, Optional, Sequence, Tuple
 
 from master_runtime.core.bootstrap import RoleState
@@ -77,6 +77,17 @@ class SessionInfo:
         return asdict(self)
 
 
+# Per-check disappearance values on RetirementReport.disappearances.
+# CLOSED requires pane=measured and no still_present. Any skipped:* forces
+# CLOSED_PARTIAL so a partial measurement cannot read as a full three-way close.
+DISAPPEARANCE_MEASURED = "measured"
+DISAPPEARANCE_STILL_PRESENT = "still_present"
+STATUS_CLOSED = "CLOSED"
+STATUS_CLOSED_PARTIAL = "CLOSED_PARTIAL"
+STATUS_REFUSED = "REFUSED"
+STATUS_DRY_RUN = "DRY_RUN"
+
+
 @dataclass(frozen=True)
 class RetirementReport:
     status: str
@@ -85,11 +96,13 @@ class RetirementReport:
     candidates: Tuple[SessionInfo, ...]
     closed: bool = False
     match_attempts: Tuple[str, ...] = ()
+    disappearances: Mapping[str, str] = field(default_factory=dict)
 
     def to_dict(self) -> dict:
         payload = asdict(self)
         payload["candidates"] = [candidate.to_dict() for candidate in self.candidates]
         payload["match_attempts"] = list(self.match_attempts)
+        payload["disappearances"] = dict(self.disappearances)
         return payload
 
 
@@ -113,6 +126,7 @@ class SpawnReport:
 
 OrcaRunner = Callable[[Sequence[str]], Tuple[int, str, str]]
 ProcessProbe = Callable[[int], bool]
+TtyProbe = Callable[[str], bool]
 
 SPAWN_CREATE_ERROR = 20
 SPAWN_PARSE_ERROR = 21
@@ -332,11 +346,24 @@ def retire_predecessor(
     target_handle: Optional[str] = None,
     target_pty_id: Optional[str] = None,
     target_session_id: Optional[str] = None,
+    target_pid: Optional[int] = None,
+    target_tty: Optional[str] = None,
     process_probe: Optional[ProcessProbe] = None,
+    tty_probe: Optional[TtyProbe] = None,
 ) -> RetirementReport:
-    """Resolve and optionally close exactly one predecessor terminal."""
+    """Resolve and optionally close exactly one predecessor terminal.
+
+    ``CLOSED`` means three measured disappearances (pane, process, tty). When the
+    pane is gone and nothing is still present but process or tty was skipped,
+    status is ``CLOSED_PARTIAL`` so a skip cannot read as a full pass. Supply
+    ``target_pid`` / ``target_tty`` when the host terminal record omits them
+    (folder-workspace panes often report ``process_id: null``); this function
+    does not invent a pid from a null record.
+    """
 
     _require_handle(self_handle)
+    if target_pid is not None and target_pid <= 0:
+        raise SuccessionError("target_pid must be a positive integer")
     criteria = _retirement_criteria(
         predecessor_selector,
         expected_substr,
@@ -350,7 +377,7 @@ def retire_predecessor(
         raise SuccessionError("self_handle matched retirement candidate; refusing to close self")
     if not candidates:
         return RetirementReport(
-            "REFUSED",
+            STATUS_REFUSED,
             None,
             _retirement_refusal_reason("no predecessor candidates", candidates, attempts),
             candidates,
@@ -359,7 +386,7 @@ def retire_predecessor(
         )
     if len(candidates) > 1:
         return RetirementReport(
-            "REFUSED",
+            STATUS_REFUSED,
             None,
             _retirement_refusal_reason("ambiguous predecessor candidates", candidates, attempts),
             candidates,
@@ -369,7 +396,14 @@ def retire_predecessor(
 
     target = candidates[0]
     if not execute:
-        return RetirementReport("DRY_RUN", target.handle, "dry-run only", (target,), False, attempts)
+        return RetirementReport(
+            STATUS_DRY_RUN,
+            target.handle,
+            "dry-run only",
+            (target,),
+            False,
+            attempts,
+        )
 
     runner = orca_runner or _default_orca_runner
     code, stdout, stderr = runner(
@@ -377,7 +411,7 @@ def retire_predecessor(
     )
     if code != 0:
         return RetirementReport(
-            "REFUSED",
+            STATUS_REFUSED,
             target.handle,
             stderr.strip() or stdout.strip() or "orca terminal close failed",
             (target,),
@@ -385,41 +419,130 @@ def retire_predecessor(
             attempts,
         )
     remaining = find_sessions(runner)
-    if any(session.handle == target.handle for session in remaining):
-        return RetirementReport(
-            "REFUSED",
-            target.handle,
-            "target still present after close",
-            (target,),
-            False,
-            attempts,
-        )
-    if target.process_id is not None:
-        probe = process_probe or _default_process_probe
-        if probe(target.process_id):
-            return RetirementReport(
-                "REFUSED",
-                target.handle,
-                "target process still present after close: pid={0}".format(target.process_id),
-                (target,),
-                False,
-                attempts,
-            )
-        return RetirementReport(
-            "CLOSED",
-            target.handle,
-            "target disappeared after close; process gone: pid={0}".format(target.process_id),
-            (target,),
-            True,
-            attempts,
-        )
+    disappearances, measured_pid = _measure_disappearances(
+        target=target,
+        remaining=remaining,
+        target_pid=target_pid,
+        target_tty=target_tty,
+        process_probe=process_probe or _default_process_probe,
+        tty_probe=tty_probe or _default_tty_probe,
+    )
+    status, closed, reason = _retirement_outcome(
+        disappearances,
+        measured_pid=measured_pid,
+        target_tty=target_tty,
+    )
     return RetirementReport(
-        "CLOSED",
+        status,
         target.handle,
-        "target disappeared after close; no pid reported by terminal list",
+        reason,
         (target,),
-        True,
+        closed,
         attempts,
+        disappearances,
+    )
+
+
+def _measure_disappearances(
+    target: SessionInfo,
+    remaining: Sequence[SessionInfo],
+    target_pid: Optional[int],
+    target_tty: Optional[str],
+    process_probe: ProcessProbe,
+    tty_probe: TtyProbe,
+) -> Tuple[Mapping[str, str], Optional[int]]:
+    pane = (
+        DISAPPEARANCE_STILL_PRESENT
+        if any(session.handle == target.handle for session in remaining)
+        else DISAPPEARANCE_MEASURED
+    )
+
+    # Prefer an externally measured pid; otherwise keep today's terminal-record
+    # behaviour. Never invent a pid when the record is null — that is the caller's job.
+    if target_pid is not None:
+        process_pid: Optional[int] = target_pid
+        process_skip: Optional[str] = None
+    elif target.process_id is not None:
+        process_pid = target.process_id
+        process_skip = None
+    else:
+        process_pid = None
+        process_skip = "skipped:no target-pid and no pid reported by terminal list"
+
+    if process_skip is not None:
+        process = process_skip
+    elif process_probe(process_pid):  # type: ignore[arg-type]
+        process = DISAPPEARANCE_STILL_PRESENT
+    else:
+        process = DISAPPEARANCE_MEASURED
+
+    if target_tty:
+        tty = (
+            DISAPPEARANCE_STILL_PRESENT
+            if tty_probe(target_tty)
+            else DISAPPEARANCE_MEASURED
+        )
+    else:
+        tty = "skipped:no target-tty supplied"
+
+    return {"pane": pane, "process": process, "tty": tty}, process_pid
+
+
+def _retirement_outcome(
+    disappearances: Mapping[str, str],
+    measured_pid: Optional[int],
+    target_tty: Optional[str],
+) -> Tuple[str, bool, str]:
+    """Map per-check results to status / closed / reason.
+
+    Vocabulary:
+    - REFUSED: any check is still_present, or pane was not measured.
+    - CLOSED: pane, process, and tty are all measured (full three-disappearance).
+    - CLOSED_PARTIAL: pane measured, nothing still_present, but process and/or
+      tty is skipped:* — partial measurement must not read as a full CLOSED.
+    """
+
+    summary = "disappearances={0}".format(
+        ",".join("{0}={1}".format(key, disappearances[key]) for key in ("pane", "process", "tty"))
+    )
+    if disappearances.get("pane") == DISAPPEARANCE_STILL_PRESENT:
+        return STATUS_REFUSED, False, "target still present after close; " + summary
+    if disappearances.get("process") == DISAPPEARANCE_STILL_PRESENT:
+        return (
+            STATUS_REFUSED,
+            False,
+            "target process still present after close: pid={0}; {1}".format(
+                measured_pid,
+                summary,
+            ),
+        )
+    if disappearances.get("tty") == DISAPPEARANCE_STILL_PRESENT:
+        return (
+            STATUS_REFUSED,
+            False,
+            "target tty still present after close: {0}; {1}".format(target_tty, summary),
+        )
+    if disappearances.get("pane") != DISAPPEARANCE_MEASURED:
+        return STATUS_REFUSED, False, "pane disappearance not measured; " + summary
+
+    skipped = [
+        "{0}={1}".format(key, value)
+        for key, value in disappearances.items()
+        if str(value).startswith("skipped:")
+    ]
+    if skipped:
+        return (
+            STATUS_CLOSED_PARTIAL,
+            True,
+            "target pane disappeared after close; partial measurement ({0}); {1}".format(
+                ";".join(skipped),
+                summary,
+            ),
+        )
+    return (
+        STATUS_CLOSED,
+        True,
+        "target disappeared after close; three disappearances measured; " + summary,
     )
 
 
@@ -1168,6 +1291,33 @@ def _default_process_probe(pid: int) -> bool:
     return completed.returncode == 0 and bool(completed.stdout.strip())
 
 
+def _tty_bare_name(tty: str) -> str:
+    text = (tty or "").strip()
+    if text.startswith("/dev/"):
+        return text[len("/dev/") :]
+    return text
+
+
+def _default_tty_probe(tty: str) -> bool:
+    """Return True when a login/process chain still holds the tty.
+
+    Device nodes under /dev often persist after hangup on some hosts, so the
+    decisive measurement is whether any process still lists the tty. Inject a
+    ``tty_probe`` in tests rather than asserting this default.
+    """
+
+    bare = _tty_bare_name(tty)
+    if not bare:
+        return False
+    completed = subprocess.run(
+        ("ps", "-t", bare, "-o", "pid="),
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    return completed.returncode == 0 and bool(completed.stdout.strip())
+
+
 def _optional_int(value: object) -> Optional[int]:
     try:
         return int(value) if value not in (None, "") else None
@@ -1220,8 +1370,14 @@ def _require_substr(value: str, label: str) -> str:
 
 
 __all__ = (
+    "DISAPPEARANCE_MEASURED",
+    "DISAPPEARANCE_STILL_PRESENT",
     "FrozenState",
     "RetirementReport",
+    "STATUS_CLOSED",
+    "STATUS_CLOSED_PARTIAL",
+    "STATUS_DRY_RUN",
+    "STATUS_REFUSED",
     "SessionInfo",
     "SpawnReport",
     "SuccessionError",

--- a/src/master_runtime/core/succession.py
+++ b/src/master_runtime/core/succession.py
@@ -476,14 +476,19 @@ def _measure_disappearances(
     else:
         process = DISAPPEARANCE_MEASURED
 
-    if target_tty:
-        tty = (
-            DISAPPEARANCE_STILL_PRESENT
-            if tty_probe(target_tty)
-            else DISAPPEARANCE_MEASURED
-        )
-    else:
+    # Whitespace-only or "/dev/"-only values normalize to an empty bare name.
+    # Treat those as skipped, never as measured — an unusable target is not a
+    # disappearance the probe observed.
+    if target_tty is None or not str(target_tty).strip():
         tty = "skipped:no target-tty supplied"
+    else:
+        bare_tty = _tty_bare_name(str(target_tty))
+        if not bare_tty:
+            tty = "skipped:target-tty has no device name after normalization"
+        elif tty_probe(str(target_tty).strip()):
+            tty = DISAPPEARANCE_STILL_PRESENT
+        else:
+            tty = DISAPPEARANCE_MEASURED
 
     return {"pane": pane, "process": process, "tty": tty}, process_pid
 
@@ -1281,13 +1286,22 @@ def _default_orca_runner(command: Sequence[str]) -> Tuple[int, str, str]:
     return completed.returncode, completed.stdout, completed.stderr
 
 
+_PROBE_TIMEOUT_SEC = 5
+
+
 def _default_process_probe(pid: int) -> bool:
-    completed = subprocess.run(
-        ("ps", "-p", str(pid), "-o", "pid="),
-        check=False,
-        capture_output=True,
-        text=True,
-    )
+    try:
+        completed = subprocess.run(
+            ("ps", "-p", str(pid), "-o", "pid="),
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=_PROBE_TIMEOUT_SEC,
+        )
+    except subprocess.TimeoutExpired:
+        # Unmeasurable within budget: report presence so the outcome refuses
+        # instead of claiming a disappearance the probe never observed.
+        return True
     return completed.returncode == 0 and bool(completed.stdout.strip())
 
 
@@ -1303,18 +1317,25 @@ def _default_tty_probe(tty: str) -> bool:
 
     Device nodes under /dev often persist after hangup on some hosts, so the
     decisive measurement is whether any process still lists the tty. Inject a
-    ``tty_probe`` in tests rather than asserting this default.
+    ``tty_probe`` in tests rather than asserting this default. A stalled ``ps``
+    is treated as still present (fail-closed).
     """
 
     bare = _tty_bare_name(tty)
     if not bare:
         return False
-    completed = subprocess.run(
-        ("ps", "-t", bare, "-o", "pid="),
-        check=False,
-        capture_output=True,
-        text=True,
-    )
+    try:
+        completed = subprocess.run(
+            ("ps", "-t", bare, "-o", "pid="),
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=_PROBE_TIMEOUT_SEC,
+        )
+    except subprocess.TimeoutExpired:
+        # Unmeasurable within budget: report presence so the outcome refuses
+        # instead of claiming a disappearance the probe never observed.
+        return True
     return completed.returncode == 0 and bool(completed.stdout.strip())
 
 

--- a/src/master_runtime/core/succession.py
+++ b/src/master_runtime/core/succession.py
@@ -1006,12 +1006,30 @@ def _spawn_startup_command(
             quoted_kickoff,
         )
     if agent_key in ("codex",):
+        # Codex has no launch approval flag by design; it uses the account-wide
+        # pre-trust path (scripts/codex-worker-pretrust) instead.
         return "cd {0} && exec codex --model {1} {2}".format(
             quoted_root,
             quoted_model,
             quoted_kickoff,
         )
+    if agent_key in ("cursor", "cursor-agent"):
+        # The executable is cursor-agent; plain `cursor` is the updater.
+        return "cd {0} && exec cursor-agent --model {1} --force --trust {2}".format(
+            quoted_root,
+            quoted_model,
+            quoted_kickoff,
+        )
+    if agent_key in ("agy",):
+        return "cd {0} && exec agy --model {1} --dangerously-skip-permissions {2}".format(
+            quoted_root,
+            quoted_model,
+            quoted_kickoff,
+        )
     # Unknown agent: treat the name as the executable and pass model + prompt.
+    # No approval flag is attached, so such a session can come up prompt-blocked
+    # and stall on its first tool call. Add a branch above once the host's flag
+    # has been measured from its own --help; do not guess one.
     return "cd {0} && exec {1} --model {2} {3}".format(
         quoted_root,
         shlex.quote(agent.strip()),

--- a/tests/test_succession.py
+++ b/tests/test_succession.py
@@ -730,6 +730,21 @@ def test_spawn_startup_command_covers_agent_variants_and_shell_quoting() -> None
         "cd '/repo/with space' && exec codex --model gpt-5.6-sol "
         "'start; $(touch should-not-run)'"
     )
+    # Flags below are measured from each CLI's own --help, never guessed.
+    # cursor-agent is the executable; plain `cursor` is the updater, so both
+    # spellings must resolve to cursor-agent or a successor lands in the wrong
+    # binary. --force allows commands unless denied, --trust skips the
+    # workspace prompt; without them the session comes up prompt-blocked, which
+    # is how Generation 1 stalled on a bare claude.
+    for spelling in ("cursor", "cursor-agent"):
+        assert _spawn_startup_command(root, "gpt-5", kickoff, spelling) == (
+            "cd '/repo/with space' && exec cursor-agent --model gpt-5 --force --trust "
+            "'start; $(touch should-not-run)'"
+        )
+    assert _spawn_startup_command(root, "agy-model", kickoff, "agy") == (
+        "cd '/repo/with space' && exec agy --model agy-model "
+        "--dangerously-skip-permissions 'start; $(touch should-not-run)'"
+    )
     assert _spawn_startup_command(root, "custom-model", kickoff, "custom agent; touch") == (
         "cd '/repo/with space' && exec 'custom agent; touch' --model custom-model "
         "'start; $(touch should-not-run)'"

--- a/tests/test_succession.py
+++ b/tests/test_succession.py
@@ -8,6 +8,7 @@ import tempfile
 import unittest
 from pathlib import Path
 from typing import Sequence, Tuple
+from unittest.mock import patch
 
 from master_runtime.core.bootstrap import RoleState
 from master_runtime.core.recovery import RecoveryReport, RecoveryStep
@@ -15,6 +16,8 @@ from master_runtime.core.succession import (
     SPAWN_PLACEMENT_MISMATCH,
     SessionInfo,
     SuccessionError,
+    _default_process_probe,
+    _default_tty_probe,
     _reissued_terminal_candidates,
     _spawn_startup_command,
     _worktrees_match,
@@ -796,6 +799,26 @@ def test_retire_blank_target_tty_is_skipped_not_measured() -> None:
         assert report.disappearances["tty"].startswith("skipped:"), blank_tty
         assert report.status != "CLOSED", blank_tty
         assert probe_calls == [], blank_tty
+
+
+def test_default_process_probe_timeout_is_fail_closed() -> None:
+    """TimeoutExpired → still present is pure control flow, not host /dev behaviour."""
+
+    def raise_timeout(*_args, **_kwargs):
+        raise subprocess.TimeoutExpired(cmd=("ps",), timeout=5)
+
+    with patch("master_runtime.core.succession.subprocess.run", side_effect=raise_timeout):
+        assert _default_process_probe(4242) is True
+
+
+def test_default_tty_probe_timeout_is_fail_closed() -> None:
+    """TimeoutExpired → still present is pure control flow, not host /dev behaviour."""
+
+    def raise_timeout(*_args, **_kwargs):
+        raise subprocess.TimeoutExpired(cmd=("ps",), timeout=5)
+
+    with patch("master_runtime.core.succession.subprocess.run", side_effect=raise_timeout):
+        assert _default_tty_probe("/dev/ttys147") is True
 
 
 def test_retire_target_tty_supplied_and_still_present_is_refused() -> None:

--- a/tests/test_succession.py
+++ b/tests/test_succession.py
@@ -739,6 +739,65 @@ def test_retire_target_tty_supplied_and_gone() -> None:
     assert report.disappearances["tty"] == "measured"
 
 
+def test_retire_blank_target_tty_is_skipped_not_measured() -> None:
+    """Whitespace-only or /dev/-only target_tty must not count as measured."""
+    base_lists = {
+        _LIST_COMMAND: [
+            (
+                0,
+                _orca_json_from_terminals(
+                    {"handle": "term-self", "connected": True, "title": "successor"},
+                    {
+                        "handle": "term-u8",
+                        "processId": 99,
+                        "connected": True,
+                        "title": "predecessor",
+                    },
+                ),
+                "",
+            ),
+            (
+                0,
+                _orca_json_from_terminals(
+                    {"handle": "term-self", "connected": True, "title": "successor"},
+                ),
+                "",
+            ),
+        ],
+        ("orca", "terminal", "close", "--terminal", "term-u8", "--json"): (0, '{"ok":true}', ""),
+    }
+
+    for blank_tty in ("   ", "/dev/", " /dev/ "):
+        runner = _runner(
+            {
+                _LIST_COMMAND: list(base_lists[_LIST_COMMAND]),
+                ("orca", "terminal", "close", "--terminal", "term-u8", "--json"): (
+                    0,
+                    '{"ok":true}',
+                    "",
+                ),
+            }
+        )
+        probe_calls = []
+        report = retire_predecessor(
+            predecessor_selector="",
+            self_handle="term-self",
+            target_handle="term-u8",
+            orca_runner=runner,
+            execute=True,
+            target_tty=blank_tty,
+            process_probe=lambda pid: False,
+            tty_probe=lambda tty: probe_calls.append(tty) or False,
+        )
+
+        assert report.status == "CLOSED_PARTIAL", blank_tty
+        assert report.disappearances["pane"] == "measured", blank_tty
+        assert report.disappearances["process"] == "measured", blank_tty
+        assert report.disappearances["tty"].startswith("skipped:"), blank_tty
+        assert report.status != "CLOSED", blank_tty
+        assert probe_calls == [], blank_tty
+
+
 def test_retire_target_tty_supplied_and_still_present_is_refused() -> None:
     runner = _runner(
         {

--- a/tests/test_succession.py
+++ b/tests/test_succession.py
@@ -281,8 +281,13 @@ def test_retire_predecessor_execute_closes_and_rechecks() -> None:
         execute=True,
     )
 
-    assert report.status == "CLOSED"
+    # No pid/tty supplied and terminal record has none → partial, not full CLOSED.
+    assert report.status == "CLOSED_PARTIAL"
     assert report.target_handle == "term-u8"
+    assert report.closed is True
+    assert report.disappearances["pane"] == "measured"
+    assert report.disappearances["process"].startswith("skipped:")
+    assert report.disappearances["tty"].startswith("skipped:")
     assert ("orca", "terminal", "close", "--terminal", "term-u8", "--json") in calls
 
 
@@ -394,10 +399,13 @@ def test_retire_predecessor_explicit_handle_closes_title_drift_folder_context() 
         process_probe=lambda pid: False,
     )
 
-    assert report.status == "CLOSED"
+    # Process measured from terminal record; tty still skipped → CLOSED_PARTIAL.
+    assert report.status == "CLOSED_PARTIAL"
     assert report.target_handle == "term-u8"
     assert report.closed is True
-    assert "process gone: pid=4242" in report.reason
+    assert report.disappearances["pane"] == "measured"
+    assert report.disappearances["process"] == "measured"
+    assert report.disappearances["tty"].startswith("skipped:")
     assert "term-u8: handle=term-u8 -> handle" in report.match_attempts
     assert ("orca", "terminal", "close", "--terminal", "term-u8", "--json") in calls
 
@@ -453,7 +461,381 @@ def test_retire_predecessor_refuses_when_pid_survives_close() -> None:
 
     assert report.status == "REFUSED"
     assert report.closed is False
+    assert report.disappearances["pane"] == "measured"
+    assert report.disappearances["process"] == "still_present"
     assert "target process still present after close: pid=4242" in report.reason
+
+
+def test_retire_target_pid_supplied_and_gone_with_tty_is_closed() -> None:
+    runner = _runner(
+        {
+            _LIST_COMMAND: [
+                (
+                    0,
+                    _orca_json_from_terminals(
+                        {
+                            "handle": "term-self",
+                            "worktreePath": "/repo/mogui-ADE-orchestrator/u9-succession",
+                            "connected": True,
+                            "title": "u9 successor",
+                        },
+                        {
+                            "handle": "term-u8",
+                            "processId": None,
+                            "worktreePath": "",
+                            "connected": True,
+                            "title": "folder workspace predecessor",
+                        },
+                    ),
+                    "",
+                ),
+                (
+                    0,
+                    _orca_json_from_terminals(
+                        {
+                            "handle": "term-self",
+                            "worktreePath": "/repo/mogui-ADE-orchestrator/u9-succession",
+                            "connected": True,
+                            "title": "u9 successor",
+                        },
+                    ),
+                    "",
+                ),
+            ],
+            ("orca", "terminal", "close", "--terminal", "term-u8", "--json"): (0, '{"ok":true}', ""),
+        }
+    )
+    probed = []
+
+    report = retire_predecessor(
+        predecessor_selector="",
+        self_handle="term-self",
+        target_handle="term-u8",
+        orca_runner=runner,
+        execute=True,
+        target_pid=88616,
+        target_tty="/dev/ttys147",
+        process_probe=lambda pid: probed.append(pid) or False,
+        tty_probe=lambda tty: probed.append(tty) or False,
+    )
+
+    assert report.status == "CLOSED"
+    assert report.closed is True
+    assert report.disappearances == {
+        "pane": "measured",
+        "process": "measured",
+        "tty": "measured",
+    }
+    assert probed == [88616, "/dev/ttys147"]
+    assert "three disappearances measured" in report.reason
+
+
+def test_retire_target_pid_supplied_and_still_present_is_refused() -> None:
+    runner = _runner(
+        {
+            _LIST_COMMAND: [
+                (
+                    0,
+                    _orca_json_from_terminals(
+                        {
+                            "handle": "term-self",
+                            "connected": True,
+                            "title": "successor",
+                        },
+                        {
+                            "handle": "term-u8",
+                            "processId": None,
+                            "connected": True,
+                            "title": "predecessor",
+                        },
+                    ),
+                    "",
+                ),
+                (
+                    0,
+                    _orca_json_from_terminals(
+                        {"handle": "term-self", "connected": True, "title": "successor"},
+                    ),
+                    "",
+                ),
+            ],
+            ("orca", "terminal", "close", "--terminal", "term-u8", "--json"): (0, '{"ok":true}', ""),
+        }
+    )
+
+    report = retire_predecessor(
+        predecessor_selector="",
+        self_handle="term-self",
+        target_handle="term-u8",
+        orca_runner=runner,
+        execute=True,
+        target_pid=88616,
+        process_probe=lambda pid: True,
+        tty_probe=lambda tty: False,
+    )
+
+    assert report.status == "REFUSED"
+    assert report.closed is False
+    assert report.disappearances["process"] == "still_present"
+    assert "pid=88616" in report.reason
+    # A skip on tty must not be readable as a process pass.
+    assert report.disappearances["tty"].startswith("skipped:")
+    assert report.status != "CLOSED"
+    assert report.status != "CLOSED_PARTIAL"
+
+
+def test_retire_pid_omitted_with_null_terminal_pid_is_skipped_not_pass() -> None:
+    """Gen-2 teardown shape: process_id null, no --target-pid → never full CLOSED."""
+    runner = _runner(
+        {
+            _LIST_COMMAND: [
+                (
+                    0,
+                    _orca_json_from_terminals(
+                        {
+                            "handle": "term-self",
+                            "connected": True,
+                            "title": "successor",
+                        },
+                        {
+                            "handle": "term-u8",
+                            "processId": None,
+                            "connected": True,
+                            "title": "folder workspace master",
+                        },
+                    ),
+                    "",
+                ),
+                (
+                    0,
+                    _orca_json_from_terminals(
+                        {"handle": "term-self", "connected": True, "title": "successor"},
+                    ),
+                    "",
+                ),
+            ],
+            ("orca", "terminal", "close", "--terminal", "term-u8", "--json"): (0, '{"ok":true}', ""),
+        }
+    )
+    process_probe_calls = []
+
+    report = retire_predecessor(
+        predecessor_selector="",
+        self_handle="term-self",
+        target_handle="term-u8",
+        orca_runner=runner,
+        execute=True,
+        process_probe=lambda pid: process_probe_calls.append(pid) or False,
+    )
+
+    assert report.status == "CLOSED_PARTIAL"
+    assert report.closed is True
+    assert report.disappearances["pane"] == "measured"
+    assert report.disappearances["process"] == (
+        "skipped:no target-pid and no pid reported by terminal list"
+    )
+    assert report.disappearances["tty"] == "skipped:no target-tty supplied"
+    assert process_probe_calls == []
+    assert report.status != "CLOSED"
+
+
+def test_retire_null_process_id_with_external_target_pid_pins_gen2_shape() -> None:
+    """Terminal record process_id null AND --target-pid supplied (Gen-2 real shape)."""
+    runner = _runner(
+        {
+            _LIST_COMMAND: [
+                (
+                    0,
+                    _orca_json_from_terminals(
+                        {
+                            "handle": "term-self",
+                            "connected": True,
+                            "title": "gen3 successor",
+                        },
+                        {
+                            "handle": "term-u8",
+                            "processId": None,
+                            "connected": True,
+                            "title": "gen2 predecessor",
+                        },
+                    ),
+                    "",
+                ),
+                (
+                    0,
+                    _orca_json_from_terminals(
+                        {"handle": "term-self", "connected": True, "title": "gen3 successor"},
+                    ),
+                    "",
+                ),
+            ],
+            ("orca", "terminal", "close", "--terminal", "term-u8", "--json"): (0, '{"ok":true}', ""),
+        }
+    )
+    probed_pids = []
+
+    report = retire_predecessor(
+        predecessor_selector="",
+        self_handle="term-self",
+        target_handle="term-u8",
+        orca_runner=runner,
+        execute=True,
+        target_pid=88616,
+        target_tty="ttys147",
+        process_probe=lambda pid: probed_pids.append(pid) or False,
+        tty_probe=lambda tty: False,
+    )
+
+    assert probed_pids == [88616]
+    assert report.status == "CLOSED"
+    assert report.disappearances == {
+        "pane": "measured",
+        "process": "measured",
+        "tty": "measured",
+    }
+
+
+def test_retire_target_tty_supplied_and_gone() -> None:
+    runner = _runner(
+        {
+            _LIST_COMMAND: [
+                (
+                    0,
+                    _orca_json_from_terminals(
+                        {"handle": "term-self", "connected": True, "title": "successor"},
+                        {
+                            "handle": "term-u8",
+                            "processId": 99,
+                            "connected": True,
+                            "title": "predecessor",
+                        },
+                    ),
+                    "",
+                ),
+                (
+                    0,
+                    _orca_json_from_terminals(
+                        {"handle": "term-self", "connected": True, "title": "successor"},
+                    ),
+                    "",
+                ),
+            ],
+            ("orca", "terminal", "close", "--terminal", "term-u8", "--json"): (0, '{"ok":true}', ""),
+        }
+    )
+
+    report = retire_predecessor(
+        predecessor_selector="",
+        self_handle="term-self",
+        target_handle="term-u8",
+        orca_runner=runner,
+        execute=True,
+        target_tty="/dev/ttys147",
+        process_probe=lambda pid: False,
+        tty_probe=lambda tty: False,
+    )
+
+    assert report.status == "CLOSED"
+    assert report.disappearances["tty"] == "measured"
+
+
+def test_retire_target_tty_supplied_and_still_present_is_refused() -> None:
+    runner = _runner(
+        {
+            _LIST_COMMAND: [
+                (
+                    0,
+                    _orca_json_from_terminals(
+                        {"handle": "term-self", "connected": True, "title": "successor"},
+                        {
+                            "handle": "term-u8",
+                            "processId": 99,
+                            "connected": True,
+                            "title": "predecessor",
+                        },
+                    ),
+                    "",
+                ),
+                (
+                    0,
+                    _orca_json_from_terminals(
+                        {"handle": "term-self", "connected": True, "title": "successor"},
+                    ),
+                    "",
+                ),
+            ],
+            ("orca", "terminal", "close", "--terminal", "term-u8", "--json"): (0, '{"ok":true}', ""),
+        }
+    )
+
+    report = retire_predecessor(
+        predecessor_selector="",
+        self_handle="term-self",
+        target_handle="term-u8",
+        orca_runner=runner,
+        execute=True,
+        target_tty="/dev/ttys147",
+        process_probe=lambda pid: False,
+        tty_probe=lambda tty: True,
+    )
+
+    assert report.status == "REFUSED"
+    assert report.closed is False
+    assert report.disappearances["tty"] == "still_present"
+    assert "target tty still present after close: /dev/ttys147" in report.reason
+
+
+def test_retire_pane_surviving_close_is_refused() -> None:
+    runner = _runner(
+        {
+            _LIST_COMMAND: [
+                (
+                    0,
+                    _orca_json_from_terminals(
+                        {"handle": "term-self", "connected": True, "title": "successor"},
+                        {
+                            "handle": "term-u8",
+                            "processId": 99,
+                            "connected": True,
+                            "title": "predecessor",
+                        },
+                    ),
+                    "",
+                ),
+                (
+                    0,
+                    _orca_json_from_terminals(
+                        {"handle": "term-self", "connected": True, "title": "successor"},
+                        {
+                            "handle": "term-u8",
+                            "processId": 99,
+                            "connected": True,
+                            "title": "predecessor",
+                        },
+                    ),
+                    "",
+                ),
+            ],
+            ("orca", "terminal", "close", "--terminal", "term-u8", "--json"): (0, '{"ok":true}', ""),
+        }
+    )
+
+    report = retire_predecessor(
+        predecessor_selector="",
+        self_handle="term-self",
+        target_handle="term-u8",
+        orca_runner=runner,
+        execute=True,
+        target_pid=99,
+        target_tty="ttys1",
+        process_probe=lambda pid: False,
+        tty_probe=lambda tty: False,
+    )
+
+    assert report.status == "REFUSED"
+    assert report.closed is False
+    assert report.disappearances["pane"] == "still_present"
+    assert "target still present after close" in report.reason
 
 
 def test_spawn_successor_creates_and_verifies_worktree() -> None:


### PR DESCRIPTION
## Problem

On 2026-08-04, Generation 2 → Generation 3 teardown, `master-succeed retire --execute` returned `status: CLOSED` with reason `target disappeared after close; no pid reported by terminal list` when `orca terminal list` carried `process_id: null` for the folder-workspace master seat. Doctrine requires three disappearances (process, pane, tty); only the pane was measured. The successor had to re-measure pid and tty by hand. Same session: the instance succession boot card landed the FIN/ACK handshake, but `docs/public/master-lifecycle.md` still described retirement without naming `master-succeed retire`.

Owner instruction: promote master retirement to a TCP-style teardown; land the template half so CLOSED is honest.

## Why this approach

- Do not invent a pid from a null terminal record, and do not hard-fail retire when pid/tty are missing. Folder panes report null by design; the caller already holds the pid. Skip-with-honest-status matches the measurement doctrine.
- FIN machine-gate is out of scope: handshake is agent-to-agent; the tool makes CLOSED honest.
- Status vocabulary: `CLOSED` only when pane/process/tty are all `measured`; `CLOSED_PARTIAL` when pane is measured, nothing is `still_present`, but any check is `skipped:<why>`; `REFUSED` on any `still_present`.

## What this changes

- `src/master_runtime/core/succession.py`: `RetirementReport.disappearances`, fail-closed probe timeouts (`TimeoutExpired` → still present), blank/`/dev/`-only tty treated as skip.
- `tests/test_succession.py`: pins blank tty skip, timeout fail-closed for process and tty probes (host-independent control flow; inject-probe note covers host-bound `/dev` behaviour only).
- `docs/public/master-lifecycle.md`: TCP-style handshake table, host-neutral retire example (no `$ORCA_TERMINAL_HANDLE`; hyphenated placeholders so unedited paste fails predictably), TIME_WAIT wording clarified as "the same hazard that TIME_WAIT exists to prevent in TCP" (kept the purpose link; declined a rewrite that dropped it).

## Base note (spawn surface)

This branch forked from local `main`, which held unpushed `654716c` (cursor/agy successor approval flags). That commit is out of this contract's scope. Intentional home: #85. Once #85 merges, this diff drops the spawn surface without a rebase.

## Provenance

- Owner directive 2026-08-04 retirement handshake.
- Follow-up contract `mogui-master-ops/contracts/2026-08-04-pr-response-83-84.md` (sha `bf16302b`), task `task_a3c886f16c46`: timeout tests + docs findings.

## Test plan

- [x] `PYTHONPATH=src uv run --with pytest --no-project python3 -m pytest tests/test_succession.py::test_default_process_probe_timeout_is_fail_closed tests/test_succession.py::test_default_tty_probe_timeout_is_fail_closed -q` → 2 passed
- [x] `bash scripts/redaction-scan.sh` → 0 findings; organization rules not loaded (`org-rules=0`); generic patterns only