### PR TITLE
docs: correct readme platform claims

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,7 +168,7 @@ Documentation in this repository is English. `master-ops/` is a template copied 
 
 Working and exercised, as of 2026-08-08: the repository test gate reports 579 passed tests and 13 passed subtests. Succession, dispatch-gate, acceptance, compaction, and onboarding paths have run against real workspaces.
 
-The current release is in `CHANGELOG.md`, which records every version since `0.1.0`. No CI: tests and redaction scanners run locally before push, so a passing count in a pull request is the author's word. While the major version is 0, interfaces, CLI flags, and file formats can change in a minor release. Pin a version if you build on it.
+The current release is in `CHANGELOG.md`, which records every version since `0.1.0`. CI runs the test gate and committed-rule redaction scan; the local pre-push redaction scan can add organization rules that are absent from the repository. While the major version is 0, interfaces, CLI flags, and file formats can change in a minor release. Pin a version if you build on it.
 
 The template that onboarding copies is versioned separately at `master-ops/TEMPLATE-VERSION`; `master-ops/CHANGELOG.md` records each version. A generated operations repository keeps the template version it copied until you apply an upgrade.
 

--- a/README.md
+++ b/README.md
@@ -226,13 +226,13 @@ src/master_runtime/core/
 Two principles shape the layout:
 
 - **Core / adapter split.** `core/` modules avoid depending on any specific agent product. Process spawning, ledgers, and tool CLIs go through injected callables and `adapter/`, so core logic is testable with in-memory fakes.
-- **Vendor neutrality as a direction.** The master should run under different agent hosts. The spawn path still names `claude`, so Claude Code is the exercised host. The worker side is further along: `adapter/profile.py` ships synchronous CLI profiles for `codex` and `cursor-agent`. `adapter doctor` probes a fixed local tool set, and some Korean-language operator strings are embedded.
+- **Vendor neutrality as a direction.** The master should run under different agent hosts. The spawn path defaults to `claude`, onboarding asks for the agent CLI and can use a measured runtime as its fallback, and `core/succession.py` still treats the Claude CLI family specially. Claude Code remains the most exercised host. The worker side is further along: `adapter/profile.py` ships synchronous CLI profiles for `codex` and `cursor-agent`. `adapter doctor` probes a fixed local tool set, and some Korean-language operator strings are embedded.
 
 ## Working on the harness
 
 To use the system, follow [Getting Started](docs/public/getting-started.md). This section is for changing the harness itself.
 
-Prerequisites: macOS and Python 3.11 or newer for the test suite. The runtime is stdlib-only. A tool that needs a more capable interpreter locates one itself at runtime, and the [Reference](docs/public/reference.md) table states each tool's behavior in its own row. Contributors can select Python through `uv`, `pyenv`, or the system developer tools.
+Prerequisites: Python 3.11 or newer for the test suite. CI currently runs the test gate on `ubuntu-latest`, `macos-latest`, and `windows-latest` with Python 3.12; the Windows leg is measurement-only. The runtime is stdlib-only. A tool that needs a more capable interpreter locates one itself at runtime, and the [Reference](docs/public/reference.md) table states each tool's behavior in its own row. Contributors can select Python through `uv`, `pyenv`, or the system developer tools.
 
 All CLI entry points live in `scripts/` and are self-contained:
 
@@ -261,10 +261,10 @@ Local only.
 
 ## Limitations
 
-- **Master starts under Claude Code out of the box.** The spawn path in `core/succession.py` calls `claude`. Claude Code is what has been run, so it is what is recommended.
+- **Master defaults to Claude Code out of the box.** The spawn path in `core/succession.py` accepts an agent parameter, defaults it to `claude`, and handles the Claude CLI family specially. Onboarding asks for the agent CLI and records the confirmed runtime. Claude Code is what has been run most, so it is what is recommended.
 - **Workers can be any CLI.** A worker is a terminal session in an Orca pane, so it is whatever binary starts there. Claude, Codex, Cursor, Grok, and Gemini have all run this way under contract. No plugin for any of them.
 - **Codex as master is untried.** It should work by design. If you run it, a report or patch is useful.
-- **macOS is the exercised platform.** Orca ships Linux and Windows builds, and one user reported the install working on Linux. Neither path is exercised here.
+- **Platform evidence is mixed.** This repository's CI runs the test gate on Linux and macOS, with a measurement-only Windows leg for the Windows-compatible subset. Separately, user reports said Linux and Windows worked well, including Windows through WSL; WSL2 was reported as slightly ambiguous but still working. Versions, distributions, and coverage depth were not recorded.
 - **Orca required** for live sessions. Pure functions run without it.
 
 ## What this is not


### PR DESCRIPTION
## Problem

On 2026-08-09, `README.md` made stale platform and master-host claims observed with `nl -ba README.md | sed -n '210,280p'`: the spawn path was described as calling `claude`, macOS was listed as a prerequisite, Claude Code was described as the out-of-box master start, and macOS was described as the exercised platform. A review pass also found that the Status section still said `No CI` while this branch documents the measured CI test gate.

## Why this approach

The contract limited writes to `README.md`, so this change updates only the public claims that conflicted with measured repository state, measured CI state, and owner-provided platform reports.

## What this changes

- Rewords master-host claims around `core/succession.py` defaults and Claude CLI family handling.
- Replaces the macOS prerequisite with the measured CI matrix: `ubuntu-latest`, `macos-latest`, and measurement-only `windows-latest` on Python 3.12.
- Aligns the Status section with the CI test gate and committed-rule redaction scan while preserving the stronger local organization-rule scan boundary.
- Separates CI evidence from user reports about Linux, Windows, WSL, and the ambiguous WSL2 report.
- Leaves Quickstart, introduction, and unrelated sections unchanged.

## Expected effect

A reviewer can check `README.md` and see measured repository claims separated from user-reported platform experience.

## Testing

- [x] `PYTHONPATH=src uv run pytest tests -q` - 582 passed, 13 subtests passed in 39.87s with Python 3.13.13; exit 0.
- [x] No regression test was added because this is a README-only factual correction.
- [x] `git diff origin/main...HEAD -- README.md | grep '^-'` - ran and showed the removed stale README claims, including the Status-section CI sentence flagged by review.
- [x] `grep -nE "/Users/|mgm-[a-z0-9]+" README.md` - ran, exit 1, no matches.

## Review

cubic found one Status-section CI contradiction. The thread was answered, resolved, and cubic re-review passed. CodeRabbit completed review and reported passed pre-merge checks.

## Changelog

No changelog entry; this is a README-only correction.

## Template impact

none

## Notes

User report details were limited to Linux and Windows feedback, Windows through WSL, an ambiguous WSL2 report, and no recorded versions, distributions, or coverage depth.