### PR TITLE
feat: add devcontainer development environment

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/vscode/devcontainers/python:1-3.12-bookworm
+FROM mcr.microsoft.com/devcontainers/python:1-3.12-bookworm@sha256:7876580dc67fd460fd962f004cbeb480027e9bbc0657096f1087db11f9eaff39
 
 ARG GITLEAKS_VERSION=8.30.1
 ARG TARGETARCH
@@ -24,3 +24,24 @@ RUN python -m pip install --no-cache-dir pytest
 ENV PATH="/opt/gitleaks/bin:${PATH}"
 
 WORKDIR /workspaces/mogui-ADE-orchestrator
+
+RUN set -eux; \
+    fixture="$(mktemp)"; \
+    trap 'rm -f "${fixture}"' EXIT; \
+    config=/tmp/gitleaks-config.toml; \
+    curl --fail --silent --show-error --location \
+      --output "${config}" \
+      "https://raw.githubusercontent.com/gitleaks/gitleaks/v${GITLEAKS_VERSION}/config/gitleaks.toml"; \
+    token_prefix=ghp_; \
+    token_suffix=012345678901234567890123456789012345; \
+    printf 'token = "%s%s"\n' "${token_prefix}" "${token_suffix}" >"${fixture}"; \
+    export PATH="/opt/gitleaks/bin:${PATH}"; \
+    set +e; \
+    gitleaks dir --config="${config}" --no-banner "${fixture}" >/tmp/gitleaks-positive-control.log 2>&1; \
+    status=$?; \
+    set -e; \
+    cat /tmp/gitleaks-positive-control.log; \
+    test "${status}" -eq 1; \
+    rm -f "${config}"
+
+USER vscode

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -29,9 +29,11 @@ RUN set -eux; \
     fixture="$(mktemp)"; \
     trap 'rm -f "${fixture}"' EXIT; \
     config=/tmp/gitleaks-config.toml; \
+    config_sha=e163e53b9e7e8a8511e77271e2b323ed057759542a6d988258afe3a1fa329caf; \
     curl --fail --silent --show-error --location \
       --output "${config}" \
       "https://raw.githubusercontent.com/gitleaks/gitleaks/v${GITLEAKS_VERSION}/config/gitleaks.toml"; \
+    echo "${config_sha}  ${config}" | sha256sum --check --strict; \
     token_prefix=ghp_; \
     token_suffix=012345678901234567890123456789012345; \
     printf 'token = "%s%s"\n' "${token_prefix}" "${token_suffix}" >"${fixture}"; \
@@ -42,6 +44,6 @@ RUN set -eux; \
     set -e; \
     cat /tmp/gitleaks-positive-control.log; \
     test "${status}" -eq 1; \
-    rm -f "${config}"
+    rm -f "${config}" /tmp/gitleaks-positive-control.log
 
 USER vscode

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,26 @@
+FROM mcr.microsoft.com/vscode/devcontainers/python:1-3.12-bookworm
+
+ARG GITLEAKS_VERSION=8.30.1
+ARG TARGETARCH
+
+RUN set -eux; \
+    case "${TARGETARCH}" in \
+      amd64) gitleaks_arch='x64'; gitleaks_sha='551f6fc83ea457d62a0d98237cbad105af8d557003051f41f3e7ca7b3f2470eb' ;; \
+      arm64) gitleaks_arch='arm64'; gitleaks_sha='e4a487ee7ccd7d3a7f7ec08657610aa3606637dab924210b3aee62570fb4b080' ;; \
+      *) echo "unsupported Docker architecture: ${TARGETARCH}" >&2; exit 1 ;; \
+    esac; \
+    package="gitleaks_${GITLEAKS_VERSION}_linux_${gitleaks_arch}.tar.gz"; \
+    curl --fail --silent --show-error --location \
+      --output "/tmp/${package}" \
+      "https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}/${package}"; \
+    echo "${gitleaks_sha}  /tmp/${package}" | sha256sum --check --strict; \
+    tar --extract --gzip --file "/tmp/${package}" --directory /tmp gitleaks; \
+    install --directory --mode 0755 /opt/gitleaks/bin; \
+    install --mode 0755 /tmp/gitleaks /opt/gitleaks/bin/gitleaks; \
+    rm -f "/tmp/${package}" /tmp/gitleaks
+
+RUN python -m pip install --no-cache-dir pytest
+
+ENV PATH="/opt/gitleaks/bin:${PATH}"
+
+WORKDIR /workspaces/mogui-ADE-orchestrator

--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -11,9 +11,8 @@ The container cannot launch a master seat because Orca is a macOS application, n
 Run the gates from the repository root after starting the container:
 
 ```console
-export PATH=/opt/gitleaks/bin:$PATH
 PYTHONPATH=src python -m pytest tests -q
 ./scripts/redaction-scan.sh
 ```
 
-The redaction scan prints a warning when `REDACTION_EXTRA_PATTERNS` is unset, followed by its tracked-only result. Full organization-rule coverage requires running the scan on a host where that file is available.
+The image manifest is pinned and includes Linux amd64 and arm64 variants. The build and positive-control validation for this change were observed on Linux arm64 (Apple Silicon); amd64 execution was not part of this run. The redaction scan prints a warning when `REDACTION_EXTRA_PATTERNS` is unset, followed by its tracked-only result. Full organization-rule coverage requires running the scan on a host where that file is available.

--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -1,0 +1,19 @@
+# Development container
+
+This directory defines a Python 3.12 development container for the repository's two blocking gates: the pytest suite and the tracked-content redaction scan. Build it with:
+
+```console
+docker build -t mogui-ade-orchestrator-devcontainer -f .devcontainer/Dockerfile .
+```
+
+The container cannot launch a master seat because Orca is a macOS application, not a service available inside this Linux container. The container redaction gate runs only the committed rules, so `org-rules=0` is the expected reading in this environment. Because `org-rules=0` currently exits successfully, a green container scan is not evidence that organization-specific patterns were checked.
+
+Run the gates from the repository root after starting the container:
+
+```console
+export PATH=/opt/gitleaks/bin:$PATH
+PYTHONPATH=src python -m pytest tests -q
+./scripts/redaction-scan.sh
+```
+
+The redaction scan prints a warning when `REDACTION_EXTRA_PATTERNS` is unset, followed by its tracked-only result. Full organization-rule coverage requires running the scan on a host where that file is available.

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,22 @@
+{
+  "name": "mogui-ADE-orchestrator",
+  "build": {
+    "dockerfile": "Dockerfile",
+    "context": ".."
+  },
+  "remoteUser": "vscode",
+  "workspaceFolder": "/workspaces/mogui-ADE-orchestrator",
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "ms-python.python"
+      ],
+      "settings": {
+        "python.testing.pytestEnabled": true,
+        "python.testing.pytestArgs": [
+          "tests"
+        ]
+      }
+    }
+  }
+}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -5,6 +5,9 @@
     "context": ".."
   },
   "remoteUser": "vscode",
+  "containerEnv": {
+    "PYTHONPATH": "/workspaces/mogui-ADE-orchestrator/src"
+  },
   "workspaceFolder": "/workspaces/mogui-ADE-orchestrator",
   "customizations": {
     "vscode": {

--- a/README.md
+++ b/README.md
@@ -23,6 +23,8 @@ cd mogui-ADE-orchestrator
 
 When the three moves are done, or if one fails, continue with **[Getting Started](docs/public/getting-started.md)**.
 
+For container setup and its coverage boundary, see [`.devcontainer/README.md`](.devcontainer/README.md).
+
 ## Why these tools
 
 The workspace layer addresses three failures in long-lived coordination. Sessions end while work continues. A master that can spawn workers can waste them. Context loss after compaction can look like continuity. This runtime turns those failures into checks: guarded succession, append-only lineage, contract-gated dispatch, and boot probes that hold back state after compaction so recall can be measured.


### PR DESCRIPTION
## Problem

The repository had no documented development-container path, so contributors could not reproduce the Python test and redaction gates in a defined environment or see the container's master-seat and organization-rule coverage limits.

## Why this approach

The container installs Python 3.12, pytest, and a checksum-verified gitleaks release while keeping organization-specific rules outside the image. This preserves the repository's tracked-only gate behavior and makes the known Orca macOS boundary explicit instead of implying that a Linux container can launch a master seat.

## What this changes

- Add `.devcontainer/Dockerfile` with Python 3.12, pytest, and pinned gitleaks for Linux amd64 and arm64.
- Add `.devcontainer/devcontainer.json` with `vscode` as the remote user.
- Add `.devcontainer/README.md` documenting build, gate commands, seat limitations, and `org-rules=0` interpretation.
- Link the container guide from the root README.

## Expected effect

Opening the repository as a dev container provides the dependencies needed for both repository gates. The container is suitable for code and gate execution, while master-seat startup remains host-side because Orca is a macOS application.

## Testing

- `docker build --progress=plain -t mogui-ade-orchestrator-devcontainer -f .devcontainer/Dockerfile .` — passed; gitleaks arm64 checksum verified against the official release digest.
- As `vscode` inside the container, `printf "HOME=%s\\n" "$HOME"` output: a non-empty home directory for the configured remote user.
- As `vscode` inside the container, `export PATH=/opt/gitleaks/bin:$PATH; PYTHONPATH=src python -m pytest tests -q` — `582 passed, 13 subtests passed in 39.46s`.
- As `vscode` inside the container, `./scripts/redaction-scan.sh` — warning that organization-specific rules were not loaded, then `redaction-scan: OK — 0 findings (mode=tracked, files=268, commit-messages=not-scanned, org-rules=0)`; exit code 0 is the expected tracked-only result, not organization-pattern evidence.
- Host username scan command: `host_user="$(id -un)"; grep -RInF --exclude=README.md --exclude=devcontainer.json --exclude=Dockerfile "$host_user" .devcontainer`; output: no matching lines, `grep exit code: 1`.
- `git diff --cached --check` — passed.

## Review

No automated review was run; the two repository gates and the requested host/container measurements were run directly.

## Changelog

No changelog entry: this adds contributor tooling and documentation without changing runtime behavior.

## Template impact

none

## Notes

The redaction gate's organization-specific rules must be supplied on the host when full organization-pattern coverage is required.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a VS Code dev container with Python 3.12, `pytest`, and pinned `gitleaks` for reproducible tests and redaction scans. Hardens the setup by pinning the base image and validating `gitleaks` with a positive-control scan that cleans up its artifacts.

- New Features
  - `.devcontainer/Dockerfile` installs `pytest` and checksum-verified `gitleaks` for `linux/amd64` and `linux/arm64`, pins the base image by digest, adds `gitleaks` to `PATH`, and runs a positive-control scan at build with cleanup of temp files and logs.
  - `.devcontainer/devcontainer.json` sets `remoteUser` to `vscode`, workspace folder, `PYTHONPATH`, and enables `ms-python.python` with pytest config.
  - `.devcontainer/README.md` explains build/run steps and the redaction coverage boundary.
  - Root `README.md` links to the container guide.

- Migration
  - Open the repo in the dev container (or build the image) and run:
    - `PYTHONPATH=src python -m pytest tests -q`
    - `./scripts/redaction-scan.sh`
  - The container cannot start a master seat (Orca is macOS-only).
  - Redaction scan is tracked-only; full org patterns require host-supplied rules (`org-rules=0` in container).

<sup>Written for commit d1a22f22a31023920067955a7eb7fe911eb46dd4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/baksohyeon/mogui-ADE-orchestrator/pull/111?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a ready-to-use Python 3.12 development container for consistent local development.
  * Included pytest and Gitleaks validation tools with architecture support and integrity checks.
  * Configured VS Code workspace settings, Python tooling, and test discovery.

* **Documentation**
  * Added setup instructions, validation commands, platform limitations, and coverage guidance.
  * Linked the development container documentation from the main README.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->