### PR TITLE
fix: attach measured approval flags for cursor-agent and agy successors

### DIFF
--- a/master-ops/docs/charter/04-worker-routing-review.md
+++ b/master-ops/docs/charter/04-worker-routing-review.md
@@ -42,12 +42,20 @@ MEASURED examples from 2026-08-02:
 
 - Grok: `--always-approve`.
 - Claude Code: `--dangerously-skip-permissions`.
-- Cursor Agent: `--force` (also exposed as `--yolo`) to force-allow commands unless explicitly denied, plus `--trust` to trust the current workspace without prompting.
+- Cursor Agent: `--force` (also exposed as `--yolo`) to force-allow commands unless explicitly denied, plus `--trust` to trust the current workspace without prompting. Source: `cursor-agent --help`. Re-measured 2026-08-04: `-f, --force  Force allow commands unless explicitly denied`; `--trust  Trust the current workspace without prompting`.
 - Codex: run `scripts/codex-worker-pretrust <worktree-path>` and retain the account-wide hooks trust posture; Codex uses this pre-trust path instead of a launch approval flag.
 
 MEASURED addition from 2026-08-03:
 
 - Cursor Agent pre-trust: run `scripts/cursor-worker-pretrust <worktree-path>` before attach and require exit status 0 with a summary that reports `added`, `updated`, or `already trusted` (not `skipped`); this uses Cursor Agent's measured `.workspace-trusted` storage instead of relying on `--trust` at worker launch. Follow-up measurement on `cursor-agent 2026.07.23-e383d2b` with a fresh workspace plus project-local `.cursor/hooks.json` showed no second startup gate: launch passed without extra prompts, hooks executed, and no `hooks.state`/`trusted_hash` persistence appeared in Cursor state.
+
+MEASURED addition from 2026-08-04:
+
+- Agy: `--dangerously-skip-permissions` (Auto-approve all tool permission requests without prompting). Source: `agy --help`.
+
+### Successor spawn versus worker pre-trust
+
+This section governs **worker** launch into isolated worktrees. Successor TUI spawn (`master-succeed spawn` / `_spawn_startup_command`) is a different entry point: it starts the next master seat in a host terminal, not a worktree worker under dispatch. For that path the runtime attaches the measured launch approval flags above (cursor-agent: `--force --trust`; agy: `--dangerously-skip-permissions`) so the seat is not prompt-blocked on its first tool call. That does not waive the worker pre-trust workflow. Worker attach into an isolated worktree still requires `scripts/cursor-worker-pretrust` (or the matching pre-trust path for the agent) as written above. Codex successors keep no launch flag and still rely on the account-wide pre-trust path because Codex has none.
 
 Three-vote review is the default for non-trivial merges or direct-push changes. Split review lenses:
 

--- a/scripts/master-succeed
+++ b/scripts/master-succeed
@@ -15,6 +15,9 @@ SRC_ROOT = REPO_ROOT / "src"
 sys.path.insert(0, str(SRC_ROOT))
 
 
+# cursor/agy intentionally omitted: their model ids were not measured from
+# each CLI's --help or docs. Omitted --model therefore exits with
+# "--model is required for agent X" until a measured id is recorded here.
 DEFAULT_MODELS = {
     "claude": "claude-fable-5",
     "claude-code": "claude-fable-5",

--- a/src/master_runtime/core/succession.py
+++ b/src/master_runtime/core/succession.py
@@ -1015,12 +1015,22 @@ def _spawn_startup_command(
         )
     if agent_key in ("cursor", "cursor-agent"):
         # The executable is cursor-agent; plain `cursor` is the updater.
+        # Flags measured from `cursor-agent --help` (2026-08-04):
+        #   -f, --force  Force allow commands unless explicitly denied
+        #   --trust      Trust the current workspace without prompting
+        # Successor TUI spawn is not worker attach: charter §4 still requires
+        # scripts/cursor-worker-pretrust before dispatching a Cursor worker into
+        # an isolated worktree. These launch flags keep the master seat from
+        # stalling on the first tool call; they do not replace that workflow.
         return "cd {0} && exec cursor-agent --model {1} --force --trust {2}".format(
             quoted_root,
             quoted_model,
             quoted_kickoff,
         )
     if agent_key in ("agy",):
+        # Flag measured from `agy --help` (2026-08-04):
+        #   --dangerously-skip-permissions  Auto-approve all tool permission
+        #   requests without prompting
         return "cd {0} && exec agy --model {1} --dangerously-skip-permissions {2}".format(
             quoted_root,
             quoted_model,

--- a/src/master_runtime/core/succession.py
+++ b/src/master_runtime/core/succession.py
@@ -1006,12 +1006,30 @@ def _spawn_startup_command(
             quoted_kickoff,
         )
     if agent_key in ("codex",):
+        # Codex has no launch approval flag by design; it uses the account-wide
+        # pre-trust path (scripts/codex-worker-pretrust) instead.
         return "cd {0} && exec codex --model {1} {2}".format(
             quoted_root,
             quoted_model,
             quoted_kickoff,
         )
+    if agent_key in ("cursor", "cursor-agent"):
+        # The executable is cursor-agent; plain `cursor` is the updater.
+        return "cd {0} && exec cursor-agent --model {1} --force --trust {2}".format(
+            quoted_root,
+            quoted_model,
+            quoted_kickoff,
+        )
+    if agent_key in ("agy",):
+        return "cd {0} && exec agy --model {1} --dangerously-skip-permissions {2}".format(
+            quoted_root,
+            quoted_model,
+            quoted_kickoff,
+        )
     # Unknown agent: treat the name as the executable and pass model + prompt.
+    # No approval flag is attached, so such a session can come up prompt-blocked
+    # and stall on its first tool call. Add a branch above once the host's flag
+    # has been measured from its own --help; do not guess one.
     return "cd {0} && exec {1} --model {2} {3}".format(
         quoted_root,
         shlex.quote(agent.strip()),

--- a/tests/test_succession.py
+++ b/tests/test_succession.py
@@ -730,6 +730,21 @@ def test_spawn_startup_command_covers_agent_variants_and_shell_quoting() -> None
         "cd '/repo/with space' && exec codex --model gpt-5.6-sol "
         "'start; $(touch should-not-run)'"
     )
+    # Flags below are measured from each CLI's own --help, never guessed.
+    # cursor-agent is the executable; plain `cursor` is the updater, so both
+    # spellings must resolve to cursor-agent or a successor lands in the wrong
+    # binary. --force allows commands unless denied, --trust skips the
+    # workspace prompt; without them the session comes up prompt-blocked, which
+    # is how Generation 1 stalled on a bare claude.
+    for spelling in ("cursor", "cursor-agent"):
+        assert _spawn_startup_command(root, "gpt-5", kickoff, spelling) == (
+            "cd '/repo/with space' && exec cursor-agent --model gpt-5 --force --trust "
+            "'start; $(touch should-not-run)'"
+        )
+    assert _spawn_startup_command(root, "agy-model", kickoff, "agy") == (
+        "cd '/repo/with space' && exec agy --model agy-model "
+        "--dangerously-skip-permissions 'start; $(touch should-not-run)'"
+    )
     assert _spawn_startup_command(root, "custom-model", kickoff, "custom agent; touch") == (
         "cd '/repo/with space' && exec 'custom agent; touch' --model custom-model "
         "'start; $(touch should-not-run)'"


### PR DESCRIPTION
## Problem

`_spawn_startup_command` only branched for claude, grok, and codex. A successor on cursor-agent or agy fell through to the unknown-agent fallback and launched without an approval flag, so the seat came up prompt-blocked and stalled on its first tool call. Same failure mode Generation 1 hit on a bare claude launch.

This change lived as unpushed local `main` commit `654716c` and was accidentally carried into PR #83 and #84 diffs because those branches forked from local main rather than `origin/main`. Spawn behaviour was out of scope for both contracts. This PR is the intentional home for the change so the other two diffs shrink once it merges.

## Measured flags (host 2026-08-04)

Paste-ready from each CLI's own `--help` (never guessed):

| CLI | Flag | Help line |
| --- | --- | --- |
| `agy` | `--dangerously-skip-permissions` | `Auto-approve all tool permission requests without prompting` |
| `cursor-agent` | `--trust` | `Trust the current workspace without prompting` |
| `cursor-agent` | `-f, --force` | `Force allow commands unless explicitly denied` (also `--yolo` alias) |

Both spellings `cursor` and `cursor-agent` resolve to the `cursor-agent` executable; plain `cursor` on PATH is the updater.

## Pre-trust boundary

Charter §4 ("Worker Launch Approval Posture") requires `scripts/cursor-worker-pretrust` before **worker** attach into an isolated worktree, preferring durable project-key trust storage over relying on `--trust` at worker launch.

Successor TUI spawn is a different entry point (charter §6 / `master-succeed spawn`). It attaches the measured launch flags so the next master seat is not prompt-blocked. That does not waive the worker pre-trust workflow. Codex successors still use the account-wide pre-trust path because Codex has no launch approval flag.

Documented in `master-ops/docs/charter/04-worker-routing-review.md` and in comments on the spawn branches.

## DEFAULT_MODELS intentionally omits cursor and agy

`scripts/master-succeed` resolves a missing `--model` from `DEFAULT_MODELS`, which still lists only claude, grok, and codex. For cursor/agy, omitted `--model` exits with `--model is required for agent X`. That is deliberate: model identifiers for those CLIs were not measured, and this workspace does not invent model ids. Supply `--model` and the new branches run. Add entries to `DEFAULT_MODELS` only after a measured id exists. Comment above the map in `scripts/master-succeed` states this.

## What this changes

- `src/master_runtime/core/succession.py`: cursor/agy branches + measurement comments
- `tests/test_succession.py`: pins both cursor spellings and agy
- `master-ops/docs/charter/04-worker-routing-review.md`: measured flags + successor vs worker boundary
- `scripts/master-succeed`: comment on intentional DEFAULT_MODELS omission

## Provenance

- Unpushed local main commit `654716c` split out of PR #83/#84 base pollution
- Contract `mogui-master-ops/contracts/2026-08-04-pr-response-83-84.md` (sha `bf16302b`), task `task_a3c886f16c46`

## Test plan

- [x] `PYTHONPATH=src uv run --with pytest --no-project python3 -m pytest tests/test_succession.py::test_spawn_startup_command_covers_agent_variants_and_shell_quoting -q` → 1 passed
- [x] `bash scripts/redaction-scan.sh` → 0 findings; organization rules not loaded (`org-rules=0`); generic patterns only

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for launching Cursor Agent and Agy workers with their required approval and trust settings.
  * Cursor and Cursor Agent commands are normalized consistently during worker startup.

* **Documentation**
  * Clarified worker approval, pre-trust, and isolated worktree procedures for different launch types.

* **Tests**
  * Added coverage validating Cursor Agent and Agy startup commands and required options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->