### PR TITLE
docs: improve README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+
+
 # mogui-ADE-orchestrator
 
 > I have agents running in tmux sessions. Can I still drive each one manually when I want, and at the same time orchestrate all of those sessions from above? Is tmux-based agent orchestration a thing?
@@ -17,11 +19,11 @@ cd mogui-ADE-orchestrator
 ```
 
 2. Open a terminal in that folder and start your agent CLI.
-3. Say `일어나라 마스터여` / `Wake the master.`
+3. Say `일어나라 마스터여` / `Wake the master.` The agent will ask a session-mode question to route onboarding.
 
-![Claude Code in Orca, opened on the cloned repository. The prompt reads "wake up, master." and the agent has started reading master-ops/ONBOARDING.md.](docs/assets/wake-up-master.png)
+![Claude Code in Orca, opened on the cloned repository. The prompt reads "Wake the master." and the agent has started reading master-ops/ONBOARDING.md.](docs/assets/wake-up-master.png)
 
-When the three moves are done, or if one fails, continue with **[Getting Started](docs/public/getting-started.md)**.
+When the three steps are done, or if one fails, continue with **[Getting Started](docs/public/getting-started.md)**.
 
 For container setup and its coverage boundary, see [`.devcontainer/README.md`](.devcontainer/README.md).
 


### PR DESCRIPTION
Makes one small, focused improvement to the existing README.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clarifies onboarding in the README and fixes wording and caption consistency. Previously step 3 ended without explaining the next prompt; now it states the agent will ask a session-mode question to route onboarding.

- Docs-only; no code or behavior changes.
- Step 3 now notes the session-mode question for routing.
- Replaces “moves” with “steps” for consistency.
- Capitalizes “Wake the master.” in the screenshot alt text.
- Minor spacing cleanup at the top of the README.

<sup>Written for commit c5ffbf874e554dff26567889f439b7206df1f296. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/baksohyeon/mogui-ADE-orchestrator/pull/114?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the Quickstart guide to clarify session-mode routing.
  - Improved image alternative text for accessibility.
  - Replaced “three moves” with the clearer phrase “three steps.”
  - Refined introductory spacing and presentation for improved readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->