### PR TITLE
docs: collapse readme quickstart

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,28 +10,18 @@ The orchestrating session is called the master in the docs. That is a role label
 
 ## Quickstart
 
-First run is longer than cloning the repository. You install Orca, register its shell command, put this repository in front of an agent, answer an onboarding interview, watch Generation 1 boot, then give the master one small task and watch it hand that task to a worker.
-
-Follow **[Getting Started](docs/public/getting-started.md)** for the measured checks, Orca vocabulary, onboarding decisions, proof of boot, and first supervised worker. The block below only opens that path.
-
-macOS:
-
-```console
-brew install --cask stablyai/orca/orca
-git clone https://github.com/baksohyeon/mogui-ADE-orchestrator
-cd mogui-ADE-orchestrator
-```
-
-Linux and Windows: install Orca from the [download page](https://www.onorca.dev/download), then clone the repository and enter the checkout.
+1. Clone the repository and add it to Orca as a folder.
 
 ```console
 git clone https://github.com/baksohyeon/mogui-ADE-orchestrator
 cd mogui-ADE-orchestrator
 ```
 
-Open Orca and turn on **Settings > Orca CLI > Shell command**, then confirm `orca status` shows a ready runtime. Add the folder to Orca, open a terminal in this clone, start your agent CLI, and wake it with a setup phrase, for example `Wake the master.` The agent becomes the onboarding guide.
+2. Open a terminal in that folder and start your agent CLI.
+3. Say `일어나라 마스터여` / `Wake the master.`
 
 ![Claude Code in Orca, opened on the cloned repository. The prompt reads "wake up, master." and the agent has started reading master-ops/ONBOARDING.md.](docs/assets/wake-up-master.png)
+When the three moves are done, or if one fails, continue with **[Getting Started](docs/public/getting-started.md)**.
 
 ## Why these tools
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,6 @@ Existing installations: compare the `template_version` field in your operations 
 The orchestrating session is called the master in the docs. That is a role label. During install you pick a callsign for the live session, such as 자비스 / Jarvis, Friday, Alfred, HAL-but-nice, or another short name you will say out loud.
 
 ## Quickstart
-
 1. Clone the repository and add it to Orca as a folder.
 
 ```console
@@ -21,6 +20,7 @@ cd mogui-ADE-orchestrator
 3. Say `일어나라 마스터여` / `Wake the master.`
 
 ![Claude Code in Orca, opened on the cloned repository. The prompt reads "wake up, master." and the agent has started reading master-ops/ONBOARDING.md.](docs/assets/wake-up-master.png)
+
 When the three moves are done, or if one fails, continue with **[Getting Started](docs/public/getting-started.md)**.
 
 ## Why these tools


### PR DESCRIPTION
## Problem

On 2026-08-09, `README.md` Quickstart measured 24 body lines before this branch. The section put installation and CLI setup before the three actions a reader needs after opening the repository in Orca.

## Why this approach

The owner constraint is a three-move Quickstart: clone and add the folder, open a terminal and start the agent CLI, then say the wake phrase. Onboarding code already performs runtime preflight, so setup detail belongs in the onboarding path.

## What this changes

- Collapses `README.md` Quickstart to the three requested moves.
- Keeps one `git clone` block, the wake screenshot, and the Getting Started link after the steps.
- Separates the screenshot and Getting Started link into distinct Markdown paragraphs.
- Leaves `master-ops/`, `docs/public/getting-started.md`, and `## Why these tools` unchanged.

## Expected effect

A reviewer can inspect `README.md` and see the Quickstart body at 14 lines with one clone block and no platform branch.

## Testing

- [x] `PYTHONPATH=src python -m pytest tests -q` passed with 579 tests and 13 subtests after the final README edit.
- [x] No failing test was added because this is a README-only contraction.
- [x] No new files were added.
- [x] `test -f docs/assets/wake-up-master.png && test -f docs/public/getting-started.md` confirmed the Quickstart image and relative link targets exist.
- [x] `grep -nE "/Users/|mgm-[a-z0-9]+" README.md` produced no output.

## Review

cubic reported three threads. One Markdown paragraph issue was fixed, the scoped-prerequisite suggestion was declined because the section is deliberately short for readers already in Orca, and the image-path report was declined after local path verification.

## Changelog

None. The contract allows only `README.md` changes.

## Template impact

none

## Notes

Before and after counts: Quickstart body 24 to 14 lines, file 285 to 275 lines. The coordinator's 25-line section count includes the heading; the body count here excludes it.