### PR TITLE
docs: link the bd tool in the stack table

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ This project was designed for the case where you already pay for coding-agent CL
 | Tool | What it does here | Replaceable |
 | --- | --- | --- |
 | [Orca](https://www.onorca.dev/download) | Execution substrate: terminal sessions that outlive windows, worktree placement, dispatch, and retirement. | No |
-| `bd` | Work ledger: issues, dependencies, active tracks, and boot-time task context through `master-bootstrap-live`. | Yes, through an adapter |
+| [`bd`](https://beads.gascity.com) | Work ledger: issues, dependencies, active tracks, and boot-time task context through `master-bootstrap-live`. | Yes, through an adapter |
 | [ctx](https://ctx.rs) | Cross-provider agent history index: one local query surface for prior session text, decisions, commands, and summaries. | Wired to `ctx`; alternatives exist but have not been evaluated here |
 | Git | Source of truth: charters, decisions, runbooks, lineage, and worktree isolation. | No |
 


### PR DESCRIPTION
## Problem

The stack table in `README.md` links Orca and ctx and leaves `bd` unlinked, so a reader who wants to know what the work ledger is has nowhere to go. Found by the owner reading the published page.

## Why this approach

One cell changes. The row already describes what `bd` does here; only the link was missing.

## What this changes

`| `bd` |` becomes `| [`bd`](https://beads.gascity.com) |` in the stack table. Nothing else.

## Expected effect

The three tool rows that have homepages all carry them. The link returns 200.

Provenance: opened by the coordinator rather than a dispatched worker, at owner instruction, after a direct push to `main` was correctly refused by the repository rule requiring a pull request.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a link to `bd` in the README stack table (https://beads.gascity.com) so readers can find the work ledger, keeping the tools list consistent with Orca and ctx.

<sup>Written for commit 728fa6fdff3ec3bdf214cc86a393c4a7c80b8e30. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/baksohyeon/mogui-ADE-orchestrator/pull/109?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the tools table so the `bd` entry links directly to its website.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->