### PR TITLE
docs: record measured spawn flags and pre-trust boundary

### DIFF
--- a/master-ops/docs/charter/04-worker-routing-review.md
+++ b/master-ops/docs/charter/04-worker-routing-review.md
@@ -42,12 +42,20 @@ MEASURED examples from 2026-08-02:
 
 - Grok: `--always-approve`.
 - Claude Code: `--dangerously-skip-permissions`.
-- Cursor Agent: `--force` (also exposed as `--yolo`) to force-allow commands unless explicitly denied, plus `--trust` to trust the current workspace without prompting.
+- Cursor Agent: `--force` (also exposed as `--yolo`) to force-allow commands unless explicitly denied, plus `--trust` to trust the current workspace without prompting. Source: `cursor-agent --help`. Re-measured 2026-08-04: `-f, --force  Force allow commands unless explicitly denied`; `--trust  Trust the current workspace without prompting`.
 - Codex: run `scripts/codex-worker-pretrust <worktree-path>` and retain the account-wide hooks trust posture; Codex uses this pre-trust path instead of a launch approval flag.
 
 MEASURED addition from 2026-08-03:
 
 - Cursor Agent pre-trust: run `scripts/cursor-worker-pretrust <worktree-path>` before attach and require exit status 0 with a summary that reports `added`, `updated`, or `already trusted` (not `skipped`); this uses Cursor Agent's measured `.workspace-trusted` storage instead of relying on `--trust` at worker launch. Follow-up measurement on `cursor-agent 2026.07.23-e383d2b` with a fresh workspace plus project-local `.cursor/hooks.json` showed no second startup gate: launch passed without extra prompts, hooks executed, and no `hooks.state`/`trusted_hash` persistence appeared in Cursor state.
+
+MEASURED addition from 2026-08-04:
+
+- Agy: `--dangerously-skip-permissions` (Auto-approve all tool permission requests without prompting). Source: `agy --help`.
+
+### Successor spawn versus worker pre-trust
+
+This section governs **worker** launch into isolated worktrees. Successor TUI spawn (`master-succeed spawn` / `_spawn_startup_command`) is a different entry point: it starts the next master seat in a host terminal, not a worktree worker under dispatch. For that path the runtime attaches the measured launch approval flags above (cursor-agent: `--force --trust`; agy: `--dangerously-skip-permissions`) so the seat is not prompt-blocked on its first tool call. That does not waive the worker pre-trust workflow. Worker attach into an isolated worktree still requires `scripts/cursor-worker-pretrust` (or the matching pre-trust path for the agent) as written above. Codex successors keep no launch flag and still rely on the account-wide pre-trust path because Codex has none.
 
 Three-vote review is the default for non-trivial merges or direct-push changes. Split review lenses:
 

--- a/scripts/master-succeed
+++ b/scripts/master-succeed
@@ -15,6 +15,9 @@ SRC_ROOT = REPO_ROOT / "src"
 sys.path.insert(0, str(SRC_ROOT))
 
 
+# cursor/agy intentionally omitted: their model ids were not measured from
+# each CLI's --help or docs. Omitted --model therefore exits with
+# "--model is required for agent X" until a measured id is recorded here.
 DEFAULT_MODELS = {
     "claude": "claude-fable-5",
     "claude-code": "claude-fable-5",


### PR DESCRIPTION
## Why this PR exists

This is the documentation remainder of **#85** (`fix/spawn-approval-flags`).

Merge order changed under owner instruction: **#84** (`2360d8b`) and **#83** (`198ee09`) landed first. Both had carried unpushed `654716c` via base pollution, so their squash merges put the **cursor/agy launch branches and tests** on `main` already. Squash does not share history with the cherry-pick on #85, so #85 became `CONFLICTING`/`DIRTY` even though most of its code already exists on `main`.

## What is already on main (code — not in this PR)

Verified on current `main` (`198ee09`):

- `src/master_runtime/core/succession.py`: cursor/agy branches in `_spawn_startup_command`
- matching tests in `tests/test_succession.py`

Landed via:

- #84 squash: `2360d8bb2b561f3a1108d150e2bbabc9268fbb4b`
- #83 squash: `198ee09426ca49cd6d4e078c489ea08713bd2387`

No succession runtime or test files are changed here.

## What this PR still lands (docs only)

Copied verbatim from `origin/fix/spawn-approval-flags` (the #85 tip), not rewritten:

1. **Charter §4 measured flags** — cursor-agent re-measure from `--help` (`--force`, `--trust`); agy `--dangerously-skip-permissions` from `agy --help` (2026-08-04).
2. **Successor spawn versus worker pre-trust** — successor TUI spawn uses measured launch flags; worker attach into an isolated worktree still requires `scripts/cursor-worker-pretrust`.
3. **`scripts/master-succeed` `DEFAULT_MODELS` comment** — cursor/agy omitted until model ids are measured; omitted `--model` correctly exits with `--model is required for agent X`.

These fill the gap cubic called out on #85: the repository held no measurement text for the new flags, and the pre-trust boundary judgment lived only in review replies.

## Provenance

- Former PR: #85
- Code already on main via #84 (`2360d8b`) and #83 (`198ee09`)
- Source of docs text: `origin/fix/spawn-approval-flags` (`3f6b313` lineage)

## Test plan

- [x] Diff is docs-only: charter §4 + `scripts/master-succeed` comment; no `succession.py` / test changes
- [x] `bash scripts/redaction-scan.sh` → 0 findings; organization rules not loaded (`org-rules=0`); generic patterns only
- [x] Grep on branch: `Re-measured 2026-08-04`, `Successor TUI spawn`, `cursor/agy intentionally` each present


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updates Charter §4 to record measured launch approval flags from `--help` for `cursor-agent` (`--force`/`--yolo`, `--trust`) and `agy` (`--dangerously-skip-permissions`), and clarifies that successor TUI spawn uses these flags while worker attach still requires pre-trust via `scripts/cursor-worker-pretrust`. Also adds a note in `scripts/master-succeed` explaining why `DEFAULT_MODELS` omits unmeasured model IDs until they’re recorded.

<sup>Written for commit 4d8954e5dce538f186986f2dad7ba5b4c5fbf43b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/baksohyeon/mogui-ADE-orchestrator/pull/86?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

