### PR TITLE
docs: restore ops repository naming recommendation

### DIFF
--- a/master-ops/onboarding/03-ops-repo.md
+++ b/master-ops/onboarding/03-ops-repo.md
@@ -12,7 +12,7 @@ Load rule: read this file only when Step 2 begins. Router: [`../ONBOARDING.md`](
 
 Where we are: the workspace facts are confirmed, and the Herald now needs a book for the Master to read from. What we decide next: where this workspace's governance records will live — a small repository that is clearly separate from product code. Explain like ELI5: product repositories hold the thing being built; the ops repository holds how the Master should coordinate that work. Ask whether to create a new repository or reuse an existing operations repository, and whether local Git initialization is allowed for a new ops repository; this choice applies only to `{{OPS_REPO}}`, never to `{{WORKSPACE_ROOT}}`.
 
-Inspect the confirmed names; propose two or three candidates with pros and cons; recommend `<workspace>-ops`; evaluate governance clarity, separation from product scope, and shell-title ambiguity; use a structured choice when available.
+Inspect the confirmed names; propose two or three candidates with pros and cons; recommend `<workspace>-bridge` by default; keep `<workspace>-ops` as the plain conventional alternative; avoid hub/core-style names that imply product traffic flows through this repository; evaluate governance clarity, separation from product scope, and shell-title ambiguity; use a structured choice when available.
 
 ### Verify (Step 2)
 


### PR DESCRIPTION
## Problem

The onboarding naming guidance did not preserve the owner's preferred default for the operations repository. The affected guidance is the naming recommendation in `master-ops/onboarding/03-ops-repo.md`.

## Why this approach

Change only the specified recommendation line so the surrounding onboarding and manifest guidance remains intact.

## What this changes

- Restores the `<workspace>-bridge` default recommendation and retains `<workspace>-ops` as the conventional alternative in `master-ops/onboarding/03-ops-repo.md`.
- Leaves all other files and lines out of scope.

## Expected effect

Step 2 now presents `<workspace>-bridge` as the default recommendation, with `<workspace>-ops` as the conventional alternative, while preserving the existing governance and shell-title checks.

## Testing

- [x] `PYTHONPATH=src python -m pytest tests -q`: 582 passed, 13 subtests passed
- [x] The one-line documentation correction is directly observable in `master-ops/onboarding/03-ops-repo.md`.
- [x] `REDACTION_REQUIRE_EXTRA=1 REDACTION_EXTRA_PATTERNS=~/.config/redaction-extra.txt ./scripts/redaction-scan.sh`: 0 findings, org-rules=10

## Review

The diff was checked directly and is exactly 1 insertion and 1 deletion in the requested file.

## Changelog

No changelog entry is needed for this focused documentation correction.

## Template impact

This touches `master-ops/`; existing installs need the normal template update process to receive the restored naming recommendation.

## Notes

Tracking reference: mgm-xhe.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores the default ops repository naming recommendation to `<workspace>-bridge`, keeping `<workspace>-ops` as the conventional alternative. Updates only `master-ops/onboarding/03-ops-repo.md` and aligns with Linear mgm-xhe.

<sup>Written for commit 3150a62048b2894f54b50271cf0d5820c0353dac. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/baksohyeon/mogui-ADE-orchestrator/pull/112?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

