### PR TITLE
docs: restructure root readme

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,6 +76,8 @@ you build on it.
 
 ### Changed
 
+- Root README now starts with product summary, Quickstart, and the tool rationale, with overlapping Orca and tool-stack explanations consolidated.
+
 - `master-succeed retire` now reports each of the three disappearances
   (`pane`, `process`, `tty`) as `measured` / `still_present` / `skipped:<why>`.
   Full `CLOSED` requires all three measured; any skip yields `CLOSED_PARTIAL`

--- a/README.md
+++ b/README.md
@@ -24,6 +24,11 @@ cd mogui-ADE-orchestrator
 
 Linux and Windows: install Orca from the [download page](https://www.onorca.dev/download), then clone the repository and enter the checkout.
 
+```console
+git clone https://github.com/baksohyeon/mogui-ADE-orchestrator
+cd mogui-ADE-orchestrator
+```
+
 Open Orca and turn on **Settings > Orca CLI > Shell command**, then confirm `orca status` shows a ready runtime. Add the folder to Orca, open a terminal in this clone, start your agent CLI, and wake it with a setup phrase, for example `Wake the master.` The agent becomes the onboarding guide.
 
 ![Claude Code in Orca, opened on the cloned repository. The prompt reads "wake up, master." and the agent has started reading master-ops/ONBOARDING.md.](docs/assets/wake-up-master.png)

--- a/README.md
+++ b/README.md
@@ -1,125 +1,105 @@
 # mogui-ADE-orchestrator
 
-> Existing installations: compare the `Template version` line in your operations repository's `docs/MASTER-OPERATIONS.md` against the [latest release](https://github.com/baksohyeon/mogui-ADE-orchestrator/releases/latest). If they differ, read the [template changelog](master-ops/CHANGELOG.md) entries between the two and apply what applies; local edits win. Watch → Custom → Releases on this repository sends an email each time that line moves.
->
-> *I have agents running in tmux sessions. Can I still drive each one manually when I want, and at the same time orchestrate all of those sessions from above? Is tmux-based agent orchestration a thing?*
+Run one long-lived agent session as the master of a multi-repository workspace. The master plans work, dispatches isolated workers, verifies their reports, records lineage, and hands the role to a successor when the current session reaches its limits.
 
-Yes. That is what this is. Any mix of agents, as many as you want. (Claude as the master is the combination that has been run hard.)
+This is for people who already use coding-agent CLIs and want one supervised workspace layer above them. Any mix of worker CLIs can run in Orca terminals. Claude Code as the master is the path that has been exercised hardest.
 
-Anyone running more than two agents at once hits this. Dorito hit it, got tired of it, and wrote this.
+Existing installations: compare the `Template version` line in your operations repository's `docs/MASTER-OPERATIONS.md` with `master-ops/TEMPLATE-VERSION` in the current template, then read the matching entries in `master-ops/CHANGELOG.md`. Local edits win. Watching releases on this repository sends mail when that line moves.
 
-Clone it, open it in Orca, start an agent inside the clone, and tell it to wake up. The agent runs the install interview and explains as it goes. The honest first-run path (prerequisites, Orca vocabulary, onboarding decisions, first supervised worker) is [Getting Started](docs/public/getting-started.md), not this paragraph alone.
-
-It runs the fleet on [Orca](https://www.onorca.dev/download). A session has to outlive its window and be addressable by handle before anything can orchestrate it. Built and run on macOS; Orca also ships Linux and Windows. Python 3, stdlib-only core, MIT. No API key.
-
-The orchestrating session is called the master in the docs — that is a temporary role label, not a permanent name. At install you pick a **callsign** for the living session (examples people have used or floated: 자비스 / Jarvis, Friday, Alfred, HAL-but-nice, or anything short you will say out loud). Suggestions still welcome.
-
-
-## Why these tools
-
-Five questions decided the stack, and they are the bar for anything proposed later:
-
-1. Does it require an API key?
-2. Does it force telemetry, or collect more than the job needs?
-3. Does it add a management point?
-4. Does it still work if the operation grows past one person?
-5. Every tool claims to help with agent context. What else does this one actually resolve?
-
-Failing the first three usually means a subscription presenting itself as a dependency. Passing them while answering nothing for the fifth means a preference, which is allowed and labelled as one, and nothing gates on it.
-
-The maintainer-facing version of this bar is in `CONTRIBUTING.md`; the installer-facing one is in `master-ops/onboarding/08-settings-and-skills.md`, routed from `master-ops/ONBOARDING.md`.
+The orchestrating session is called the master in the docs. That is a role label. During install you pick a callsign for the live session, such as 자비스 / Jarvis, Friday, Alfred, HAL-but-nice, or another short name you will say out loud.
 
 ## Quickstart
 
-First run is longer than a clone and a wake-up phrase. You install Orca, register its shell command, put this repository in front of an agent, answer an onboarding interview, watch Generation 1 boot, then give the master one small task and watch it hand that task to a worker. The human-facing path with measured checks, vocabulary earned in order, and failure shapes is **[Getting Started](docs/public/getting-started.md)**. Follow that page; the block below is only the opening commands.
+First run is longer than cloning the repository. You install Orca, register its shell command, put this repository in front of an agent, answer an onboarding interview, watch Generation 1 boot, then give the master one small task and watch it hand that task to a worker.
+
+Follow **[Getting Started](docs/public/getting-started.md)** for the measured checks, Orca vocabulary, onboarding decisions, proof of boot, and first supervised worker. The block below only opens that path.
 
 ```console
 $ brew install --cask stablyai/orca/orca
-$ git clone https://github.com/baksohyeon/mogui-ADE-orchestrator
+$ git clone <repository-url>
 $ cd mogui-ADE-orchestrator
 ```
 
-Not on macOS? Orca has Linux and Windows builds on its [download page](https://www.onorca.dev/download). `--cask` is macOS-only, so Homebrew is not the route there.
+Orca has Linux and Windows builds on its [download page](https://www.onorca.dev/download). `--cask` is macOS-only.
 
-Open Orca and turn on **Settings → Orca CLI → Shell command**, then confirm `orca status` shows a ready runtime. Add the folder to Orca, open a terminal in this clone, start your agent CLI, and wake it with any short phrase that is not a concrete task (for example `Wake the master.`). The agent becomes the onboarding guide. Setup is not finished at spawn: stay with [Getting Started](docs/public/getting-started.md) through proof of boot and the first supervised worker.
+Open Orca and turn on **Settings > Orca CLI > Shell command**, then confirm `orca status` shows a ready runtime. Add the folder to Orca, open a terminal in this clone, start your agent CLI, and wake it with a setup phrase, for example `Wake the master.` The agent becomes the onboarding guide.
 
 ![Claude Code in Orca, opened on the cloned repository. The prompt reads "wake up, master." and the agent has started reading master-ops/ONBOARDING.md.](docs/assets/wake-up-master.png)
 
-### Why Orca is required
+## Why these tools
 
-Without Orca there is no session lifetime, no stable handles, and no supervised dispatch. The harness degrades to screen-polling and an unsupervised agent. In a real incident, a user skipped Orca setup, trusted the harness alone, and watched their agent run wild on errors.
+Five questions decide what belongs in the stack:
 
-| | Without Orca | With Orca |
+1. Does it require an API key?
+2. Does it force telemetry or collect more than the job needs?
+3. Does it add a management point?
+4. Does it still work if the operation grows past one person?
+5. Every tool claims to help with agent context. What else does this one resolve?
+
+Failing the first three usually means a subscription presented as a dependency. Passing them while answering nothing for the fifth means a preference. Preferences are allowed, labelled, and kept out of gates. The maintainer-facing version is in `CONTRIBUTING.md`; the installer-facing version is in `master-ops/onboarding/08-settings-and-skills.md`, routed from `master-ops/ONBOARDING.md`.
+
+The workspace layer addresses three failures in long-lived coordination. Sessions end while work continues. A master that can spawn workers can waste them. Context loss after compaction can look like continuity. This runtime turns those failures into checks: guarded succession, append-only lineage, contract-gated dispatch, and boot probes that hold back state after compaction so recall can be measured.
+
+Orca is required for live operation. A master needs session lifetime, stable terminal handles, worktree-scoped placement, a durable Run mailbox, and supervised dispatch. Without Orca, the harness falls back to screen-polling and an unsupervised agent. Step 0 preflight refuses to proceed without it.
+
+| Surface | Without Orca | With Orca |
 | --- | --- | --- |
-| Completion detection | Reading the worker's screen every N seconds | Zero contact until the Run mailbox rings |
-| Master state | Tied to a watch loop | Free, with the receiver in the background |
+| Completion detection | Screen polling | Run mailbox |
+| Master state | Bound to a watch loop | Background receiver |
 | Signal loss | Missed if the session dies | Durable mailbox survives restarts |
+| Placement | Inferred from text | Pane has a worktree identity |
 
-Step 0 preflight refuses to proceed without Orca; running runtime scripts without Orca is unsupported.
+This project was designed for the case where you already pay for coding-agent CLIs and want a workspace orchestrator with no API key and no per-token bill. If you want an API-key process graph, [LangChain deepagents](https://docs.langchain.com/oss/python/deepagents/overview) is the adjacent project to inspect. The comparison entered this repository after the architecture existed; `git log -S deepagents --reverse` shows when that happened.
+
+| Tool | What it does here | Replaceable |
+| --- | --- | --- |
+| [Orca](https://www.onorca.dev/download) | Execution substrate: terminal sessions that outlive windows, worktree placement, dispatch, and retirement. | No |
+| `bd` | Work ledger: issues, dependencies, active tracks, and boot-time task context through `master-bootstrap-live`. | Yes, through an adapter |
+| [ctx](https://ctx.rs) | Session archive index: searches earlier session text and treats summaries as claims. | Yes, through an adapter |
+| Git | Source of truth: charters, decisions, runbooks, lineage, and worktree isolation. | No |
+
+The optional skill layer is raised during onboarding. Declining all of it is normal; every script here runs with the base environment. The recommended set has four roles: method guidance, lifecycle hooks, task commands, and durable state. Some Claude Code plugins in that set edit user configuration during install, so onboarding prints commands for the human to run.
+
+One integration note if you adopt a context monitor: its warning thresholds can fire before this project's succession threshold. Record in your charter that the warning is advisory, or patch the monitor knowing updates can restore the managed file.
 
 Agents: ground Orca claims in the [Orca docs snapshot agent index](https://grok-wiki.com/public/docs/stablyai-orca-2036d532bf1c/llms.txt) before improvising; the link hash may change with snapshot updates.
 
+## What one dispatch looks like
 
-### What one dispatch actually looks like
+1. **A contract file becomes the dispatch brief.** The work lives in a file. The file is hashed, recorded with the gate decision, and carried with the task so the claim can be checked later.
+2. **The dispatch gate measures budget.** `scripts/dispatch-gate check` reads the runtime, model, contract, estimated characters, completion channel, and policy file. A deny reason stops dispatch and is written to the JSONL ledger.
+3. **Task creation makes work into state.** `orca orchestration task-create --spec <text>` creates a task id inside Orca's state machine.
+4. **A worktree and terminal isolate the worker.** `orca worktree create --name <name>` creates a separate checkout. `orca terminal create --worktree <selector>` opens the worker shell there.
+5. **Dispatch binds task to terminal.** `orca orchestration dispatch --task <id> --to <handle> --inject` attaches the task to the terminal and delivers the worker preamble. The dispatch record stays separate from the shell effect.
+6. **Registration measures the running worker.** `scripts/dispatch-gate register` probes the worker session and compares the measured model with the declared model.
+7. **Completion arrives through the mailbox.** The coordinator waits on `orca orchestration check --wait`. The worker sends `worker_done`, and the Run mailbox wakes the coordinator.
+8. **Acceptance comes from re-verification.** The worker report is a claim. The coordinator re-runs gates, reads diffs, examines artifacts, and checks redaction scans.
 
-This section walks a single supervised dispatch end to end for readers who understand what supervised dispatch means in principle but have never watched the state objects come into being. No re-argument for [why Orca is required](#why-orca-is-required); link that section instead. Assume an engineer who has never seen this system.
+This separation paid for itself when an inject returned `dispatched` while the worker terminal was still on its startup screen. The Dispatch object and shell effect could be compared, the task was reset to ready, the brief was sent again, and the prompt was confirmed before the record was trusted.
 
-1. **A contract file becomes the dispatch brief.** The work lives in a file, not in prose. The file is hashed; that hash is recorded with the gate decision and travels with the task, so any reader can re-verify the claim against the original file later. A conversation, by contrast, disappears when the terminal closes and cannot be audited after the fact by anything but a human who was listening.
+## What is standing guard
 
-2. **The dispatch gate measures budget.** `scripts/dispatch-gate check` runs the caller's model and contract through a policy file (`master-ops/model-tier-policy.json`). The gate resolves the model to a tier, looks at how many agents have run in this tier's window, and compares the tally against the cap. It returns a decision with a reason code; deny stops the dispatch entirely, not as a warning. The decision goes into a JSONL ledger.
+The expanded guard inventory is [`docs/public/defense-inventory.md`](docs/public/defense-inventory.md).
 
-3. **Task creation makes work into state.** `orca orchestration task-create --spec <text>` creates an orchestration task object. The task receives a stable id and enters Orca's state machine. It is a thing that can be queried, monitored, and reported on, not a line of text in a terminal.
+- **Dispatch gate, tier x fan-out, ledgered decisions.** `scripts/dispatch-gate` with `master-ops/model-tier-policy.json` caps agents per tier over a rolling window. Top-tier dispatch is an owner-approval question in `master-ops/scripts/dispatch --top-approved`. Dry-run checks use `--no-record`.
+- **Model identity from transcripts.** `scripts/model-identity-probe` samples recent assistant turns. `scripts/model-drift-audit` walks the transcript for transitions. TUI status lines are renderer output.
+- **Placement verification before master spawn.** `scripts/master-succeed spawn --expected-placement` fail-closes on worktree mismatch with exit 26 and `SPAWN_PLACEMENT_MISMATCH`. The placement three-set is in `master-ops/docs/runbooks/succession-boot-card.md`; the motivating failure is in `docs/public/orca-concepts.md`.
+- **Empty-seat gate against duplicate masters.** Founding spawn requires zero terminals in the seat. Runtime duplicate detection is `scripts/master-succeed check-duplicates`.
+- **Redaction gates that name blind spots.** `scripts/redaction-scan.sh` prints scope and rules loaded. `REDACTION_REQUIRE_EXTRA=1` exits 2 when organization rules are missing. `scripts/redaction-inventory` reports uncovered candidates.
+- **Revival checks for frozen sessions.** Retirement is complete only when process, pane, and tty are measured gone. Boot scans lineage session ids for revived processes.
+- **Progressive onboarding.** `master-ops/ONBOARDING.md` is a router. It loads one file under `master-ops/onboarding/` per turn, and the next file opens only after Verify.
 
-4. **A worktree and terminal isolate the worker.** `orca worktree create --name <name>` spawns a separate git checkout. `orca terminal create --worktree <selector>` opens a shell prompt inside that checkout. Two workers cannot collide because they cannot share a working tree.
+## Try the core without setup
 
-5. **Dispatch binds task to terminal and delivers the brief.** `orca orchestration dispatch --task <id> --to <handle> --inject` attaches the task to the terminal's session and delivers the preamble (which tells the worker how to report, where the Run mailbox is, and what the dispatchId is). The dispatch decision itself stays separate from the delivery mechanism; "dispatched" status in the record is not proof the preamble actually landed in the worker's shell.
-
-6. **Registration measures what is actually running.** After the worker starts, `scripts/dispatch-gate register` runs a caller-supplied probe command against the worker's session record. The probe reads the model that is actually running and compares it with the model declared at gate-check time. When the measured model is stricter (more expensive, with a tighter per-tier cap) than declared, the gate denies the task; running cheaper than declared warns and is allowed. An unverifiable probe warns and records anyway, so a runtime that cannot report its model does not get forced into a false-positive gate.
-
-7. **Completion comes through the mailbox, not the screen.** The coordinator calls `orca orchestration check --wait` and blocks. No polling loop, no watching the worker's terminal. When the worker sends `worker_done` through `orca orchestration send --type worker_done`, the message lands in the Run's mailbox. The check call unblocks and returns it.
-
-8. **The worker's report is a claim; acceptance comes from re-verification.** `worker_done` says the task is complete. But a dispatch record is not evidence of what the worker actually produced. Acceptance requires the coordinator to re-run the gates, read the diff, examine the artifacts, and check the redaction scan. Self-report is not proof.
-
-This design resolves a failure mode that cost time to debug: an inject returned a dispatched status while the worker terminal was still on its startup screen. The dispatch record showed dispatched and silent (no heartbeat). It was caught because the state object (the Dispatch) and the effect (the shell prompt landing) are separate things that can be compared. The recovery that worked: reset the task to ready, send the brief again with `orca terminal send`, and confirm the prompt actually appeared before trusting the record. The machinery is only as good as the reader's ability to compare the two.
-
-
-### What is standing guard
-
-The system is only as strong as the guards a reader can find. Each line below names a real path; the expanded table is [`docs/public/defense-inventory.md`](docs/public/defense-inventory.md).
-
-- **Dispatch gate, tier × fan-out, ledgered decisions.** `scripts/dispatch-gate` with `master-ops/model-tier-policy.json` caps agents per tier over a rolling window when a tier still has a cap; top-tier dispatch is an owner-approval question in `master-ops/scripts/dispatch --top-approved`. Normal decisions are appended to a JSONL ledger with the policy path and its `sha256`; dry-run checks use `--no-record`. See `master-ops/docs/MASTER-OPERATIONS.md` §5 and §9.
-- **Model identity from transcripts, never status lines.** `scripts/model-identity-probe` samples recent assistant turns; `scripts/model-drift-audit` walks the whole transcript for transitions. A TUI status line is a renderer drawing, not a measurement (`master-ops/docs/MASTER-OPERATIONS.md` §5, §9).
-- **Placement verification before any master spawn.** `scripts/master-succeed spawn --expected-placement` fail-closes on worktree mismatch (exit 26, `SPAWN_PLACEMENT_MISMATCH`). The placement three-set is in `master-ops/docs/runbooks/succession-boot-card.md`; the misplacement that paid for the flag is in `docs/public/orca-concepts.md`.
-- **Empty-seat gate against duplicate masters.** Founding spawn requires zero terminals in the seat (`master-ops/onboarding/09-spawn.md`); runtime duplicate detection is `scripts/master-succeed check-duplicates`.
-- **Redaction gates that name their blind spots.** `scripts/redaction-scan.sh` prints scope and rules loaded; `REDACTION_REQUIRE_EXTRA=1` exits 2 when organization rules are missing instead of going green on generics alone. `scripts/redaction-inventory` asks the inverse (exit 1 for uncovered candidates is the normal finding).
-- **Revival checks for frozen sessions.** Retirement is complete only when process, pane, and tty are measured gone; boot scans lineage session ids for revived processes (`master-ops/docs/runbooks/succession-boot-card.md`). Paid for by four retired masters revived at once from a mobile resume.
-- **Progressive onboarding that survived a real model meltdown.** `master-ops/ONBOARDING.md` is a router; one file under `master-ops/onboarding/` per turn, next file only after Verify. Measured 2026-08-03: one model drowned in the monolith, one improvised past steps (`master-ops/CHANGELOG.md`, progressive-load split).
-
-
-<details><summary>Prefer to poke at it before installing anything</summary>
-
-The core is stdlib-only, so you can call it without Orca and without setup. You will not get a master session this way, just the pure functions.
+The core is stdlib-only. These commands exercise pure functions without creating a master session.
 
 ```console
-$ cd mogui-ADE-orchestrator
 $ scripts/master-succeed detect "routine status update" --context-ratio 0.7 --json
 $ scripts/dispatch-gate --ledger /tmp/gate.jsonl check \
   --runtime codex --model grok-4.5 --contract README.md --agents 1 --est-chars 1000 \
   --completion-channel orchestration
 $ scripts/adapter doctor
 ```
-
-</details>
-
-## Why this exists
-
-Run one long-lived session as the orchestrator of a multi-repository workspace and three failure modes appear that repo-level tooling does not cover.
-
-1. **Sessions end, work does not.** Context fills, sessions crash, sessions get compacted. Pasting a summary into a fresh session loses role state, open tracks, and standing decisions. You find out when the successor repeats a question you answered, or reopens a decision you made.
-2. **A master that can spawn workers can waste them.** Delegation is cheap to trigger and expensive to run. Without a gate, duplicate dispatches, oversized inputs, and dispatches into the wrong tree all go through, and nothing says so.
-3. **Context loss after compaction is invisible.** The session reads as continuous while state is gone. Re-feed everything at boot and you lose the one chance to find out what it still holds.
-
-This runtime treats all three as testable. Succession is a guarded procedure. Lineage is an append-only ledger with a fixed schema. Worker dispatch needs a readable contract and passes budget and routing checks. The boot path withholds state after compaction to probe recall.
 
 ## How it fits together
 
@@ -152,11 +132,11 @@ flowchart TB
     G -.->|"boot"| M2
 ```
 
-Solid arrows are orchestration. Dotted arrows are you. The panes are real terminals, take any of them over.
+Solid arrows are orchestration. Dotted arrows are direct human control. The panes are real terminals, and you can take over any of them.
 
 ## Sibling project
 
-Two layers, split by unit of operation. This repository owns the workspace. [mogui-agent-harness](https://github.com/baksohyeon/mogui-agent-harness) owns one repository.
+Two layers split by unit of operation. This repository owns the workspace. `mogui-agent-harness` owns one repository.
 
 ```mermaid
 flowchart LR
@@ -169,205 +149,129 @@ flowchart LR
     A -->|"contract, never source coupling"| B
 ```
 
-| | mogui-agent-harness | mogui-ADE-orchestrator (this repo) |
-|---|---|---|
-| Layer | Repository Harness (repo-local runtime) | Workspace Master Runtime |
+| | mogui-agent-harness | mogui-ADE-orchestrator |
+| --- | --- | --- |
+| Layer | Repository Harness | Workspace Master Runtime |
 | Unit of operation | one repository | a workspace of many repositories |
 | Owns | repo-local rules, hooks, wiki, runbooks | orchestration state, roles, succession, lineage |
 
 Either runs alone. Use both when a track crosses repositories and each repository still needs its own rules.
-
-## Scope
-
-Local only.
-
-- No network calls. Every import in `src/` and `scripts/` is standard library, none of them networking. `git grep -nE "^[[:space:]]*(import|from)[[:space:]]+(urllib|http|socket|ssl|requests)" -- src scripts` returns nothing.
-- No API key, no model endpoint, no telemetry.
-- Reads the folder you point it at and paths you name in config. Nothing walks your home directory. Redaction scanners read one repository's tracked files through `git ls-files`.
-- The CLIs it drives reach their own providers as before. No traffic added.
-- Master starts with approval prompts off, to run unattended. Shift-Tab cycles the mode.
-
-## Limitations
-
-- **Master starts under Claude Code out of the box.** The spawn path in `core/succession.py` calls `claude`. Nothing in the design depends on that, and pointing the line at another CLI is a small change. Claude Code is what has been run, so it is what is recommended.
-- **Workers can be any CLI.** A worker is a terminal session in an Orca pane, so it is whatever binary starts there. Claude, Codex, Cursor, Grok, Gemini have all run this way under contract. No plugin for any of them.
-- **Codex as master should work, and nobody has tried it.** Untested rather than unsupported. If you run it, a report or a patch is welcome.
-- **macOS is what this has been run on.** Orca itself ships Linux and Windows builds, and one user has reported the install working on Linux. Neither is exercised here, so reports are useful.
-- **Orca required** for live sessions. Pure functions run without it.
-
-## Alternatives
-
-**If you are going to use an API key, use [LangChain deepagents](https://docs.langchain.com/oss/python/deepagents/overview).** It is well documented and it solves this problem inside your process. This project is for the other case: you already pay for coding-agent CLIs and you want one orchestrator driving all of them, with no key and no per-token bill.
-
-| | LangChain deepagents | this |
-| --- | --- | --- |
-| Cost model | API key, billed per token | your existing CLI subscription |
-| Subagent | an actor inside the process | a real CLI session under a contract |
-| Filesystem | virtual, pluggable backend | a git worktree |
-| Approval | a runtime callback | a gate a human holds |
-| Orchestrator dies | the graph dies with it | the successor takes the role and proves it |
-
-The order of events matters for reading this table. This system was designed and built first; Dorito learned deepagents existed when its announcement landed two weeks into the work. Dorito then ran the comparison on purpose, reading their code and documentation and checking this system against their published spec, and the two turned out to decompose the same problem the same way: two teams staring at the same failure modes converged, with no lineage in either direction. The repository history is consistent with that reading: `git log -S deepagents --reverse` shows when the comparison entered, well after the architecture did.
-
-## What this runs on
-
-### Why Orca
-
-A master that outlives one session needs somewhere to live. A terminal tab does not qualify. [Orca](https://www.onorca.dev/download) does, and it is the one dependency this project does not abstract away.
-
-- **Sessions outlive the window.** Close the tab, restart the app, come back tomorrow. The session is there, with a handle you can read, write to, and retire. Succession is auditable because the predecessor stays addressable while you verify the successor.
-- **Warm context is money.** A long-lived session keeps its prompt cache warm. Respawning for every task pays the context tax again.
-- **Many agents, many accounts.** Run several CLI agents side by side on different runtimes and accounts. Switch when one runs out of credit. A worker's quota does not kill the orchestrator.
-- **Placement is addressable.** Every pane carries a worktree identity. "Which folder did that worker run in" has an answer you can check.
-- **Reachable from anywhere.** Put it behind Tailscale and the same sessions answer from another machine. Long jobs do not need you at the laptop that started them.
-
-Without this substrate you can read the ideas here. You cannot run a master that survives its own session.
-
-### The tools this actually runs on
-
-Vendor-neutral here means the master is not tied to one *AI agent host*. It does not mean the tooling is a mystery. These are the real dependencies, by name.
-
-| Tool | What it does here | Replaceable? |
-| --- | --- | --- |
-| [Orca](https://www.onorca.dev/download) | Execution substrate. Terminal sessions that outlive the window, worktree-scoped placement, dispatch and retirement of worker panes. | No. Everything about session lifetime assumes it. |
-| [beads](https://github.com/gastownhall/beads) (`bd`) | Work ledger. Tracks, issues, dependencies, and the memory block the boot path audits. `master-bootstrap-live` shells out to `bd` for active-track lines. | Yes, through the adapter. Any tracker with a CLI that lists issues by status works. |
-| [ctx](https://ctx.rs) | Session archive index. Lets a master search what an earlier session actually said instead of trusting a summary of it. | Yes, through the adapter. |
-| Git | Long-term source of truth. Charters, decisions, runbooks, lineage. Worktrees are also the isolation primitive for workers. | No. |
-
-The split matters: `core/` never learns these names, `adapter/` wires them, and swapping one means writing an adapter rather than editing the units. `adapter/profile.py` currently ships synchronous CLI profiles for `codex` and `cursor-agent`; that is the layer where an agent host gets named, and it is the only one.
-
-### The skill layer it runs under
-
-Nothing to do before you start. Onboarding raises this during setup, explains each one, and asks. Declining all of it is a normal answer. Every script here runs with none of it installed.
-
-Listed here so the recommendation is readable before you are asked. Vendor neutrality covers agent hosts, not tooling.
-
-Optimized for Claude Code. These are Claude Code plugins and skills. Workers can be Codex or another CLI and the adapter ships a `codex` profile. The orchestrator side assumes Claude Code.
-
-| Layer | Tool | What it does in the harness |
-| --- | --- | --- |
-| Method | [superpowers](https://github.com/obra/superpowers) | Puts process ahead of code. A SessionStart hook injects a rule that a relevant skill must be invoked before any response, including clarifying questions. Ships brainstorming, plan writing and execution, TDD, systematic debugging, code review on both sides, and verification before completion. |
-| Lifecycle | [GSD](https://github.com/open-gsd/gsd-core) | The largest harness footprint of the four. A spec to plan to execute to verify command set, plus around a dozen hooks: a statusline, a context monitor that warns the agent rather than only the user as the window fills, prompt-injection scanners over both written and read content, a guard that blocks writes outside the worktree root, and commit validation. |
-| Commands | [gstack](https://github.com/garrytan/gstack) | Task commands rather than methodology: ship, review, QA, headless-browser dogfooding, plan review from CEO, engineering, and design angles, context save and restore. |
-| State | [beads](https://github.com/gastownhall/beads) | Listed in the table above. The boot path already shells out to it. |
-
-Say yes and onboarding prints the command for you to run. GSD's installer edits `~/.claude/settings.json` and wires hooks across most lifecycle events. An agent should not do that to your configuration.
-
-One integration note if you adopt GSD. Its context monitor warns the agent at 35% context remaining and escalates at 25%, well before the succession threshold this project recommends. Left alone, a master is told to stop and save state while its charter says to keep working. Record in your charter that the warning is advisory and not a succession trigger. Editing the thresholds in `gsd-context-monitor.js` also works, but the file is GSD-managed and an update restores it; `/gsd-update --reapply` offers the patch back, and the offer is easy to skip. The charter line survives updates.
 
 ## Which document do you want?
 
 | You are | Start here |
 | --- | --- |
 | Reading about the system for the first time | [`docs/public/overview.md`](./docs/public/overview.md) |
-| Installing it on your own machine (human path) | [`docs/public/getting-started.md`](./docs/public/getting-started.md) |
-| Agent-executed onboarding steps (after the wake-up) | [`master-ops/ONBOARDING.md`](./master-ops/ONBOARDING.md) |
-| Looking for a specific document | [`docs/README.md`](./docs/README.md) (the document index) |
+| Installing it on your own machine | [`docs/public/getting-started.md`](./docs/public/getting-started.md) |
+| Agent-executed onboarding steps after wake-up | [`master-ops/ONBOARDING.md`](./master-ops/ONBOARDING.md) |
+| Looking for a specific document | [`docs/README.md`](./docs/README.md) |
 | Confused by Orca projects, workspaces, or an "Unavailable worktree" label | [`docs/public/orca-concepts.md`](./docs/public/orca-concepts.md) |
-| Reading the code | [Architecture](#architecture) below, then `src/master_runtime/core/` |
+| Reading the code | [Architecture](#architecture), then `src/master_runtime/core/` |
 
-Documentation in this repository is English. `master-ops/` is a template that gets copied and substituted during onboarding, not documentation about this repository. See the index for why the two are separate.
+Documentation in this repository is English. `master-ops/` is a template copied and substituted during onboarding. See the index for why the two are separate.
 
 ## Status
 
-Working and exercised, as of 2026-08-03: 441 unit tests pass, none skipped. Every
-unit listed below exists in `src/master_runtime/core/`. The succession,
-dispatch-gate, acceptance, and compaction paths have run against real
-workspaces, and onboarding has been run start to finish by someone other than
-its author.
+Working and exercised, as of 2026-08-03: 441 unit tests pass, none skipped. Every unit listed below exists in `src/master_runtime/core/`. Succession, dispatch-gate, acceptance, compaction, and onboarding paths have run against real workspaces.
 
-The current release is in `CHANGELOG.md`, which records every version since
-0.1.0. No CI: tests and the redaction scanners run locally before a push, so
-a passing count in a pull request is the author's word. While the major version
-is 0, interfaces, CLI flags, and file formats can change in a minor release.
-Pin a version if you build on it.
+The current release is in `CHANGELOG.md`, which records every version since `0.1.0`. No CI: tests and redaction scanners run locally before push, so a passing count in a pull request is the author's word. While the major version is 0, interfaces, CLI flags, and file formats can change in a minor release. Pin a version if you build on it.
 
-The template that onboarding copies is versioned separately at
-`master-ops/TEMPLATE-VERSION`; `master-ops/CHANGELOG.md` records what each
-version changed. A generated operations repository does not update when the
-template does, so that number is how an installation says where it came from.
+The template that onboarding copies is versioned separately at `master-ops/TEMPLATE-VERSION`; `master-ops/CHANGELOG.md` records each version. A generated operations repository keeps the template version it copied until you apply an upgrade.
 
 ## Core concepts
 
 ### Succession
 
-`src/master_runtime/core/succession.py` implements master-to-master handoff as an explicit, guarded procedure rather than a copy-paste. `detect_trigger()` classifies signals into `IMMEDIATE` (explicit user instruction), `ADVISORY` (context usage ratio at or above the `0.60` default, or a natural milestone; advisory triggers **never** auto-start succession, they only propose it), or `NONE`. The flow then builds a handoff, spawns the successor, verifies the successor booted with the inherited state (`PASS` / `PARTIAL` / `FAILED`), checks for duplicate master instances, and retires the predecessor. Hard safety violations raise `SuccessionError` instead of proceeding.
+`src/master_runtime/core/succession.py` implements master-to-master handoff as an explicit guarded procedure. `detect_trigger()` classifies signals into `IMMEDIATE`, `ADVISORY`, or `NONE`. Advisory triggers include context usage ratio at or above the `0.60` default and natural milestones. Advisory triggers only propose succession.
 
-The advisory ratio is a code default, not a claim about what any given workspace should use; an operating charter can set its own threshold.
+The flow builds a handoff, spawns the successor, verifies inherited state, checks for duplicate master instances, and retires the predecessor. Hard safety violations raise `SuccessionError`.
 
 ### Lineage
 
-`src/master_runtime/core/lineage.py` keeps an append-only markdown ledger of every succession: generation number, parent/successor session IDs, inherited role and open tracks, verification result, and honesty metrics such as `repeated_question_count`, `reopened_decision_count`, and a `context_loss_summary`. The schema is fixed (13 required fields), duplicate generations are rejected, and every write is re-verified as append-only. By design, lineage is observability metadata only; it never feeds runtime decisions.
+`src/master_runtime/core/lineage.py` keeps an append-only markdown ledger of every succession: generation number, parent and successor session ids, inherited role and open tracks, verification result, repeated-question count, reopened-decision count, and context-loss summary.
+
+The schema has 13 required fields. Duplicate generations are rejected, and every write is re-verified as append-only. Lineage is observability metadata; it never feeds runtime decisions.
 
 ### Contract-gated dispatch
 
-`src/master_runtime/core/dispatch_gate.py` sits between the master and any worker dispatch. A dispatch request (runtime, model, contract file path, estimated input characters, agent count, completion channel) is resolved to a `GateDecision` with a stable reason code: `OK`, `BUDGET_EXCEEDED` (defaults: 500k chars single / 1M batch), `TIER_FANOUT_CAP` (the model's tier has a fan-out cap measured over a rolling window; overrides are ledgered), `NO_COMPLETION_CHANNEL`, `CONTRACT_UNREADABLE`, `PATH_OUTSIDE_KNOWN_ROOTS`, and others. Repeated contract hashes are allowed and recorded as hash-plus-attempt lineage in the JSONL ledger, so legitimate retries keep their provenance without becoming denials. `register` verifies the job id against an artifact probe and measures the worker's actual model rather than trusting the declaration. Normal checks write each decision to the ledger, while dry-run callers use `check --no-record` so inspection does not spend fan-out budget.
+`src/master_runtime/core/dispatch_gate.py` sits between the master and any worker dispatch. A dispatch request resolves to a `GateDecision` with a stable reason code such as `OK`, `BUDGET_EXCEEDED`, `TIER_FANOUT_CAP`, `NO_COMPLETION_CHANNEL`, `CONTRACT_UNREADABLE`, or `PATH_OUTSIDE_KNOWN_ROOTS`.
+
+Repeated contract hashes are allowed and recorded with attempt ordinals. `register` verifies the job id against an artifact probe and measures the worker's actual model. Dry-run callers use `check --no-record`.
 
 ### Acceptance loop
 
-`src/master_runtime/core/acceptance/` runs candidate changes against a casebook and produces a scorecard instead of trusting a worker's completion report. Raw case results and aggregated scores are separate types, the casebook owns which split a case belongs to (an evaluator cannot relabel its own case), and holdout visibility is a single predicate so the private-holdout invariant cannot drift. Candidates that change nothing still produce a decision record.
+`src/master_runtime/core/acceptance/` runs candidate changes against a casebook and produces a scorecard. Raw case results and aggregate scores are separate. The casebook owns which split a case belongs to. Candidates that change nothing still produce a decision record.
 
-### Compaction-resilience probe (E12)
+### Compaction-resilience probe
 
-`scripts/master-bootstrap-live` is a session-start hook that emits a small (~1KB budgeted) dynamic bootstrap block and is written to never fail the boot (any internal error degrades to a `[BOOTSTRAP-FALLBACK]` line with exit code 0). When the incoming session event reports `source == "compact"`, the hook **suppresses** the Role State and active-tracks sections. The post-compaction session has to recall that state from its own context first, and you compare what it recalled against the ledger. That turns silent context loss into a number you can read.
+`scripts/master-bootstrap-live` emits a small dynamic bootstrap block and is written to degrade to a fallback line with exit code 0 on internal error. When the incoming session event reports `source == "compact"`, the hook suppresses Role State and active-track sections. The next session has to recall that state from its own context before the ledger comparison.
 
 ## Architecture
 
-```
+```text
 src/master_runtime/core/
 ├── bootstrap.py        # session boot: charter + handoff + role state, char-budgeted
-├── bootstrap_live.py   # live boot block for session-start hooks (audits, dual-instance check)
-├── succession.py       # trigger detection, handoff, spawn/verify/retire
+├── bootstrap_live.py   # live boot block for session-start hooks
+├── succession.py       # trigger detection, handoff, spawn, verify, retire
 ├── lineage.py          # append-only succession ledger
 ├── dispatch_gate.py    # contract-gated worker dispatch decisions
 ├── recovery.py         # recovery flow after abnormal termination
 ├── watchdog.py         # stall detection for dispatched work
-├── digest_loop.py      # read-only L1 digest loop for orchestrator observations
+├── digest_loop.py      # read-only L1 digest loop
 ├── work_ledger.py      # workspace track ledger and session cache
-├── context/            # pure filesystem context resolver (path -> ContextDescriptor)
+├── context/            # pure filesystem context resolver
 ├── approval/           # approval gates and registry
-├── acceptance/         # casebook-driven acceptance loop and scorecards
+├── acceptance/         # casebook-driven acceptance loop
 └── adapter/            # adapter layer: doctor, sync CLI profiles
 ```
 
 Two principles shape the layout:
 
-- **Core / adapter split.** `core/` modules avoid depending on any specific agent product; contact with the outside world (process spawning, ledgers, tool CLIs) goes through injected callables and the `adapter/` layer, so core logic is testable with in-memory fakes. Tool names live in `adapter/`, not in the units above it.
-- **Vendor neutrality as a direction.** The master should run under different AI agent hosts. The spawn path still names `claude`, so Claude Code is the host that has been exercised. The worker side is further along, with `adapter/profile.py` shipping synchronous CLI profiles for `codex` and `cursor-agent`. `adapter doctor` probes a fixed set of local tools, and some Korean-language operator strings are embedded. Broadening this is ongoing work.
+- **Core / adapter split.** `core/` modules avoid depending on any specific agent product. Process spawning, ledgers, and tool CLIs go through injected callables and `adapter/`, so core logic is testable with in-memory fakes.
+- **Vendor neutrality as a direction.** The master should run under different agent hosts. The spawn path still names `claude`, so Claude Code is the exercised host. The worker side is further along: `adapter/profile.py` ships synchronous CLI profiles for `codex` and `cursor-agent`. `adapter doctor` probes a fixed local tool set, and some Korean-language operator strings are embedded.
 
 ## Working on the harness
 
-To use the system, follow [Getting Started](docs/public/getting-started.md); the [Quickstart](#quickstart) only opens that path. This section is for changing the harness itself.
+To use the system, follow [Getting Started](docs/public/getting-started.md). This section is for changing the harness itself.
 
-Prerequisites: macOS and the `python3` it already has. The runtime is stdlib-only; there is nothing to install, and no version floor is enforced: the core imports and runs on the 3.9.6 a bare Mac ends up with. A tool that needs a more capable interpreter locates one itself at runtime, and the [Reference](docs/public/reference.md) table states each tool's behavior in its own row. The suite's collection imports `tomllib` (3.11+), so tests reach an older interpreter through `uv`, and tests are the agent's job either way.
+Prerequisites: macOS and the `python3` it already has. The runtime is stdlib-only. A tool that needs a more capable interpreter locates one itself at runtime, and the [Reference](docs/public/reference.md) table states each tool's behavior in its own row. The suite's collection imports `tomllib` and therefore needs Python 3.11 or newer.
 
-All CLI entry points live in `scripts/` and are self-contained (they insert `src/` on `sys.path` themselves):
+All CLI entry points live in `scripts/` and are self-contained:
 
 ```console
-# Classify a succession trigger signal (pure function, safe to try)
 $ scripts/master-succeed detect "routine status update" --context-ratio 0.7 --json
-# → {"status": "ADVISORY", "reason": "context ratio threshold reached", ...}
-
-# Ask the dispatch gate whether a worker dispatch may proceed
 $ scripts/dispatch-gate --ledger ./gate-ledger.jsonl check \
   --runtime codex --model grok-4.5 --contract ./job-contract.md \
   --agents 1 --est-chars 1000 --completion-channel orchestration
-# → {"allow": true, "reason": "OK", "contract_sha": "...", "cost_proxy": 1000}
-
-# Check which adapter-layer tools are present on this machine
 $ scripts/adapter doctor
-
-# Boot a master session from a charter document (add --handoff for a handoff file)
 $ scripts/master-bootstrap --charter path/to/charter.md --json
 ```
 
-Other entry points, briefly: `scripts/master-succeed` also provides `handoff`, `verify-successor`, `check-duplicates`, `retire`, and `spawn` subcommands; `scripts/master-recover` runs the recovery flow from a charter + handoff after abnormal termination; `scripts/master-bootstrap-live` is meant to be wired as a session-start hook rather than run by hand; `scripts/l1-digest tick` advances the read-only digest loop; `scripts/acceptance-loop` runs the acceptance casebook. Run any of them with `--help` for current flags.
+Other entry points: `scripts/master-succeed` also provides `handoff`, `verify-successor`, `check-duplicates`, `retire`, and `spawn`; `scripts/master-recover` runs recovery from a charter and handoff after abnormal termination; `scripts/master-bootstrap-live` is a session-start hook; `scripts/l1-digest tick` advances the read-only digest loop; `scripts/acceptance-loop` runs the acceptance casebook. Run any of them with `--help` for current flags.
 
-Tests are the agent's job. Ask the agent working on the harness to run them and report, the same way you ask it for anything else. There is no test step here for a person to type.
+Tests are the agent's job. Ask the agent working on the harness to run them and report.
+
+## Scope
+
+Local only.
+
+- No network calls. Every import in `src/` and `scripts/` is standard library, and none are networking imports. `git grep -nE "^[[:space:]]*(import|from)[[:space:]]+(urllib|http|socket|ssl|requests)" -- src scripts` returns nothing.
+- No API key, model endpoint, or telemetry.
+- Reads the folder you point it at and paths you name in config. Redaction scanners read one repository's tracked files through `git ls-files`.
+- The CLIs it drives reach their own providers as before. No traffic added.
+- Master starts with approval prompts off, to run unattended. Shift-Tab cycles the mode.
+
+## Limitations
+
+- **Master starts under Claude Code out of the box.** The spawn path in `core/succession.py` calls `claude`. Claude Code is what has been run, so it is what is recommended.
+- **Workers can be any CLI.** A worker is a terminal session in an Orca pane, so it is whatever binary starts there. Claude, Codex, Cursor, Grok, and Gemini have all run this way under contract. No plugin for any of them.
+- **Codex as master is untried.** It should work by design. If you run it, a report or patch is useful.
+- **macOS is the exercised platform.** Orca ships Linux and Windows builds, and one user reported the install working on Linux. Neither path is exercised here.
+- **Orca required** for live sessions. Pure functions run without it.
 
 ## What this is not
 
-This repo owns workspace-level orchestration state only. Repo-local rules, hooks, wikis, and runbooks belong to a repository-harness layer (see the sibling project above); the connection between the two layers is contract-based, never source-tree coupling. Submodules only ever appear as pinned example fixtures, never as core dependencies.
+This repo owns workspace-level orchestration state only. Repo-local rules, hooks, wikis, and runbooks belong to a repository-harness layer. The connection between the two layers is contract-based. Submodules appear only as pinned example fixtures.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Run one long-lived agent session as the master of a multi-repository workspace. 
 
 This is for people who already use coding-agent CLIs and want one supervised workspace layer above them. Any mix of worker CLIs can run in Orca terminals. Claude Code as the master is the path that has been exercised hardest.
 
-Existing installations: compare the `Template version` line in your operations repository's `docs/MASTER-OPERATIONS.md` with `master-ops/TEMPLATE-VERSION` in the current template, then read the matching entries in `master-ops/CHANGELOG.md`. Local edits win. Watching releases on this repository sends mail when that line moves.
+Existing installations: compare `TEMPLATE-VERSION` in your operations repository against `master-ops/TEMPLATE-VERSION` in the current template, then read the entries between them in `master-ops/CHANGELOG.md`. Local edits win.
 
 The orchestrating session is called the master in the docs. That is a role label. During install you pick a callsign for the live session, such as 자비스 / Jarvis, Friday, Alfred, HAL-but-nice, or another short name you will say out loud.
 

--- a/README.md
+++ b/README.md
@@ -14,13 +14,15 @@ First run is longer than cloning the repository. You install Orca, register its 
 
 Follow **[Getting Started](docs/public/getting-started.md)** for the measured checks, Orca vocabulary, onboarding decisions, proof of boot, and first supervised worker. The block below only opens that path.
 
+macOS:
+
 ```console
-$ brew install --cask stablyai/orca/orca
-$ git clone <repository-url>
-$ cd mogui-ADE-orchestrator
+brew install --cask stablyai/orca/orca
+git clone https://github.com/baksohyeon/mogui-ADE-orchestrator
+cd mogui-ADE-orchestrator
 ```
 
-Orca has Linux and Windows builds on its [download page](https://www.onorca.dev/download). `--cask` is macOS-only.
+Linux and Windows: install Orca from the [download page](https://www.onorca.dev/download), then clone the repository and enter the checkout.
 
 Open Orca and turn on **Settings > Orca CLI > Shell command**, then confirm `orca status` shows a ready runtime. Add the folder to Orca, open a terminal in this clone, start your agent CLI, and wake it with a setup phrase, for example `Wake the master.` The agent becomes the onboarding guide.
 
@@ -40,7 +42,7 @@ Failing the first three usually means a subscription presented as a dependency. 
 
 The workspace layer addresses three failures in long-lived coordination. Sessions end while work continues. A master that can spawn workers can waste them. Context loss after compaction can look like continuity. This runtime turns those failures into checks: guarded succession, append-only lineage, contract-gated dispatch, and boot probes that hold back state after compaction so recall can be measured.
 
-Orca is required for live operation. A master needs session lifetime, stable terminal handles, worktree-scoped placement, a durable Run mailbox, and supervised dispatch. Without Orca, the harness falls back to screen-polling and an unsupervised agent. Step 0 preflight refuses to proceed without it.
+Orca is required for live operation. A master needs session lifetime, stable terminal handles, worktree-scoped placement, a durable Run mailbox, and supervised dispatch. Step 0 preflight refuses to proceed until `orca status` reports a usable runtime.
 
 | Surface | Without Orca | With Orca |
 | --- | --- | --- |
@@ -172,7 +174,7 @@ Documentation in this repository is English. `master-ops/` is a template copied 
 
 ## Status
 
-Working and exercised, as of 2026-08-03: 441 unit tests pass, none skipped. Every unit listed below exists in `src/master_runtime/core/`. Succession, dispatch-gate, acceptance, compaction, and onboarding paths have run against real workspaces.
+Working and exercised, as of 2026-08-08: the repository test gate reports 579 passed tests and 13 passed subtests. Succession, dispatch-gate, acceptance, compaction, and onboarding paths have run against real workspaces.
 
 The current release is in `CHANGELOG.md`, which records every version since `0.1.0`. No CI: tests and redaction scanners run locally before push, so a passing count in a pull request is the author's word. While the major version is 0, interfaces, CLI flags, and file formats can change in a minor release. Pin a version if you build on it.
 
@@ -234,7 +236,7 @@ Two principles shape the layout:
 
 To use the system, follow [Getting Started](docs/public/getting-started.md). This section is for changing the harness itself.
 
-Prerequisites: macOS and the `python3` it already has. The runtime is stdlib-only. A tool that needs a more capable interpreter locates one itself at runtime, and the [Reference](docs/public/reference.md) table states each tool's behavior in its own row. The suite's collection imports `tomllib` and therefore needs Python 3.11 or newer.
+Prerequisites: macOS and Python 3.11 or newer for the test suite. The runtime is stdlib-only. A tool that needs a more capable interpreter locates one itself at runtime, and the [Reference](docs/public/reference.md) table states each tool's behavior in its own row. Contributors can select Python through `uv`, `pyenv`, or the system developer tools.
 
 All CLI entry points live in `scripts/` and are self-contained:
 
@@ -255,10 +257,10 @@ Tests are the agent's job. Ask the agent working on the harness to run them and 
 
 Local only.
 
-- No network calls. Every import in `src/` and `scripts/` is standard library, and none are networking imports. `git grep -nE "^[[:space:]]*(import|from)[[:space:]]+(urllib|http|socket|ssl|requests)" -- src scripts` returns nothing.
+- Repository code makes no direct network calls. Every import in `src/` and `scripts/` is standard library, and none are networking imports. `git grep -nE "^[[:space:]]*(import|from)[[:space:]]+(urllib|http|socket|ssl|requests)" -- src scripts` returns nothing.
 - No API key, model endpoint, or telemetry.
 - Reads the folder you point it at and paths you name in config. Redaction scanners read one repository's tracked files through `git ls-files`.
-- The CLIs it drives reach their own providers as before. No traffic added.
+- The CLIs it drives may reach their own providers. This project adds no provider traffic.
 - Master starts with approval prompts off, to run unattended. Shift-Tab cycles the mode.
 
 ## Limitations

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Run one long-lived agent session as the master of a multi-repository workspace. 
 
 This is for people who already use coding-agent CLIs and want one supervised workspace layer above them. Any mix of worker CLIs can run in Orca terminals. Claude Code as the master is the path that has been exercised hardest.
 
-Existing installations: compare `TEMPLATE-VERSION` in your operations repository against `master-ops/TEMPLATE-VERSION` in the current template, then read the entries between them in `master-ops/CHANGELOG.md`. Local edits win.
+Existing installations: compare the `template_version` field in your operations repository `MANIFEST.json` against `master-ops/TEMPLATE-VERSION` in the current template, then read the entries between them in `master-ops/CHANGELOG.md`. Local edits win.
 
 The orchestrating session is called the master in the docs. That is a role label. During install you pick a callsign for the live session, such as 자비스 / Jarvis, Friday, Alfred, HAL-but-nice, or another short name you will say out loud.
 


### PR DESCRIPTION
## Problem

On 2026-08-08, `README.md` measured 374 lines and 27 headings. `## Why these tools` appeared before `## Quickstart`, and seven sections covered tool rationale, Orca rationale, project purpose, alternatives, runtime substrate, and tool dependencies.

## Why this approach

The required reading order was product summary, Quickstart, then tool rationale. A single `## Why these tools` section now carries the distinct facts from the seven overlapping sections, and reference material follows the argument.

## What this changes

- Reorders the README so the opening flow is product summary, `## Quickstart`, then `## Why these tools`.
- Consolidates `## Why these tools`, `### Why Orca is required`, `## Why this exists`, `## Alternatives`, `## What this runs on`, `### Why Orca`, and `### The tools this actually runs on` into one `## Why these tools` section.
- Keeps `## Scope`, `## Limitations`, `## What this is not`, and `## License`.
- Adds an `[Unreleased]` changelog entry for the public README change.
- Leaves `master-ops/` files untouched.

## Expected effect

Reviewers can read `README.md` top to bottom and reach setup before the tool rationale. The root README now measures 278 lines, down from 374, and the overlapping rationale headings now resolve to one `## Why these tools` section.

## Testing

- [x] `PYTHONPATH=src python -m pytest tests -q` — 579 passed, 13 subtests passed, exit 0
- [x] Docs-only structure change; pytest plus README link validation cover the touched surface
- [x] New files staged before scan; no new files in this PR

## Review

Self-review checked README headings, changed-line public-surface patterns, and whitespace with `git diff --check`. README relative link validation checked 11 links including anchors and image paths; missing links were 0. `scripts/redaction-scan.sh` ran and found 0 generic-pattern findings across 260 tracked files; organization-specific rules were unloaded, so the scan scope was generic-only.

## Changelog

Root `CHANGELOG.md` has an `[Unreleased]` entry for the README restructure.

## Template impact

none

## Notes

Line count: 374 before, 278 after. Section count: 27 before, 21 after.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restructured the root `README.md` to lead with the product summary and Quickstart, with one clear “Why these tools” rationale and a tighter dispatch/guard walkthrough. Updated upgrade guidance to read the ops repo `MANIFEST.json` `template_version`, clarified cross‑platform setup, and kept tests/runtime notes current.

- **Refactors**
  - Reordered opening flow; consolidated overlapping rationale; kept Scope, Limitations, What this is not, and License.
  - Quickstart clarified: macOS via Homebrew and Linux/Windows paths; fixed Settings > Orca CLI > Shell command; added `orca status`, master callsign, and Getting Started as the path.
  - Rationale updated: requirements table (incl. Placement); replaceability for Orca/`bd`/`ctx`/Git; noted `LangChain deepagents` as the API‑key alternative; optional skill‑layer and context‑monitor guidance.
  - Dispatch/guards tightened: 8‑step dispatch walk‑through, trimmed defense inventory, and “Try the core without setup.”
  - Upgrade guidance corrected: compare ops `MANIFEST.json` `template_version` to `master-ops/TEMPLATE-VERSION` and review `master-ops/CHANGELOG.md`; generated ops repos keep their template version until you apply upgrades.
  - Misc: tests require Python 3.11+ (runtime stays stdlib‑only); sibling project referenced as `mogui-agent-harness`; added an `[Unreleased]` changelog entry; no `master-ops/` changes.

<sup>Written for commit a1d850b909fd171f079d1de7061793ae6303591e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/baksohyeon/mogui-ADE-orchestrator/pull/101?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a product summary, Quickstart guidance, and tool rationale to the README.
  * Clarified installation, platform requirements, setup-free commands, operational terminology, and getting-started resources.
  * Improved documentation for workflows, architecture, core concepts, scope, limitations, and project boundaries.
  * Updated navigation, comparison tables, implementation details, and current status information.
  * Consolidated overlapping tooling explanations and added an Unreleased changelog entry summarizing these improvements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->