### PR TITLE
feat: add bare-cd warning hook

### DIFF
--- a/master-ops/MANIFEST.json
+++ b/master-ops/MANIFEST.json
@@ -51,6 +51,7 @@
     "scripts/gate_runner.py",
     "scripts/harness-selfcheck.sh",
     "scripts/hook-coverage-report",
+    "scripts/hooks/bash-bare-cd-warn.sh",
     "scripts/hooks/bash-output-trim-warn.sh",
     "scripts/hooks/bash-poll-warn.sh",
     "scripts/hooks/orch-inbox-warn.sh",

--- a/master-ops/scripts/hooks/bash-bare-cd-warn.sh
+++ b/master-ops/scripts/hooks/bash-bare-cd-warn.sh
@@ -1,0 +1,79 @@
+#!/bin/bash
+# PreToolUse(Bash) hook: warn when command starts with bare `cd`.
+# This hook is warning-only and never blocks execution.
+
+log_fire() {
+  local fire_log="${MOGUI_HOOK_FIRE_LOG:-$HOME/.mogui/hook-fire-log.jsonl}"
+  mkdir -p "$(dirname "$fire_log")" 2>/dev/null || return 0
+  local session_kind="unknown"
+  if [ -n "${ORCA_TASK_ID:-}" ] || [ -n "${ORCA_DISPATCH_ID:-}" ] || [[ "$PWD" == *".orca/worktrees"* ]]; then
+    session_kind="worker"
+  elif [ -f "$PWD/docs/MASTER-OPERATIONS.md" ]; then
+    session_kind="master"
+  fi
+  python3 - "bash-bare-cd-warn" "PreToolUse(Bash)" "$PWD" "${MOGUI_RUNTIME_HINT:-unknown}" "$session_kind" <<'PY' >> "$fire_log" 2>/dev/null || true
+import json
+import sys
+import time
+
+_, hook, event, cwd, runtime_hint, session_kind = sys.argv
+print(json.dumps({
+    "ts": int(time.time()),
+    "hook": hook,
+    "event": event,
+    "cwd": cwd,
+    "runtime_hint": runtime_hint,
+    "session_kind": session_kind,
+}, separators=(",", ":")))
+PY
+}
+
+log_fire
+
+INPUT=$(cat)
+WARN=$(
+  printf '%s' "$INPUT" | python3 -c '
+import json
+import shlex
+import sys
+
+payload = json.load(sys.stdin)
+raw = payload.get("tool_input", {}).get("command", "")
+
+# Some runtimes may encode command as a list of lines.
+if isinstance(raw, list):
+    command = "\n".join(str(part) for part in raw)
+elif isinstance(raw, str):
+    command = raw
+else:
+    command = str(raw or "")
+
+if not command.strip():
+    print("0")
+    raise SystemExit(0)
+
+try:
+    lexer = shlex.shlex(command, posix=True, punctuation_chars=";&|()")
+    lexer.whitespace_split = True
+    tokens = list(lexer)
+except Exception:
+    # Parsing failures should never block or warn.
+    print("0")
+    raise SystemExit(0)
+
+first = ""
+for token in tokens:
+    if token:
+        first = token
+        break
+
+# Subshell-wrapped calls begin with "("; only bare first-token cd should warn.
+print("1" if first == "cd" else "0")
+'
+)
+
+if [ "$WARN" = "1" ]; then
+  echo "[bash-bare-cd-warn] first token is bare cd; shell state persists between Bash calls, use git -C/gh --repo/absolute paths." >&2
+fi
+
+exit 0

--- a/master-ops/scripts/hooks/bash-bare-cd-warn.sh
+++ b/master-ops/scripts/hooks/bash-bare-cd-warn.sh
@@ -37,8 +37,13 @@ import json
 import shlex
 import sys
 
-payload = json.load(sys.stdin)
-raw = payload.get("tool_input", {}).get("command", "")
+try:
+    payload = json.load(sys.stdin)
+    raw = payload.get("tool_input", {}).get("command", "")
+except (ValueError, AttributeError, TypeError):
+    # ValueError includes JSONDecodeError; all malformed/shape inputs should stay silent.
+    print("0")
+    raise SystemExit(0)
 
 # Some runtimes may encode command as a list of lines.
 if isinstance(raw, list):


### PR DESCRIPTION
## Problem

On 2026-09-08, this template had no `scripts/hooks/*` hook that warns when a Bash tool call starts with bare `cd`. The existing hook set did not guard this specific shell-state drift pattern, and a bare `cd` at the start of one call can redirect later relative commands because the Bash tool keeps working directory state between calls.

## Why this approach

A warning-only PreToolUse(Bash) hook matches the owner ruling and keeps valid subshell usage available. A blocking guard was not selected because this change is scoped to warning behavior and must avoid false positives that reduce signal trust.

## What this changes

- Adds `master-ops/scripts/hooks/bash-bare-cd-warn.sh` to parse `tool_input.command` and emit one stderr warning only when the first token is `cd`.
- Keeps behavior warning-only with `exit 0` and silent stderr on every payload it cannot read: empty stdin, malformed JSON, a JSON list, a null `tool_input`, and a null `command`.
- Handles both string and list-shaped command payloads for multiline tolerance.
- Updates `master-ops/MANIFEST.json` via `python3 scripts/generate-manifest` to register `scripts/hooks/bash-bare-cd-warn.sh`.
- Leaves blocking policy and all non-hook surfaces unchanged.

## Expected effect

Reviewers can run `printf '{"tool_input":{"command":"cd /tmp"}}' | master-ops/scripts/hooks/bash-bare-cd-warn.sh 2>&1` and observe a single warning line with zero exit status. They can also run subshell and chained-command inputs to observe silence and zero exit status.

Measured on this branch, stderr bytes per payload, exit status 0 throughout:

| payload | stderr |
|---|---|
| `{"tool_input":{"command":"cd /tmp"}}` | 122 B, the warning |
| `{"tool_input":{"command":"(cd /tmp && ls)"}}` | 0 B |
| `{"tool_input":{"command":"ls && cd /tmp"}}` | 0 B |
| empty stdin | 0 B |
| `{not json` | 0 B |
| `[1,2,3]` | 0 B |
| `{"tool_input":null}` | 0 B |
| `{}` | 0 B |
| `{"tool_input":{"command":null}}` | 0 B |
| `{"tool_input":{"command":"bash -c \"cd /tmp\""}}` | 0 B |

The guarded parse catches `ValueError`, `AttributeError`, and `TypeError`. `ValueError` is the parent of `json.JSONDecodeError` and covers decoding; the other two cover a payload whose shape is not a mapping.

## Testing

- [x] `PYTHONPATH=src python -m pytest tests -q` — `582 passed, 13 subtests passed in 45.73s`
- [x] A test that fails without this change, or a note on why none was needed — no repository test harness currently exercises this specific warning hook; behavior was measured with direct hook input and output cases from the contract.
- [x] New files staged before running any scan. The scanners read tracked files, so an unstaged addition is invisible to them and the run comes back green without having looked at it.

## Review

Ran `code-reviewer` on the uncommitted diff. It reported no issues and approved the change.

## Changelog

none

## Template impact

This touches `master-ops/` in the template source. Existing installed operations repositories need a template update flow to receive this new hook and manifest registration.

## Notes

`scripts/hooks/bash-bare-cd-warn.sh` is the install-frame path registered in the manifest. In this template repository layout, that file lives at `master-ops/scripts/hooks/bash-bare-cd-warn.sh`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a PreToolUse(Bash) hook that warns when a Bash tool call starts with bare `cd`, since persistent shell state can affect later commands. The warning is non-blocking.

- Detects only the first token being exactly `cd`; subshells and chained commands are ignored.
- Handles string and list command payloads and exits 0 on parse failures or empty input.
- Logs each hook fire to `~/.mogui/hook-fire-log.jsonl` (or `MOGUI_HOOK_FIRE_LOG`) for monitoring.
- Registers the new hook in `master-ops/MANIFEST.json`.
- Existing operations repos need a template update to receive the new hook and manifest entry.

<sup>Written for commit 643ce69af6ac71b14be3a6bfe1ceff00db406afb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/baksohyeon/mogui-ADE-orchestrator/pull/117?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an informational warning when Bash commands begin with a bare `cd`.
  * Warnings help users identify potentially unintended directory changes without interrupting or blocking command execution.
  * Hook activity is recorded with relevant execution details to support troubleshooting and monitoring.
  * The hook continues operating safely when commands are empty, malformed, or otherwise difficult to parse.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->