### PR TITLE
docs: trim readme opening

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,8 +31,6 @@ The harness accepts any agent behind a master that can reason. `AGENTS.md` and `
 
 Orca is the required execution substrate for live operation. It supplies session lifetime that outlives a window, stable terminal handles, worktree-scoped placement, a durable Run mailbox that survives restarts, a background receiver, supervised dispatch, and pane identity tied to a worktree. Step 0 preflight refuses to proceed until `orca status` reports a usable runtime.
 
-Orca is required. A live session has to outlive its window and be addressable by handle before this repository can orchestrate it. The preflight measures that in code.
-
 The Orca decision is also a labelled preference. It came from building this harness for a month and running it against other agent development environments. What they offered read as a subset of what Orca offers. That is a preference and it is recorded as one.
 
 For replaceable stack components, five questions decide what belongs in the stack:

--- a/README.md
+++ b/README.md
@@ -2,15 +2,11 @@
 
 > I have agents running in tmux sessions. Can I still drive each one manually when I want, and at the same time orchestrate all of those sessions from above? Is tmux-based agent orchestration a thing?
 
-Yes. That is what this is. The harness accepts any agent behind a master that can reason. `AGENTS.md` and `CLAUDE.md` ship byte-identical, and a repository test asserts it on every change. Claude Code is what this has been run on hardest.
+Yes. That is what this is.
 
 Anyone running more than two agents at once hits this. Dorito hit it, got tired of it, and wrote this.
 
 Clone it, open it in Orca, start an agent inside the clone, and tell it to wake up. The agent runs the install interview and explains as it goes.
-
-The system underneath is deep. The reader does not need to understand the machinery before using it, because the agent does. It guides the first run, explains each decision, and keeps the orchestration state in the workspace.
-
-Orca is required. A live session has to outlive its window and be addressable by handle before this repository can orchestrate it. The preflight measures that in code.
 
 ## Quickstart
 1. Clone the repository and add it to Orca as a folder.
@@ -31,7 +27,11 @@ When the three moves are done, or if one fails, continue with **[Getting Started
 
 The workspace layer addresses three failures in long-lived coordination. Sessions end while work continues. A master that can spawn workers can waste them. Context loss after compaction can look like continuity. This runtime turns those failures into checks: guarded succession, append-only lineage, contract-gated dispatch, and boot probes that hold back state after compaction so recall can be measured.
 
+The harness accepts any agent behind a master that can reason. `AGENTS.md` and `CLAUDE.md` ship byte-identical, and a repository test asserts it on every change. Claude Code is what this has been run on hardest.
+
 Orca is the required execution substrate for live operation. It supplies session lifetime that outlives a window, stable terminal handles, worktree-scoped placement, a durable Run mailbox that survives restarts, a background receiver, supervised dispatch, and pane identity tied to a worktree. Step 0 preflight refuses to proceed until `orca status` reports a usable runtime.
+
+Orca is required. A live session has to outlive its window and be addressable by handle before this repository can orchestrate it. The preflight measures that in code.
 
 The Orca decision is also a labelled preference. It came from building this harness for a month and running it against other agent development environments. What they offered read as a subset of what Orca offers. That is a preference and it is recorded as one.
 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ When the three moves are done, or if one fails, continue with **[Getting Started
 
 The workspace layer addresses three failures in long-lived coordination. Sessions end while work continues. A master that can spawn workers can waste them. Context loss after compaction can look like continuity. This runtime turns those failures into checks: guarded succession, append-only lineage, contract-gated dispatch, and boot probes that hold back state after compaction so recall can be measured.
 
-The harness accepts any agent behind a master that can reason. `AGENTS.md` and `CLAUDE.md` ship byte-identical, and a repository test asserts it on every change. Claude Code is what this has been run on hardest.
+The harness accepts any agent behind a master that can reason. `AGENTS.md` and `CLAUDE.md` ship byte-identical, and a repository test asserts it on every change. `claude` is one example CLI; Claude Code is the exercised host.
 
 Orca is the required execution substrate for live operation. It supplies session lifetime that outlives a window, stable terminal handles, worktree-scoped placement, a durable Run mailbox that survives restarts, a background receiver, supervised dispatch, and pane identity tied to a worktree. Step 0 preflight refuses to proceed until `orca status` reports a usable runtime.
 


### PR DESCRIPTION
## Problem

On 2026-08-09 KST, `README.md` had 14 lines between the H1 and `## Quickstart`. The second paragraph carried tool-compatibility, byte-identity, and exercised-host details before the reader reached the short product answer.

## Why this approach

The contract fixed the opening structure: one question block, one direct answer, one origin sentence, and one Orca startup sentence. The README keeps that structure and moves reusable tool facts into `## Why these tools` instead of keeping them in the opening.

## What this changes

- Trims `README.md` so the H1-to-Quickstart opening is 10 lines and four content blocks.
- Moves the harness compatibility, `AGENTS.md` / `CLAUDE.md` byte-identity, repository-test, `claude` example CLI, and exercised-host details into `## Why these tools`.
- Absorbs the moved Orca-required/preflight facts into the existing `## Why these tools` Orca execution-substrate paragraph.
- Drops the deep-system paragraph from the opening because the remaining startup sentence already says the install interview explains as it goes.
- Leaves `## Quickstart` and later sections otherwise unchanged apart from the tool-rationale additions and duplicate-rationale removal.

## Expected effect

A reviewer can run `sed -n '1,40p' README.md` and see that `## Quickstart` now follows the four-block opening directly. The moved tool and Orca facts are visible under `## Why these tools` without repeating the Orca preflight rationale.

## Testing

- [x] `PYTHONPATH=src uv run pytest tests -q` — 582 passed, 13 subtests passed on Python 3.13.13, exit 0
- [x] No new regression test was added because this is README prose movement only.
- [x] No new files were added.

## Review

Manual review checked the deleted lines from `git diff origin/main...HEAD -- README.md | grep '^-'`. The harness compatibility, byte-identity, repository-test, exercised-host, and Orca preflight facts were moved or absorbed into `## Why these tools`; the deep-system paragraph was removed as redundant with the opening's install-interview sentence. CodeRabbit flagged agent-host wording neutrality, and the tool-rationale sentence now names `claude` as an example CLI. Cubic flagged a duplicate Orca rationale paragraph, and the duplicate paragraph was removed.

## Changelog

No changelog file change. `[Unreleased]` already has a root README opening/rationale entry, and this PR narrows that same README surface.

## Template impact

none

## Notes

Opening line count changed from 14 to 10. The intro has 0 links and 0 images, so the intro link/image path check had no paths to resolve. `grep -nE "/Users/|mgm-[a-z0-9]+" README.md` produced no output, exit 1.
