### PR TITLE
docs: promote working directory clause into contract conventions

### DIFF
--- a/master-ops/docs/runbooks/contract-conventions.md
+++ b/master-ops/docs/runbooks/contract-conventions.md
@@ -313,10 +313,42 @@ emitting a link that goes nowhere; that case stays described as a name, not link
 Verify the links, do not assume them: resolve each target relative to the file that
 contains it and confirm the file exists before committing.
 
-## Grade distribution (2026-08-04)
+## 10. Working directory clause [measured]
+
+Every runnable command in a document states the directory it runs from, and a document
+that contains more than one command uses one base for all of them. Prefer forms that do
+not care where the shell is: `git -C <path>`, `gh --repo <owner/name>`, absolute paths.
+A script that needs its own repository should anchor on its file location, not on the
+invoking cwd, so that callers are free to stand anywhere.
+
+A relative path is only half an instruction. The other half is the base it resolves
+against, and when that half is unwritten the reader supplies it by guessing. This is the
+same defect as a document reference in backticks, one layer down: the string looks
+complete and silently means something different depending on where it is read.
+
+Basis, measured 2026-08-05 on the authoring instance. A document's spawn and
+duplicate-check steps were written against the workspace root while its seat-check step
+was written against the ops repository, and nothing in the document said to move between
+them. No single directory satisfied the document, so a successor following it in order
+would hit a false failure at whichever step did not match, and the failure would look
+like a broken tool rather than a broken path. The same day, a shell left inside a product
+checkout made `git archive` resolve against the wrong repository and made a stale
+worktree ref read as canonical — twice, in the space of one session.
+
+The fix is in that order: make the tool location-independent, then state one base, then
+write the commands. A self-check that needed its own repository was changed to anchor its
+repo-relative paths on its own file location and verified to produce byte-identical
+output and exit 0 from three different directories; its regression suite still passed.
+Only after that could the document's two bases be merged into one. The document can name
+a single base only once the tool no longer inherits the invoking cwd.
+
+Never leave the shell parked somewhere other than the seat. Reaching a repository is not
+a reason to move into it.
+
+## Grade distribution (2026-08-05)
 
 - machine-enforced: 1
-- measured: 6
+- measured: 7
 - prose: 2
 
 Distribution is non-uniform, so these grades are based on enforceability and


### PR DESCRIPTION
## Problem

Measured 2026-08-05 on the authoring instance: a multi-step document mixed two command bases (workspace root for spawn/duplicate-check, ops repository for seat-check) and never said to change directory. No single shell directory could follow the card end-to-end; the failure looked like a broken tool rather than a broken path. The same session, a shell left inside a product checkout made `git archive` resolve against the wrong repository and made a stale worktree ref read as canonical — twice. Command on this template before the change: `rg -n 'Working directory clause' master-ops/docs/runbooks/contract-conventions.md` — zero hits. Numbered clauses ended at 9 (Document reference); grade distribution still said 2026-08-04 with measured: 6.

## Why this approach

Port the instance clause text from `mogui-master-ops/docs/runbooks/contract-conventions.md` §11 rather than rewrite from the dispatch contract. The alternative not taken was inventing a shorter "always use absolute paths" tip; that would drop the measured fix ordering (tool location-independence first, then one document base) and the false-tool-failure framing. Instance-specific names (`harness-selfcheck.sh`, the boot card path) are generalized because this template does not ship those files; the three facts kept are mixed bases, tool-shaped failure, and tool-then-document order. Clause number is **10** by counting this template's headings 1–9 (instance is 11 because it carries a public-surface redaction clause this template does not).

## What this changes

- Adds `## 10. Working directory clause [measured]` to `master-ops/docs/runbooks/contract-conventions.md`, after Document reference and before Grade distribution.
- Updates grade distribution date to 2026-08-05 and measured count 6 → 7 (machine-enforced 1, prose 2 unchanged).
- Out of scope: script changes (template has no harness self-check), renumbering existing clauses, other runbooks, merge, force-push.
- Intentionally not in this contract: `TEMPLATE-VERSION` bump and `master-ops/CHANGELOG.md` entry (PR template normally requires them for `master-ops/` changes; contract limited edits to `contract-conventions.md` only).

## Expected effect

A reader of `master-ops/docs/runbooks/contract-conventions.md` finds clause 10 requiring one command base per document, location-independent tools preferred, and tool-then-document fix order, graded `[measured]`. Grade distribution lists measured: 7 on 2026-08-05. Observe with: `rg -n '^\## [0-9]+\. |Grade distribution' master-ops/docs/runbooks/contract-conventions.md`.

## Testing

- [x] Docs-only change; full pytest suite not required for this contract.
- [x] Consistency pass (local): numbered headings contiguous 1–10; grade tags → machine-enforced 1 / measured 7 / prose 2 matches the distribution section; no gap after 8.
- [x] Document references written in the new clause: none (conceptual mention of "document reference in backticks" only). Pre-existing link `[Review voice](review-voice.md)` still resolves (`test -f master-ops/docs/runbooks/review-voice.md`).
- [x] Redaction: `scripts/redaction-scan.sh --range origin/main..HEAD` — 0 findings; **organization rules not loaded** (`org-rules=0`, `REDACTION_EXTRA_PATTERNS` unset). Not claimed as a clean org-rules pass.
- [x] New content staged before scan (commit `f5e7342`).

## Review

Self consistency pass only (numbers, grade tally, link existence). No external bot review yet. Findings: none blocking. Base-mixing elsewhere in the template: no clear mixed-base command sequence like the instance card found in the scoped file or a quick look at `succession-boot-card.md` (it states workspace root as the seat); any broader template sweep is deliberately out of scope.

## Changelog

- Root `CHANGELOG.md`: none (docs-only template runbook; no orchestrator user-facing change).
- `master-ops/CHANGELOG.md`: deferred — contract forbade edits outside `contract-conventions.md`.

## Template impact

Touches `master-ops/docs/runbooks/contract-conventions.md` only. Generated operations repositories are copies made at onboarding and do not pick up this change. Existing installs that want the clause must copy clause 10 (and the updated grade distribution) by hand, or re-onboard from a template that includes this commit. `TEMPLATE-VERSION` not bumped in this PR (contract scope).

## Notes

- Provenance: authoring-instance measurement 2026-08-05; contract `2026-08-05-working-directory-clause-promotion.md` (sha d2091c26); dispatch `task_f687cf01b1e4`.
- FIRST ACTION: worktree path contains `.orca/worktrees`; branch `feat/wd-clause-0805` from `origin/main` at `3e6f41b`.
- Do not merge — master merges.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds clause 10 “Working directory” to `master-ops/docs/runbooks/contract-conventions.md` to require one command base per document and prefer location‑independent commands; updates the grade distribution to measured: 7 dated 2026‑08‑05. This clarifies where commands run and avoids false tool failures caused by mixed bases.

<sup>Written for commit f5e7342716647ee21ce33013cef96e01388cb37e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/baksohyeon/mogui-ADE-orchestrator/pull/88?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

