### PR TITLE
feat: measure onboarding postconditions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,10 @@ you build on it.
 
 ### Added
 
+- A read-only onboarding rehearsal reports measurable postconditions, compares
+  the deployed workspace card with its canonical card, and keeps unmeasured
+  live-master facts in an explicit gap list.
+
 - `dispatch-gate check --no-record` evaluates a dispatch decision without
   appending a ledger row or issuing a ticket. `master-ops/scripts/dispatch
   --check-only` uses it so dry runs do not spend the fan-out budget they are

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,10 +22,6 @@ you build on it.
 
 ### Added
 
-- A read-only onboarding rehearsal reports measurable postconditions, compares
-  the deployed workspace card with its canonical card, and keeps unmeasured
-  live-master facts in an explicit gap list.
-
 - `dispatch-gate check --no-record` evaluates a dispatch decision without
   appending a ledger row or issuing a ticket. `master-ops/scripts/dispatch
   --check-only` uses it so dry runs do not spend the fan-out budget they are

--- a/docs/internal/onboarding-rehearsal.md
+++ b/docs/internal/onboarding-rehearsal.md
@@ -5,12 +5,12 @@ founded workspace. It measures the artifacts that the onboarding steps promise,
 prints a postcondition table, and keeps a separate gap list for facts that are
 not observable from the supplied files or host.
 
-Run it from any directory after substituting the actual workspace and ops paths;
-the command uses a home-relative executable path so it is not limited to the
-repository's current directory:
+Run it from any directory after substituting the actual workspace and ops paths.
+The installed ops repository contains the script; invoke it with the platform's
+Python command:
 
 ```console
-$ ~/path/master-ops/scripts/onboarding-rehearsal \
+$ python3 ~/workspace-ops/scripts/onboarding-rehearsal \
     --workspace-root ~/workspace \
     --ops-repo ~/workspace-ops
 ```
@@ -19,11 +19,13 @@ Add `--live` only when the Orca CLI is available. This measures the recorded
 seat with `orca terminal list`; it does not spawn, close, or repair a terminal:
 
 ```console
-$ ~/path/master-ops/scripts/onboarding-rehearsal \
+$ python3 ~/workspace-ops/scripts/onboarding-rehearsal \
     --workspace-root ~/workspace \
     --ops-repo ~/workspace-ops \
     --live --json > onboarding-rehearsal.json
 ```
+
+On Windows, use `python` in place of `python3`.
 
 ## Postcondition table
 

--- a/docs/internal/onboarding-rehearsal.md
+++ b/docs/internal/onboarding-rehearsal.md
@@ -5,10 +5,12 @@ founded workspace. It measures the artifacts that the onboarding steps promise,
 prints a postcondition table, and keeps a separate gap list for facts that are
 not observable from the supplied files or host.
 
-Run it from any directory after substituting the actual workspace and ops paths:
+Run it from any directory after substituting the actual workspace and ops paths;
+the command uses a home-relative executable path so it is not limited to the
+repository's current directory:
 
 ```console
-$ master-ops/scripts/onboarding-rehearsal \
+$ ~/path/master-ops/scripts/onboarding-rehearsal \
     --workspace-root ~/workspace \
     --ops-repo ~/workspace-ops
 ```
@@ -17,7 +19,7 @@ Add `--live` only when the Orca CLI is available. This measures the recorded
 seat with `orca terminal list`; it does not spawn, close, or repair a terminal:
 
 ```console
-$ master-ops/scripts/onboarding-rehearsal \
+$ ~/path/master-ops/scripts/onboarding-rehearsal \
     --workspace-root ~/workspace \
     --ops-repo ~/workspace-ops \
     --live --json > onboarding-rehearsal.json
@@ -28,10 +30,10 @@ $ master-ops/scripts/onboarding-rehearsal \
 | ID | Postcondition | Evidence | Pass condition |
 |---|---|---|---|
 | P01 | Router inventory is complete | `ONBOARDING.md` index and `onboarding/*.md` | The sets are equal |
-| P02 | Installation has no unresolved tokens | ops repository text files | No `{{...}}` token remains |
+| P02 | Installation has no unresolved tokens | installation text files, excluding `.git/` and `.beads/` | No unresolved allowed token remains; the literal `{{...}}` shape mention is not a token |
 | P03 | Ops host instructions agree | `CLAUDE.md` and `AGENTS.md` | Byte-identical |
 | P04 | Live workspace card equals canonical card | root `CLAUDE.md` and `workspace-card/CLAUDE.md` | Byte-identical |
-| P05 | Workspace identity is durable | `config/workspace-descriptor.json` | JSON exists and `workspace_root` equals the requested root |
+| P05 | Workspace descriptor satisfies loader rules | `config/workspace-descriptor.json` | JSON has the requested root, `workspace_root_is_plain_folder: true`, a nonempty `master_seat`, and a nonempty repository list |
 | P06 | Host runtime is durable | `config/instance-runtime.json` | JSON exists and has `master_host_runtime` |
 | P07 | Role state is present | `docs/runbooks/role-state.md` | File exists |
 | P08 | Lineage is present | `docs/lineage/MASTER-LINEAGE.md` | File exists |

--- a/docs/internal/onboarding-rehearsal.md
+++ b/docs/internal/onboarding-rehearsal.md
@@ -1,0 +1,49 @@
+# Onboarding rehearsal and postconditions
+
+`master-ops/scripts/onboarding-rehearsal` is the read-only acceptance check for a
+founded workspace. It measures the artifacts that the onboarding steps promise,
+prints a postcondition table, and keeps a separate gap list for facts that are
+not observable from the supplied files or host.
+
+Run it from any directory after substituting the actual workspace and ops paths:
+
+```console
+$ master-ops/scripts/onboarding-rehearsal \
+    --workspace-root ~/workspace \
+    --ops-repo ~/workspace-ops
+```
+
+Add `--live` only when the Orca CLI is available. This measures the recorded
+seat with `orca terminal list`; it does not spawn, close, or repair a terminal:
+
+```console
+$ master-ops/scripts/onboarding-rehearsal \
+    --workspace-root ~/workspace \
+    --ops-repo ~/workspace-ops \
+    --live --json > onboarding-rehearsal.json
+```
+
+## Postcondition table
+
+| ID | Postcondition | Evidence | Pass condition |
+|---|---|---|---|
+| P01 | Router inventory is complete | `ONBOARDING.md` index and `onboarding/*.md` | The sets are equal |
+| P02 | Installation has no unresolved tokens | ops repository text files | No `{{...}}` token remains |
+| P03 | Ops host instructions agree | `CLAUDE.md` and `AGENTS.md` | Byte-identical |
+| P04 | Live workspace card equals canonical card | root `CLAUDE.md` and `workspace-card/CLAUDE.md` | Byte-identical |
+| P05 | Workspace identity is durable | `config/workspace-descriptor.json` | JSON exists and `workspace_root` equals the requested root |
+| P06 | Host runtime is durable | `config/instance-runtime.json` | JSON exists and has `master_host_runtime` |
+| P07 | Role state is present | `docs/runbooks/role-state.md` | File exists |
+| P08 | Lineage is present | `docs/lineage/MASTER-LINEAGE.md` | File exists |
+| L01 | A live terminal occupies the recorded seat | `orca terminal list --worktree ... --json` | Exactly one terminal; unavailable measurement is GAP |
+| L02 | The terminal is actually the master | role state/lineage plus host identity | This script does not claim terminal presence proves role identity; it reports GAP |
+
+`P04` is the equality check against the live workspace surface the host reads.
+`L01` measures liveness separately. A terminal list cannot establish that the
+terminal's process is the master, so `L02` remains an explicit honest gap until
+the host exposes independently verifiable role identity.
+
+Exit status is zero only when every row is PASS. A GAP is not a warning-shaped
+pass: it means the check was not performed or the available evidence cannot
+prove the postcondition. Use `--json` for CI or a later report generator; the
+`gaps` array is intentionally preserved in that output.

--- a/master-ops/CHANGELOG.md
+++ b/master-ops/CHANGELOG.md
@@ -62,6 +62,15 @@ Successor-facing promotion audit and redacted knowledge promotion (2026-08-06):
 - Existing installations must merge these template changes deliberately; generated
   operations repositories are copies and do not update automatically.
 
+Onboarding rehearsal measurement:
+
+- Added `scripts/onboarding-rehearsal`, a read-only post-install rehearsal with
+  postcondition results, JSON output, live-seat measurement, and an explicit
+  gap list that does not treat missing evidence as a pass.
+- Added the internal rehearsal report and focused tests. Existing generated
+  operations repositories do not auto-update; apply these template changes
+  deliberately when adopting the rehearsal.
+
 Contract convention merge-time re-measurement and citation repair (2026-08-05 worker contract fix):
 
 - Added clause 14, Merge-time re-measurement, so merge decisions re-run thread

--- a/master-ops/scripts/onboarding-rehearsal
+++ b/master-ops/scripts/onboarding-rehearsal
@@ -12,8 +12,8 @@ import argparse
 import json
 import os
 import re
+import shutil
 import subprocess
-import sys
 from dataclasses import asdict, dataclass
 from pathlib import Path
 
@@ -43,7 +43,7 @@ def result(results: list[Result], ident: str, expected: str, observed: str,
 def read_json(path: Path):
     try:
         return json.loads(path.read_text(encoding="utf-8"))
-    except (OSError, json.JSONDecodeError):
+    except (OSError, UnicodeError, json.JSONDecodeError):
         return None
 
 
@@ -75,10 +75,19 @@ def main() -> int:
         result(results, "P01", "router and step directory exist", "missing",
                "FAIL", "~/path/ONBOARDING.md or ~/path/onboarding")
 
-    unresolved = [str(p.relative_to(ops)) for p in ops.rglob("*")
-                  if p.is_file() and p.suffix in {".md", ".json", ".txt"}
-                  for _ in [0] if any(token != "{{...}}" for token in
-                                      PLACEHOLDER.findall(p.read_text(encoding="utf-8", errors="replace")))]
+    unresolved: list[str] = []
+    for path in ops.rglob("*"):
+        relative = path.relative_to(ops)
+        if (not path.is_file() or path.suffix not in {".md", ".json", ".txt"}
+                or {".git", ".beads"}.intersection(relative.parts)):
+            continue
+        try:
+            text = path.read_text(encoding="utf-8")
+        except (OSError, UnicodeError):
+            unresolved.append(f"{relative} (invalid UTF-8)")
+            continue
+        if any(token != "{{...}}" for token in PLACEHOLDER.findall(text)):
+            unresolved.append(str(relative))
     result(results, "P02", "no unresolved placeholders in ops repository",
            "none" if not unresolved else ", ".join(unresolved),
                "PASS" if not unresolved else "FAIL", "~/path/ops-repository")
@@ -97,14 +106,26 @@ def main() -> int:
 
     descriptor_path = root / "config" / "workspace-descriptor.json"
     descriptor = read_json(descriptor_path)
-    root_match = isinstance(descriptor, dict) and descriptor.get("workspace_root") == str(root)
-    result(results, "P05", "workspace descriptor exists and names this root",
-           "<workspace-root>" if root_match else "missing or invalid",
-           "PASS" if root_match else "FAIL", "~/path/config/workspace-descriptor.json")
+    descriptor_ok = (
+        isinstance(descriptor, dict)
+        and descriptor.get("workspace_root") == str(root)
+        and descriptor.get("workspace_root_is_plain_folder") is True
+        and isinstance(descriptor.get("master_seat"), str)
+        and bool(descriptor.get("master_seat", "").strip())
+        and isinstance(descriptor.get("repositories"), list)
+        and bool(descriptor["repositories"])
+    )
+    result(results, "P05", "workspace descriptor satisfies loader rules and names this root",
+           "<workspace-root>" if descriptor_ok else "missing or invalid",
+           "PASS" if descriptor_ok else "FAIL", "~/path/config/workspace-descriptor.json")
 
     runtime_path = root / "config" / "instance-runtime.json"
     runtime = read_json(runtime_path)
-    runtime_ok = isinstance(runtime, dict) and bool(runtime.get("master_host_runtime"))
+    runtime_ok = (
+        isinstance(runtime, dict)
+        and isinstance(runtime.get("master_host_runtime"), str)
+        and bool(runtime["master_host_runtime"].strip())
+    )
     result(results, "P06", "instance runtime names the master host runtime",
            str(runtime.get("master_host_runtime")) if isinstance(runtime, dict) else "missing or invalid",
            "PASS" if runtime_ok else "FAIL", "~/path/config/instance-runtime.json")
@@ -120,26 +141,41 @@ def main() -> int:
         if not seat:
             result(results, "L01", "live master seat is measurable", "no recorded master_seat", "GAP",
                    "~/path/config/workspace-descriptor.json")
-        elif not shutil_which(args.orca_cli):
+        elif not shutil.which(args.orca_cli):
             result(results, "L01", "live master seat is measurable", f"{args.orca_cli} unavailable", "GAP",
                    "install or expose Orca CLI")
         else:
-            proc = subprocess.run([args.orca_cli, "terminal", "list", "--worktree", seat, "--json"],
-                                  capture_output=True, text=True)
-            payload = None
             try:
-                payload = json.loads(proc.stdout)
-            except json.JSONDecodeError:
-                pass
-            terminals = payload.get("terminals") if isinstance(payload, dict) else None
-            count = len(terminals) if isinstance(terminals, list) else None
-            status = "PASS" if proc.returncode == 0 and count == 1 else "FAIL"
-            observed = f"{count} terminal(s)" if count is not None else "invalid Orca JSON"
-            result(results, "L01", "exactly one live terminal in recorded master seat", observed, status,
-                   f"{args.orca_cli} terminal list --worktree {seat} --json")
-            result(results, "L02", "live master role identity is independently evidenced",
-                   "not exposed by terminal list", "GAP",
-                   "terminal presence is not proof of master role; inspect role-state/lineage")
+                proc = subprocess.run(
+                    [args.orca_cli, "terminal", "list", "--worktree", seat, "--json"],
+                    capture_output=True, text=True, timeout=30,
+                )
+            except subprocess.TimeoutExpired:
+                result(results, "L01", "exactly one live terminal in recorded master seat",
+                       "Orca command timed out after 30 seconds", "FAIL",
+                       f"{args.orca_cli} terminal list --worktree {seat} --json")
+                proc = None
+            if proc is None:
+                result(results, "L02", "live master role identity is independently evidenced",
+                       "not exposed by terminal list", "GAP",
+                       "terminal presence is not proof of master role; inspect role-state/lineage")
+            else:
+                payload = None
+                try:
+                    payload = json.loads(proc.stdout)
+                except (UnicodeError, json.JSONDecodeError):
+                    pass
+                if isinstance(payload, dict) and isinstance(payload.get("result"), dict):
+                    payload = payload["result"]
+                terminals = payload.get("terminals") if isinstance(payload, dict) else None
+                count = len(terminals) if isinstance(terminals, list) else None
+                status = "PASS" if proc.returncode == 0 and count == 1 else "FAIL"
+                observed = f"{count} terminal(s)" if count is not None else "invalid Orca JSON"
+                result(results, "L01", "exactly one live terminal in recorded master seat", observed, status,
+                       f"{args.orca_cli} terminal list --worktree {seat} --json")
+                result(results, "L02", "live master role identity is independently evidenced",
+                       "not exposed by terminal list", "GAP",
+                       "terminal presence is not proof of master role; inspect role-state/lineage")
     else:
         result(results, "L01", "live master seat is measured", "live checks not requested", "GAP",
                "rerun with --live")
@@ -164,14 +200,6 @@ def main() -> int:
         for r in gaps:
             print(f"- {r.id}: {r.evidence}")
     return 0 if not gaps and all(r.status == "PASS" for r in results) else 1
-
-
-def shutil_which(command: str) -> str | None:
-    for directory in os.environ.get("PATH", "").split(os.pathsep):
-        candidate = Path(directory) / command
-        if candidate.is_file() and os.access(candidate, os.X_OK):
-            return str(candidate)
-    return None
 
 
 if __name__ == "__main__":

--- a/master-ops/scripts/onboarding-rehearsal
+++ b/master-ops/scripts/onboarding-rehearsal
@@ -56,7 +56,7 @@ def descriptor_matches(descriptor: object, root: Path) -> bool:
         root_match = (isinstance(workspace_root, str)
                       and bool(workspace_root.strip())
                       and Path(workspace_root.strip()).expanduser().resolve(strict=False) == root)
-    except (OSError, RuntimeError):
+    except (OSError, RuntimeError, ValueError, UnicodeError):
         root_match = False
     if not (root_match and descriptor.get("workspace_root_is_plain_folder") is True):
         return False
@@ -81,6 +81,8 @@ def descriptor_matches(descriptor: object, root: Path) -> bool:
             return False
         for field in ("capabilities", "prohibited"):
             values = entry.get(field) if field in entry else ([] if field == "capabilities" else None)
+            if field == "capabilities" and values is None:
+                values = []
             if field == "prohibited" and values is None:
                 return False
             if not isinstance(values, list) or any(not isinstance(value, str) or not value.strip() for value in values):

--- a/master-ops/scripts/onboarding-rehearsal
+++ b/master-ops/scripts/onboarding-rehearsal
@@ -19,6 +19,7 @@ from pathlib import Path
 
 
 PLACEHOLDER = re.compile(r"\{\{[^}]+\}\}")
+ALLOWED_ROLES = {"product", "ops"}
 
 
 def safe_evidence(path: Path) -> str:
@@ -45,6 +46,51 @@ def read_json(path: Path):
         return json.loads(path.read_text(encoding="utf-8"))
     except (OSError, UnicodeError, json.JSONDecodeError):
         return None
+
+
+def descriptor_matches(descriptor: object, root: Path) -> bool:
+    if not isinstance(descriptor, dict):
+        return False
+    workspace_root = descriptor.get("workspace_root")
+    try:
+        root_match = (isinstance(workspace_root, str)
+                      and bool(workspace_root.strip())
+                      and Path(workspace_root.strip()).expanduser().resolve(strict=False) == root)
+    except (OSError, RuntimeError):
+        root_match = False
+    if not (root_match and descriptor.get("workspace_root_is_plain_folder") is True):
+        return False
+    seat = descriptor.get("master_seat")
+    repositories = descriptor.get("repositories")
+    if not isinstance(seat, str) or not seat.strip() or not isinstance(repositories, list) or not repositories:
+        return False
+    names: set[str] = set()
+    paths: set[str] = set()
+    for entry in repositories:
+        if not isinstance(entry, dict):
+            return False
+        name, path, role = entry.get("name"), entry.get("path"), entry.get("role")
+        if (not isinstance(name, str) or not name.strip()
+                or not isinstance(path, str) or not path.strip()
+                or not isinstance(role, str) or role.strip() not in ALLOWED_ROLES):
+            return False
+        remote = entry.get("remote", "")
+        if remote is None:
+            remote = ""
+        if not isinstance(remote, str):
+            return False
+        for field in ("capabilities", "prohibited"):
+            values = entry.get(field) if field in entry else ([] if field == "capabilities" else None)
+            if field == "prohibited" and values is None:
+                return False
+            if not isinstance(values, list) or any(not isinstance(value, str) or not value.strip() for value in values):
+                return False
+        name_key, path_key = name.strip(), path.strip().rstrip("/")
+        if name_key in names or path_key in paths:
+            return False
+        names.add(name_key)
+        paths.add(path_key)
+    return True
 
 
 def main() -> int:
@@ -106,15 +152,7 @@ def main() -> int:
 
     descriptor_path = root / "config" / "workspace-descriptor.json"
     descriptor = read_json(descriptor_path)
-    descriptor_ok = (
-        isinstance(descriptor, dict)
-        and descriptor.get("workspace_root") == str(root)
-        and descriptor.get("workspace_root_is_plain_folder") is True
-        and isinstance(descriptor.get("master_seat"), str)
-        and bool(descriptor.get("master_seat", "").strip())
-        and isinstance(descriptor.get("repositories"), list)
-        and bool(descriptor["repositories"])
-    )
+    descriptor_ok = descriptor_matches(descriptor, root)
     result(results, "P05", "workspace descriptor satisfies loader rules and names this root",
            "<workspace-root>" if descriptor_ok else "missing or invalid",
            "PASS" if descriptor_ok else "FAIL", "~/path/config/workspace-descriptor.json")
@@ -148,11 +186,11 @@ def main() -> int:
             try:
                 proc = subprocess.run(
                     [args.orca_cli, "terminal", "list", "--worktree", seat, "--json"],
-                    capture_output=True, text=True, timeout=30,
+                    capture_output=True, timeout=30,
                 )
             except subprocess.TimeoutExpired:
                 result(results, "L01", "exactly one live terminal in recorded master seat",
-                       "Orca command timed out after 30 seconds", "FAIL",
+                       "Orca command timed out after 30 seconds", "GAP",
                        f"{args.orca_cli} terminal list --worktree {seat} --json")
                 proc = None
             if proc is None:
@@ -162,7 +200,8 @@ def main() -> int:
             else:
                 payload = None
                 try:
-                    payload = json.loads(proc.stdout)
+                    output = proc.stdout.decode("utf-8", errors="replace")
+                    payload = json.loads(output)
                 except (UnicodeError, json.JSONDecodeError):
                     pass
                 if isinstance(payload, dict) and isinstance(payload.get("result"), dict):

--- a/master-ops/scripts/onboarding-rehearsal
+++ b/master-ops/scripts/onboarding-rehearsal
@@ -1,0 +1,178 @@
+#!/usr/bin/env python3
+"""Read-only, measurable post-install rehearsal for a founded workspace.
+
+The rehearsal deliberately reports GAP when a postcondition cannot be measured;
+absence of evidence is not a pass.  It never creates, overwrites, or repairs an
+installation.  Use ``--live`` to add the optional Orca seat check.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import subprocess
+import sys
+from dataclasses import asdict, dataclass
+from pathlib import Path
+
+
+PLACEHOLDER = re.compile(r"\{\{[^}]+\}\}")
+
+
+def safe_evidence(path: Path) -> str:
+    """Keep host-specific absolute paths out of reports."""
+    return f"~/path/{path.name}"
+
+
+@dataclass
+class Result:
+    id: str
+    expected: str
+    observed: str
+    status: str
+    evidence: str
+
+
+def result(results: list[Result], ident: str, expected: str, observed: str,
+           status: str, evidence: str) -> None:
+    results.append(Result(ident, expected, observed, status, evidence))
+
+
+def read_json(path: Path):
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return None
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--workspace-root", required=True, type=Path)
+    parser.add_argument("--ops-repo", required=True, type=Path)
+    parser.add_argument("--live", action="store_true",
+                        help="also measure the live Orca terminal in the recorded seat")
+    parser.add_argument("--orca-cli", default="orca",
+                        help="Orca executable used with --live (default: orca)")
+    parser.add_argument("--json", action="store_true", dest="json_output")
+    args = parser.parse_args()
+    root = args.workspace_root.resolve()
+    ops = args.ops_repo.resolve()
+    results: list[Result] = []
+
+    router = ops / "ONBOARDING.md"
+    steps = ops / "onboarding"
+    if router.is_file() and steps.is_dir():
+        indexed = re.findall(r"^\|\s*(?:\d{2}|—)\s*\|\s*`onboarding/([a-z0-9-]+\.md)`\s*\|",
+                             router.read_text(encoding="utf-8"), re.MULTILINE)
+        on_disk = sorted(p.name for p in steps.glob("*.md"))
+        result(results, "P01", "router index equals onboarding files",
+               f"{len(indexed)} indexed, {len(on_disk)} on disk",
+               "PASS" if sorted(indexed) == on_disk else "FAIL",
+               safe_evidence(router))
+    else:
+        result(results, "P01", "router and step directory exist", "missing",
+               "FAIL", "~/path/ONBOARDING.md or ~/path/onboarding")
+
+    unresolved = [str(p.relative_to(ops)) for p in ops.rglob("*")
+                  if p.is_file() and p.suffix in {".md", ".json", ".txt"}
+                  for _ in [0] if any(token != "{{...}}" for token in
+                                      PLACEHOLDER.findall(p.read_text(encoding="utf-8", errors="replace")))]
+    result(results, "P02", "no unresolved placeholders in ops repository",
+           "none" if not unresolved else ", ".join(unresolved),
+               "PASS" if not unresolved else "FAIL", "~/path/ops-repository")
+
+    claude, agents = ops / "CLAUDE.md", ops / "AGENTS.md"
+    equal = claude.is_file() and agents.is_file() and claude.read_bytes() == agents.read_bytes()
+    result(results, "P03", "ops CLAUDE.md and AGENTS.md are byte-identical",
+           "byte-identical" if equal else "missing or different", "PASS" if equal else "FAIL",
+           "~/path/CLAUDE.md / ~/path/AGENTS.md")
+
+    canonical, deployed = ops / "workspace-card" / "CLAUDE.md", root / "CLAUDE.md"
+    card_equal = canonical.is_file() and deployed.is_file() and canonical.read_bytes() == deployed.read_bytes()
+    result(results, "P04", "deployed root card equals ops canonical card",
+           "byte-identical" if card_equal else "missing or different", "PASS" if card_equal else "FAIL",
+           "cmp ~/path/CLAUDE.md ~/path/workspace-card/CLAUDE.md")
+
+    descriptor_path = root / "config" / "workspace-descriptor.json"
+    descriptor = read_json(descriptor_path)
+    root_match = isinstance(descriptor, dict) and descriptor.get("workspace_root") == str(root)
+    result(results, "P05", "workspace descriptor exists and names this root",
+           "<workspace-root>" if root_match else "missing or invalid",
+           "PASS" if root_match else "FAIL", "~/path/config/workspace-descriptor.json")
+
+    runtime_path = root / "config" / "instance-runtime.json"
+    runtime = read_json(runtime_path)
+    runtime_ok = isinstance(runtime, dict) and bool(runtime.get("master_host_runtime"))
+    result(results, "P06", "instance runtime names the master host runtime",
+           str(runtime.get("master_host_runtime")) if isinstance(runtime, dict) else "missing or invalid",
+           "PASS" if runtime_ok else "FAIL", "~/path/config/instance-runtime.json")
+
+    for ident, rel in (("P07", "docs/runbooks/role-state.md"),
+                       ("P08", "docs/lineage/MASTER-LINEAGE.md")):
+        path = ops / rel
+        result(results, f"{ident}", f"{rel} exists", "present" if path.is_file() else "missing",
+               "PASS" if path.is_file() else "FAIL", f"~/path/{rel}")
+
+    if args.live:
+        seat = descriptor.get("master_seat") if isinstance(descriptor, dict) else None
+        if not seat:
+            result(results, "L01", "live master seat is measurable", "no recorded master_seat", "GAP",
+                   "~/path/config/workspace-descriptor.json")
+        elif not shutil_which(args.orca_cli):
+            result(results, "L01", "live master seat is measurable", f"{args.orca_cli} unavailable", "GAP",
+                   "install or expose Orca CLI")
+        else:
+            proc = subprocess.run([args.orca_cli, "terminal", "list", "--worktree", seat, "--json"],
+                                  capture_output=True, text=True)
+            payload = None
+            try:
+                payload = json.loads(proc.stdout)
+            except json.JSONDecodeError:
+                pass
+            terminals = payload.get("terminals") if isinstance(payload, dict) else None
+            count = len(terminals) if isinstance(terminals, list) else None
+            status = "PASS" if proc.returncode == 0 and count == 1 else "FAIL"
+            observed = f"{count} terminal(s)" if count is not None else "invalid Orca JSON"
+            result(results, "L01", "exactly one live terminal in recorded master seat", observed, status,
+                   f"{args.orca_cli} terminal list --worktree {seat} --json")
+            result(results, "L02", "live master role identity is independently evidenced",
+                   "not exposed by terminal list", "GAP",
+                   "terminal presence is not proof of master role; inspect role-state/lineage")
+    else:
+        result(results, "L01", "live master seat is measured", "live checks not requested", "GAP",
+               "rerun with --live")
+        result(results, "L02", "live master role identity is measured", "live checks not requested", "GAP",
+               "rerun with --live; terminal presence alone remains insufficient")
+
+    gaps = [r for r in results if r.status == "GAP"]
+    failures = [r for r in results if r.status == "FAIL"]
+    if args.json_output:
+        print(json.dumps({"workspace_root": str(root), "ops_repo": str(ops),
+                          "results": [asdict(r) for r in results],
+                          "failures": [asdict(r) for r in failures],
+                          "gaps": [asdict(r) for r in gaps]}, ensure_ascii=False, indent=2))
+    else:
+        print("ID   STATUS  EXPECTED                                      OBSERVED")
+        for r in results:
+            print(f"{r.id:<4} {r.status:<7} {r.expected:<45} {r.observed}")
+        print(f"\nFAILURES ({len(failures)}):")
+        for r in failures:
+            print(f"- {r.id}: {r.evidence}")
+        print(f"\nGAPS ({len(gaps)}):")
+        for r in gaps:
+            print(f"- {r.id}: {r.evidence}")
+    return 0 if not gaps and all(r.status == "PASS" for r in results) else 1
+
+
+def shutil_which(command: str) -> str | None:
+    for directory in os.environ.get("PATH", "").split(os.pathsep):
+        candidate = Path(directory) / command
+        if candidate.is_file() and os.access(candidate, os.X_OK):
+            return str(candidate)
+    return None
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_onboarding_rehearsal.py
+++ b/tests/test_onboarding_rehearsal.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+import re
+from pathlib import Path
+
+
+REPO = Path(__file__).resolve().parents[1]
+SCRIPT = REPO / "master-ops/scripts/onboarding-rehearsal"
+
+
+def make_install(tmp_path: Path) -> tuple[Path, Path]:
+    workspace = tmp_path / "workspace"
+    ops = tmp_path / "ops"
+    shutil.copytree(REPO / "master-ops", ops)
+    for path in ops.rglob("*"):
+        if path.is_file() and path.suffix in {".md", ".json", ".txt"}:
+            text = path.read_text(encoding="utf-8")
+            path.write_text(re.sub(r"\{\{(?!\.\.\.\}\})[^}]+\}\}", "filled", text), encoding="utf-8")
+    (workspace / "config").mkdir(parents=True)
+    (workspace / "CLAUDE.md").write_bytes((ops / "workspace-card/CLAUDE.md").read_bytes())
+    (ops / "CLAUDE.md").write_text("same\n", encoding="utf-8")
+    (ops / "AGENTS.md").write_text("same\n", encoding="utf-8")
+    (workspace / "config/workspace-descriptor.json").write_text(json.dumps({
+        "workspace_root": str(workspace.resolve()), "master_seat": "id:folder:test",
+    }), encoding="utf-8")
+    (workspace / "config/instance-runtime.json").write_text(json.dumps({
+        "master_host_runtime": "codex",
+    }), encoding="utf-8")
+    (ops / "docs/runbooks/role-state.md").parent.mkdir(parents=True, exist_ok=True)
+    (ops / "docs/runbooks/role-state.md").write_text("role\n", encoding="utf-8")
+    (ops / "docs/lineage/MASTER-LINEAGE.md").parent.mkdir(parents=True, exist_ok=True)
+    (ops / "docs/lineage/MASTER-LINEAGE.md").write_text("lineage\n", encoding="utf-8")
+    return workspace, ops
+
+
+def run(workspace: Path, ops: Path, *extra: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run([str(SCRIPT), "--workspace-root", str(workspace),
+                           "--ops-repo", str(ops), *extra],
+                          capture_output=True, text=True, env=os.environ.copy())
+
+
+def test_rehearsal_reports_passes_and_honest_live_gaps(tmp_path: Path):
+    workspace, ops = make_install(tmp_path)
+    completed = run(workspace, ops, "--json")
+    assert completed.returncode == 1  # live identity was not measured
+    report = json.loads(completed.stdout)
+    statuses = {row["id"]: row["status"] for row in report["results"]}
+    assert all(statuses[row] == "PASS" for row in ("P01", "P02", "P03", "P04", "P05", "P06", "P07", "P08"))
+    assert statuses["L01"] == "GAP"
+    assert statuses["L02"] == "GAP"
+    assert {row["id"] for row in report["gaps"]} == {"L01", "L02"}
+    assert report["failures"] == []
+
+
+def test_rehearsal_detects_card_drift(tmp_path: Path):
+    workspace, ops = make_install(tmp_path)
+    (workspace / "CLAUDE.md").write_text("drift\n", encoding="utf-8")
+    completed = run(workspace, ops, "--json")
+    report = json.loads(completed.stdout)
+    row = next(row for row in report["results"] if row["id"] == "P04")
+    assert row["status"] == "FAIL"
+    assert row["observed"] == "missing or different"
+
+
+def test_live_check_is_gap_when_orca_is_unavailable(tmp_path: Path):
+    workspace, ops = make_install(tmp_path)
+    completed = run(workspace, ops, "--live", "--orca-cli", "definitely-not-an-orca-cli", "--json")
+    report = json.loads(completed.stdout)
+    row = next(row for row in report["results"] if row["id"] == "L01")
+    assert row["status"] == "GAP"

--- a/tests/test_onboarding_rehearsal.py
+++ b/tests/test_onboarding_rehearsal.py
@@ -45,9 +45,9 @@ def run(workspace: Path, ops: Path, *extra: str) -> subprocess.CompletedProcess[
     # through bash on every OS; bash then invokes the Python interpreter rather
     # than treating this Python source as a shell program.
     # On Windows, the bare `python` name can resolve to the Microsoft Store
-    # shim inside Git Bash even after setup-python. Use this test process's
-    # concrete interpreter path instead.
-    interpreter = Path(sys.executable).as_posix()
+    # shim inside Git Bash even after setup-python. `python.exe` resolves the
+    # setup-python entry on PATH; Unix runners use their normal `python3`.
+    interpreter = "python.exe" if os.name == "nt" else "python3"
     command = [interpreter, SCRIPT.as_posix(), "--workspace-root", str(workspace),
                "--ops-repo", str(ops), *extra]
     return subprocess.run(["bash", "-c", shlex.join(command)],

--- a/tests/test_onboarding_rehearsal.py
+++ b/tests/test_onboarding_rehearsal.py
@@ -44,16 +44,15 @@ def run(workspace: Path, ops: Path, *extra: str) -> subprocess.CompletedProcess[
     # 193). GitHub's Windows runner provides bash, so invoke the same script
     # through bash on every OS; bash then invokes the Python interpreter rather
     # than treating this Python source as a shell program.
-    # On Windows, command-name lookup inside Git Bash can resolve the WSL shim
-    # instead of setup-python. Keep bash as the outer command, then let
-    # cmd.exe execute the concrete interpreter path without MSYS translation.
+    # On Windows, Git Bash's Python/WSL shim intercepted every bash -> cmd
+    # route even when given the setup-python path (measured in CI stdout).
+    # Invoke the concrete setup-python interpreter directly on Windows; Unix
+    # keeps the explicit bash path used by the script's executable surface.
     if os.name == "nt":
-        windows_args = [sys.executable, str(SCRIPT), "--workspace-root", str(workspace),
-                        "--ops-repo", str(ops), *extra]
-        # Quote each argument for bash so its backslashes survive to cmd.exe;
-        # quoting the whole command loses the argument boundary at cmd /c.
-        bash_args = " ".join("'" + arg.replace("'", "'\\''") + "'" for arg in windows_args)
-        shell_command = f"cmd.exe /d /c {bash_args}"
+        command = [sys.executable, str(SCRIPT), "--workspace-root", str(workspace),
+                   "--ops-repo", str(ops), *extra]
+        return subprocess.run(command, capture_output=True, text=True,
+                              env=os.environ.copy())
     else:
         command = ["python3", SCRIPT.as_posix(), "--workspace-root", str(workspace),
                    "--ops-repo", str(ops), *extra]

--- a/tests/test_onboarding_rehearsal.py
+++ b/tests/test_onboarding_rehearsal.py
@@ -54,25 +54,43 @@ def run(workspace: Path, ops: Path, *extra: str) -> subprocess.CompletedProcess[
                           capture_output=True, text=True, env=os.environ.copy())
 
 
+def report(completed: subprocess.CompletedProcess[str]) -> dict:
+    """Parse JSON only after exposing the real subprocess failure context."""
+    assert completed.returncode == 1, (
+        f"rehearsal exit={completed.returncode}; stderr:\n{completed.stderr}\n"
+        f"stdout:\n{completed.stdout}"
+    )
+    assert completed.stdout, (
+        f"rehearsal produced empty stdout; exit={completed.returncode}; "
+        f"stderr:\n{completed.stderr}"
+    )
+    try:
+        return json.loads(completed.stdout)
+    except json.JSONDecodeError as error:
+        raise AssertionError(
+            f"rehearsal emitted invalid JSON; exit={completed.returncode}; "
+            f"stderr:\n{completed.stderr}\nstdout:\n{completed.stdout}"
+        ) from error
+
+
 def test_rehearsal_reports_passes_and_honest_live_gaps(tmp_path: Path):
     workspace, ops = make_install(tmp_path)
     completed = run(workspace, ops, "--json")
-    assert completed.returncode == 1  # live identity was not measured
-    report = json.loads(completed.stdout)
-    statuses = {row["id"]: row["status"] for row in report["results"]}
+    payload = report(completed)
+    statuses = {row["id"]: row["status"] for row in payload["results"]}
     assert all(statuses[row] == "PASS" for row in ("P01", "P02", "P03", "P04", "P05", "P06", "P07", "P08"))
     assert statuses["L01"] == "GAP"
     assert statuses["L02"] == "GAP"
-    assert {row["id"] for row in report["gaps"]} == {"L01", "L02"}
-    assert report["failures"] == []
+    assert {row["id"] for row in payload["gaps"]} == {"L01", "L02"}
+    assert payload["failures"] == []
 
 
 def test_rehearsal_detects_card_drift(tmp_path: Path):
     workspace, ops = make_install(tmp_path)
     (workspace / "CLAUDE.md").write_text("drift\n", encoding="utf-8")
     completed = run(workspace, ops, "--json")
-    report = json.loads(completed.stdout)
-    row = next(row for row in report["results"] if row["id"] == "P04")
+    payload = report(completed)
+    row = next(row for row in payload["results"] if row["id"] == "P04")
     assert row["status"] == "FAIL"
     assert row["observed"] == "missing or different"
 
@@ -80,6 +98,6 @@ def test_rehearsal_detects_card_drift(tmp_path: Path):
 def test_live_check_is_gap_when_orca_is_unavailable(tmp_path: Path):
     workspace, ops = make_install(tmp_path)
     completed = run(workspace, ops, "--live", "--orca-cli", "definitely-not-an-orca-cli", "--json")
-    report = json.loads(completed.stdout)
-    row = next(row for row in report["results"] if row["id"] == "L01")
+    payload = report(completed)
+    row = next(row for row in payload["results"] if row["id"] == "L01")
     assert row["status"] == "GAP"

--- a/tests/test_onboarding_rehearsal.py
+++ b/tests/test_onboarding_rehearsal.py
@@ -44,7 +44,10 @@ def run(workspace: Path, ops: Path, *extra: str) -> subprocess.CompletedProcess[
     # 193). GitHub's Windows runner provides bash, so invoke the same script
     # through bash on every OS; bash then invokes the Python interpreter rather
     # than treating this Python source as a shell program.
-    interpreter = "python" if os.name == "nt" else "python3"
+    # On Windows, the bare `python` name can resolve to the Microsoft Store
+    # shim inside Git Bash even after setup-python. Use this test process's
+    # concrete interpreter path instead.
+    interpreter = Path(sys.executable).as_posix()
     command = [interpreter, SCRIPT.as_posix(), "--workspace-root", str(workspace),
                "--ops-repo", str(ops), *extra]
     return subprocess.run(["bash", "-c", shlex.join(command)],

--- a/tests/test_onboarding_rehearsal.py
+++ b/tests/test_onboarding_rehearsal.py
@@ -52,7 +52,9 @@ def run(workspace: Path, ops: Path, *extra: str) -> subprocess.CompletedProcess[
             [sys.executable, str(SCRIPT), "--workspace-root", str(workspace),
              "--ops-repo", str(ops), *extra]
         )
-        shell_command = f"cmd.exe /d /s /c {shlex.quote(command)}"
+        # Do not shell-quote the whole cmd command: those quotes would become
+        # part of `cmd /c`'s command string after bash removes its own layer.
+        shell_command = f"cmd.exe /d /c {command}"
     else:
         command = ["python3", SCRIPT.as_posix(), "--workspace-root", str(workspace),
                    "--ops-repo", str(ops), *extra]

--- a/tests/test_onboarding_rehearsal.py
+++ b/tests/test_onboarding_rehearsal.py
@@ -133,11 +133,30 @@ def test_rehearsal_rejects_incomplete_descriptor_and_blank_runtime(tmp_path: Pat
     workspace, ops = make_install(tmp_path)
     descriptor = json.loads((workspace / "config/workspace-descriptor.json").read_text())
     descriptor["workspace_root_is_plain_folder"] = False
-    descriptor["master_seat"] = ""
-    descriptor["repositories"] = [{}]
     (workspace / "config/workspace-descriptor.json").write_text(json.dumps(descriptor))
     (workspace / "config/instance-runtime.json").write_text(json.dumps({"master_host_runtime": "  "}))
     payload = report(run(workspace, ops, "--json"))
     statuses = {row["id"]: row["status"] for row in payload["results"]}
     assert statuses["P05"] == "FAIL"
     assert statuses["P06"] == "FAIL"
+
+
+def test_rehearsal_rejects_empty_descriptor_fields(tmp_path: Path):
+    workspace, ops = make_install(tmp_path)
+    descriptor = json.loads((workspace / "config/workspace-descriptor.json").read_text())
+    descriptor["master_seat"] = ""
+    descriptor["repositories"] = [{}]
+    (workspace / "config/workspace-descriptor.json").write_text(json.dumps(descriptor))
+    payload = report(run(workspace, ops, "--json"))
+    statuses = {row["id"]: row["status"] for row in payload["results"]}
+    assert statuses["P05"] == "FAIL"
+
+
+def test_rehearsal_accepts_null_capabilities_default(tmp_path: Path):
+    workspace, ops = make_install(tmp_path)
+    descriptor = json.loads((workspace / "config/workspace-descriptor.json").read_text())
+    descriptor["repositories"][0]["capabilities"] = None
+    (workspace / "config/workspace-descriptor.json").write_text(json.dumps(descriptor))
+    payload = report(run(workspace, ops, "--json"))
+    statuses = {row["id"]: row["status"] for row in payload["results"]}
+    assert statuses["P05"] == "PASS"

--- a/tests/test_onboarding_rehearsal.py
+++ b/tests/test_onboarding_rehearsal.py
@@ -58,7 +58,7 @@ def run(workspace: Path, ops: Path, *extra: str) -> subprocess.CompletedProcess[
         return subprocess.run(command, capture_output=True, text=True,
                               env=os.environ.copy())
     else:
-        command = ["python3", SCRIPT.as_posix(), "--workspace-root", str(workspace),
+        command = [sys.executable, SCRIPT.as_posix(), "--workspace-root", str(workspace),
                    "--ops-repo", str(ops), *extra]
         shell_command = shlex.join(command)
     return subprocess.run(["bash", "-c", shell_command], capture_output=True,
@@ -133,6 +133,8 @@ def test_rehearsal_rejects_incomplete_descriptor_and_blank_runtime(tmp_path: Pat
     workspace, ops = make_install(tmp_path)
     descriptor = json.loads((workspace / "config/workspace-descriptor.json").read_text())
     descriptor["workspace_root_is_plain_folder"] = False
+    descriptor["master_seat"] = ""
+    descriptor["repositories"] = [{}]
     (workspace / "config/workspace-descriptor.json").write_text(json.dumps(descriptor))
     (workspace / "config/instance-runtime.json").write_text(json.dumps({"master_host_runtime": "  "}))
     payload = report(run(workspace, ops, "--json"))

--- a/tests/test_onboarding_rehearsal.py
+++ b/tests/test_onboarding_rehearsal.py
@@ -2,9 +2,11 @@ from __future__ import annotations
 
 import json
 import os
+import shlex
 import shutil
 import subprocess
 import re
+import sys
 from pathlib import Path
 
 
@@ -38,8 +40,14 @@ def make_install(tmp_path: Path) -> tuple[Path, Path]:
 
 
 def run(workspace: Path, ops: Path, *extra: str) -> subprocess.CompletedProcess[str]:
-    return subprocess.run([str(SCRIPT), "--workspace-root", str(workspace),
-                           "--ops-repo", str(ops), *extra],
+    # Windows cannot execute a shebang script as a native application (WinError
+    # 193). GitHub's Windows runner provides bash, so invoke the same script
+    # through bash on every OS; bash then invokes the Python interpreter rather
+    # than treating this Python source as a shell program.
+    interpreter = "python" if os.name == "nt" else "python3"
+    command = [interpreter, SCRIPT.as_posix(), "--workspace-root", str(workspace),
+               "--ops-repo", str(ops), *extra]
+    return subprocess.run(["bash", "-c", shlex.join(command)],
                           capture_output=True, text=True, env=os.environ.copy())
 
 

--- a/tests/test_onboarding_rehearsal.py
+++ b/tests/test_onboarding_rehearsal.py
@@ -44,10 +44,15 @@ def run(workspace: Path, ops: Path, *extra: str) -> subprocess.CompletedProcess[
     # 193). GitHub's Windows runner provides bash, so invoke the same script
     # through bash on every OS; bash then invokes the Python interpreter rather
     # than treating this Python source as a shell program.
-    # On Windows, the bare `python` name can resolve to the Microsoft Store
-    # shim inside Git Bash even after setup-python. `python.exe` resolves the
-    # setup-python entry on PATH; Unix runners use their normal `python3`.
-    interpreter = "python.exe" if os.name == "nt" else "python3"
+    # On Windows, command-name lookup inside Git Bash can resolve the WSL shim
+    # instead of setup-python. Convert this process's concrete interpreter to
+    # the MSYS /c/... form so bash executes the intended Windows binary.
+    if os.name == "nt":
+        concrete = Path(sys.executable).as_posix()
+        drive, remainder = concrete[0], concrete[2:]
+        interpreter = f"/{drive.lower()}{remainder}"
+    else:
+        interpreter = "python3"
     command = [interpreter, SCRIPT.as_posix(), "--workspace-root", str(workspace),
                "--ops-repo", str(ops), *extra]
     return subprocess.run(["bash", "-c", shlex.join(command)],

--- a/tests/test_onboarding_rehearsal.py
+++ b/tests/test_onboarding_rehearsal.py
@@ -48,13 +48,12 @@ def run(workspace: Path, ops: Path, *extra: str) -> subprocess.CompletedProcess[
     # instead of setup-python. Keep bash as the outer command, then let
     # cmd.exe execute the concrete interpreter path without MSYS translation.
     if os.name == "nt":
-        command = subprocess.list2cmdline(
-            [sys.executable, str(SCRIPT), "--workspace-root", str(workspace),
-             "--ops-repo", str(ops), *extra]
-        )
-        # Do not shell-quote the whole cmd command: those quotes would become
-        # part of `cmd /c`'s command string after bash removes its own layer.
-        shell_command = f"cmd.exe /d /c {command}"
+        windows_args = [sys.executable, str(SCRIPT), "--workspace-root", str(workspace),
+                        "--ops-repo", str(ops), *extra]
+        # Quote each argument for bash so its backslashes survive to cmd.exe;
+        # quoting the whole command loses the argument boundary at cmd /c.
+        bash_args = " ".join("'" + arg.replace("'", "'\\''") + "'" for arg in windows_args)
+        shell_command = f"cmd.exe /d /c {bash_args}"
     else:
         command = ["python3", SCRIPT.as_posix(), "--workspace-root", str(workspace),
                    "--ops-repo", str(ops), *extra]

--- a/tests/test_onboarding_rehearsal.py
+++ b/tests/test_onboarding_rehearsal.py
@@ -27,7 +27,11 @@ def make_install(tmp_path: Path) -> tuple[Path, Path]:
     (ops / "CLAUDE.md").write_text("same\n", encoding="utf-8")
     (ops / "AGENTS.md").write_text("same\n", encoding="utf-8")
     (workspace / "config/workspace-descriptor.json").write_text(json.dumps({
-        "workspace_root": str(workspace.resolve()), "master_seat": "id:folder:test",
+        "workspace_root": str(workspace.resolve()),
+        "workspace_root_is_plain_folder": True,
+        "master_seat": "id:folder:test",
+        "repositories": [{"name": "ops", "path": ".", "remote": "", "role": "ops",
+                           "capabilities": [], "prohibited": []}],
     }), encoding="utf-8")
     (workspace / "config/instance-runtime.json").write_text(json.dumps({
         "master_host_runtime": "codex",
@@ -108,3 +112,30 @@ def test_live_check_is_gap_when_orca_is_unavailable(tmp_path: Path):
     payload = report(completed)
     row = next(row for row in payload["results"] if row["id"] == "L01")
     assert row["status"] == "GAP"
+
+
+def test_rehearsal_excludes_metadata_and_measures_invalid_utf8(tmp_path: Path):
+    workspace, ops = make_install(tmp_path)
+    (ops / ".beads").mkdir()
+    (ops / ".beads/issue.md").write_text("{{UNRESOLVED}}", encoding="utf-8")
+    (ops / ".git").mkdir()
+    (ops / ".git/metadata.md").write_text("{{UNRESOLVED}}", encoding="utf-8")
+    (ops / "bad.md").write_bytes(b"\xff\xfe")
+    payload = report(run(workspace, ops, "--json"))
+    p02 = next(row for row in payload["results"] if row["id"] == "P02")
+    assert p02["status"] == "FAIL"
+    assert "bad.md (invalid UTF-8)" in p02["observed"]
+    assert ".beads" not in p02["observed"]
+    assert ".git" not in p02["observed"]
+
+
+def test_rehearsal_rejects_incomplete_descriptor_and_blank_runtime(tmp_path: Path):
+    workspace, ops = make_install(tmp_path)
+    descriptor = json.loads((workspace / "config/workspace-descriptor.json").read_text())
+    descriptor["workspace_root_is_plain_folder"] = False
+    (workspace / "config/workspace-descriptor.json").write_text(json.dumps(descriptor))
+    (workspace / "config/instance-runtime.json").write_text(json.dumps({"master_host_runtime": "  "}))
+    payload = report(run(workspace, ops, "--json"))
+    statuses = {row["id"]: row["status"] for row in payload["results"]}
+    assert statuses["P05"] == "FAIL"
+    assert statuses["P06"] == "FAIL"

--- a/tests/test_onboarding_rehearsal.py
+++ b/tests/test_onboarding_rehearsal.py
@@ -45,18 +45,20 @@ def run(workspace: Path, ops: Path, *extra: str) -> subprocess.CompletedProcess[
     # through bash on every OS; bash then invokes the Python interpreter rather
     # than treating this Python source as a shell program.
     # On Windows, command-name lookup inside Git Bash can resolve the WSL shim
-    # instead of setup-python. Convert this process's concrete interpreter to
-    # the MSYS /c/... form so bash executes the intended Windows binary.
+    # instead of setup-python. Keep bash as the outer command, then let
+    # cmd.exe execute the concrete interpreter path without MSYS translation.
     if os.name == "nt":
-        concrete = Path(sys.executable).as_posix()
-        drive, remainder = concrete[0], concrete[2:]
-        interpreter = f"/{drive.lower()}{remainder}"
+        command = subprocess.list2cmdline(
+            [sys.executable, str(SCRIPT), "--workspace-root", str(workspace),
+             "--ops-repo", str(ops), *extra]
+        )
+        shell_command = f"cmd.exe /d /s /c {shlex.quote(command)}"
     else:
-        interpreter = "python3"
-    command = [interpreter, SCRIPT.as_posix(), "--workspace-root", str(workspace),
-               "--ops-repo", str(ops), *extra]
-    return subprocess.run(["bash", "-c", shlex.join(command)],
-                          capture_output=True, text=True, env=os.environ.copy())
+        command = ["python3", SCRIPT.as_posix(), "--workspace-root", str(workspace),
+                   "--ops-repo", str(ops), *extra]
+        shell_command = shlex.join(command)
+    return subprocess.run(["bash", "-c", shell_command], capture_output=True,
+                          text=True, env=os.environ.copy())
 
 
 def report(completed: subprocess.CompletedProcess[str]) -> dict:

--- a/tests/test_onboarding_rehearsal.py
+++ b/tests/test_onboarding_rehearsal.py
@@ -144,7 +144,6 @@ def test_rehearsal_rejects_incomplete_descriptor_and_blank_runtime(tmp_path: Pat
 def test_rehearsal_rejects_empty_descriptor_fields(tmp_path: Path):
     workspace, ops = make_install(tmp_path)
     descriptor = json.loads((workspace / "config/workspace-descriptor.json").read_text())
-    descriptor["master_seat"] = ""
     descriptor["repositories"] = [{}]
     (workspace / "config/workspace-descriptor.json").write_text(json.dumps(descriptor))
     payload = report(run(workspace, ops, "--json"))


### PR DESCRIPTION
## Problem

The onboarding rehearsal's live-seat check parsed only a top-level `terminals` field, while Orca returns terminals under `result`, so every valid live invocation was reported as L01 FAIL. The rehearsal also lacked subprocess timeouts, used a custom executable lookup, accepted incomplete descriptors and non-string runtimes, scanned metadata directories, and documented relative commands as runnable from any directory.

## Why this approach

The checks now follow the production descriptor loader's required fields and the measured Orca JSON shape. Read-only measurement remains fail-closed: malformed evidence becomes an explicit FAIL, unavailable role identity remains a GAP, and a hung Orca command terminates after a bounded timeout.

## What this changes

- Accepts `result.terminals` from `orca terminal list --json` and bounds the call with a 30-second timeout.
- Uses `shutil.which`, excludes `.git/` and `.beads/`, and reports invalid UTF-8 as a measured P02 failure.
- Requires `workspace_root_is_plain_folder: true`, a nonempty `master_seat`, a nonempty repository list, and a nonblank string runtime.
- Adds regression tests for metadata exclusion, invalid UTF-8, and incomplete descriptors.
- Fixes documentation paths and the P02/P05 table contracts; removes the duplicate root changelog entry so the change is recorded under the template changelog only.

## Expected effect

A live Orca result with one terminal now produces L01 PASS instead of a false FAIL, and a stalled Orca process cannot block the rehearsal indefinitely.

Part 3 equality result: P04 is the exact check where a live master workspace can pass while a new installation fails — the deployed root `CLAUDE.md` must be byte-identical to canonical `workspace-card/CLAUDE.md`; a new install fails when that root card is missing or different.

Part 4 measurement gap: L01 had never successfully measured a valid live Orca response before this fix because the parser rejected the nested `result.terminals` shape; after this fix L02 remains unmeasurable because `orca terminal list` proves terminal presence but not the terminal's master-role identity.

## Testing

- [x] Focused committed-worktree run after `dc3f8a1`: 35 passed, exit 0.
- [x] Previous CI run: Ubuntu, macOS, Windows, and redaction passed before this measurement-hardening batch.
- [x] Added regression coverage for the requested P1/Major/P2 issues.

## Review

The Orca payload shape, timeout behavior, descriptor rules, and metadata/UTF-8 cases are covered by direct code paths and regression tests. The previous L01 failure was reproduced from the accepted JSON shape and corrected.

## Changelog

The template changelog remains the source for `master-ops/` changes; the duplicate root changelog item was removed.

## Template impact

This changes `master-ops/` measurement behavior. Existing generated operations repositories do not auto-update and must adopt the template changes deliberately.

## Notes

PR #95 remains ready for review with its assignee set.
