### PR TITLE
fix holdout leak test identifier matching

### DIFF
--- a/tests/test_acceptance_loop.py
+++ b/tests/test_acceptance_loop.py
@@ -105,13 +105,18 @@ def _holdout_case_ids(casebook: CaseBook) -> tuple[str, ...]:
 
 
 def _find_holdout_identifier_leaks(
-    workspace: Path, holdout_case_ids: Sequence[str]
+    workspace: Path,
+    holdout_case_ids: Sequence[str],
+    ignored_literals: Sequence[str] = (),
 ) -> list[Path]:
     leaked: list[Path] = []
     for path in workspace.rglob("*"):
         if not path.is_file():
             continue
         text = path.read_text(encoding="utf-8", errors="replace")
+        for literal in ignored_literals:
+            if literal:
+                text = text.replace(literal, " ")
         if any(_contains_identifier(text, case_id) for case_id in holdout_case_ids):
             leaked.append(path)
     return leaked
@@ -198,14 +203,18 @@ def test_private_holdout_never_reaches_the_proposer_workspace(tmp_path: Path) ->
         / "001"
         / "proposer_workspace"
     )
-    leaked = _find_holdout_identifier_leaks(workspace, _holdout_case_ids(casebook))
+    leaked = _find_holdout_identifier_leaks(
+        workspace,
+        _holdout_case_ids(casebook),
+        ignored_literals=(str(config.run_dir),),
+    )
     assert leaked == []
     assert _contains_identifier(
         (workspace / "task.md").read_text(encoding="utf-8"), "t1"
     )
 
 
-@pytest.mark.parametrize("segment", ("a9h1z4q2", "q8h2w7m3"))
+@pytest.mark.parametrize("segment", ("a9h1z4q2", "q8h2w7m3", "h1", "h2"))
 def test_holdout_identifier_detector_ignores_path_substrings(
     tmp_path: Path, segment: str
 ) -> None:
@@ -228,12 +237,19 @@ def test_holdout_identifier_detector_ignores_path_substrings(
         / "001"
         / "proposer_workspace"
     )
-    leaked = _find_holdout_identifier_leaks(workspace, _holdout_case_ids(casebook))
+    leaked = _find_holdout_identifier_leaks(
+        workspace,
+        _holdout_case_ids(casebook),
+        ignored_literals=(str(config.run_dir),),
+    )
     assert leaked == []
 
 
-def test_holdout_identifier_detector_still_catches_real_leaks(tmp_path: Path) -> None:
-    config = _config(tmp_path / "a9h1z4q2")
+@pytest.mark.parametrize("segment", ("a9h1z4q2", "h1"))
+def test_holdout_identifier_detector_still_catches_real_leaks(
+    tmp_path: Path, segment: str
+) -> None:
+    config = _config(tmp_path / segment)
     casebook = _book()
 
     run_acceptance_loop(
@@ -253,7 +269,11 @@ def test_holdout_identifier_detector_still_catches_real_leaks(tmp_path: Path) ->
         / "proposer_workspace"
     )
     (workspace / "injected-leak.md").write_text("Holdout case id: h1", encoding="utf-8")
-    leaked = _find_holdout_identifier_leaks(workspace, _holdout_case_ids(casebook))
+    leaked = _find_holdout_identifier_leaks(
+        workspace,
+        _holdout_case_ids(casebook),
+        ignored_literals=(str(config.run_dir),),
+    )
     assert set(leaked) == {workspace / "injected-leak.md"}
 
 

--- a/tests/test_acceptance_loop.py
+++ b/tests/test_acceptance_loop.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import re
 from pathlib import Path
 from typing import Optional, Sequence
 
@@ -92,6 +93,30 @@ def _candidate(label: str = "iter-001") -> Candidate:
     )
 
 
+def _contains_identifier(text: str, identifier: str) -> bool:
+    pattern = r"(?<![A-Za-z0-9_-]){0}(?![A-Za-z0-9_-])".format(re.escape(identifier))
+    return re.search(pattern, text) is not None
+
+
+def _holdout_case_ids(casebook: CaseBook) -> tuple[str, ...]:
+    return tuple(
+        case.case_id for case in casebook.cases_for_split(CaseSplit.HOLDOUT)
+    )
+
+
+def _find_holdout_identifier_leaks(
+    workspace: Path, holdout_case_ids: Sequence[str]
+) -> list[Path]:
+    leaked: list[Path] = []
+    for path in workspace.rglob("*"):
+        if not path.is_file():
+            continue
+        text = path.read_text(encoding="utf-8", errors="replace")
+        if any(_contains_identifier(text, case_id) for case_id in holdout_case_ids):
+            leaked.append(path)
+    return leaked
+
+
 def test_loop_accepts_a_candidate_that_increases_the_combined_pass_count(
     tmp_path: Path,
 ) -> None:
@@ -155,10 +180,11 @@ def test_decision_json_records_the_audit_fields(tmp_path: Path) -> None:
 
 def test_private_holdout_never_reaches_the_proposer_workspace(tmp_path: Path) -> None:
     config = _config(tmp_path)
+    casebook = _book()
 
     run_acceptance_loop(
         config=config,
-        casebook=_book(),
+        casebook=casebook,
         baseline=Candidate(label=BASELINE_LABEL),
         proposer=_proposer([_candidate()]),
         evaluator=_evaluator({BASELINE_LABEL: set(), "iter-001": {"t1"}}),
@@ -172,14 +198,63 @@ def test_private_holdout_never_reaches_the_proposer_workspace(tmp_path: Path) ->
         / "001"
         / "proposer_workspace"
     )
-    leaked = [
-        path
-        for path in workspace.rglob("*")
-        if path.is_file()
-        and any(marker in path.read_text(encoding="utf-8") for marker in ("h1", "h2"))
-    ]
+    leaked = _find_holdout_identifier_leaks(workspace, _holdout_case_ids(casebook))
     assert leaked == []
-    assert "t1" in (workspace / "task.md").read_text(encoding="utf-8")
+    assert _contains_identifier(
+        (workspace / "task.md").read_text(encoding="utf-8"), "t1"
+    )
+
+
+@pytest.mark.parametrize("segment", ("a9h1z4q2", "q8h2w7m3"))
+def test_holdout_identifier_detector_ignores_path_substrings(
+    tmp_path: Path, segment: str
+) -> None:
+    config = _config(tmp_path / segment)
+    casebook = _book()
+
+    run_acceptance_loop(
+        config=config,
+        casebook=casebook,
+        baseline=Candidate(label=BASELINE_LABEL),
+        proposer=_proposer([_candidate()]),
+        evaluator=_evaluator({BASELINE_LABEL: set(), "iter-001": {"t1"}}),
+    )
+
+    workspace = (
+        Path(config.run_dir)
+        / "history"
+        / "visible"
+        / "iterations"
+        / "001"
+        / "proposer_workspace"
+    )
+    leaked = _find_holdout_identifier_leaks(workspace, _holdout_case_ids(casebook))
+    assert leaked == []
+
+
+def test_holdout_identifier_detector_still_catches_real_leaks(tmp_path: Path) -> None:
+    config = _config(tmp_path / "a9h1z4q2")
+    casebook = _book()
+
+    run_acceptance_loop(
+        config=config,
+        casebook=casebook,
+        baseline=Candidate(label=BASELINE_LABEL),
+        proposer=_proposer([_candidate()]),
+        evaluator=_evaluator({BASELINE_LABEL: set(), "iter-001": {"t1"}}),
+    )
+
+    workspace = (
+        Path(config.run_dir)
+        / "history"
+        / "visible"
+        / "iterations"
+        / "001"
+        / "proposer_workspace"
+    )
+    (workspace / "injected-leak.md").write_text("Holdout case id: h1", encoding="utf-8")
+    leaked = _find_holdout_identifier_leaks(workspace, _holdout_case_ids(casebook))
+    assert set(leaked) == {workspace / "injected-leak.md"}
 
 
 def test_split_artifacts_are_routed_by_visibility(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- replace substring-based holdout leak detection with identifier-aware matching in `test_private_holdout_never_reaches_the_proposer_workspace`
- derive holdout ids from the built casebook (`CaseSplit.HOLDOUT`) instead of hardcoding `h1`/`h2`
- add regression proofs that path substrings no longer trigger leaks and that a real holdout id leak is still detected

## Test plan
- [x] `PYTHONPATH=src python -m pytest tests -q`
- [x] `PYTHONPATH=src python -m pytest -q tests/test_acceptance_loop.py::test_private_holdout_never_reaches_the_proposer_workspace --basetemp tmp-basetemp-no-marker`
- [x] `PYTHONPATH=src python -m pytest -q tests/test_acceptance_loop.py::test_private_holdout_never_reaches_the_proposer_workspace --basetemp tmp-basetemp-h1`
- [x] `PYTHONPATH=src python -m pytest -q tests/test_acceptance_loop.py::test_private_holdout_never_reaches_the_proposer_workspace --basetemp tmp-basetemp-h2`

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaces substring-based holdout leak detection with identifier-aware matching in `test_private_holdout_never_reaches_the_proposer_workspace`. The test now derives holdout IDs from the built casebook and matches them with word boundaries while scrubbing the run-dir path, so substrings like `h1` or `h2` no longer trigger false positives but real holdout ID leaks are still caught. Adds regression tests for both cases.

<sup>Written for commit b6f5690b6dfbcd9c2a35cfa938aa98e38977653e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/baksohyeon/mogui-ADE-orchestrator/pull/121?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added coverage to verify private holdout identifiers are not exposed in proposer workspace files.
  * Added checks to distinguish complete identifier leaks from harmless path substrings.
  * Refactored acceptance testing to reuse shared test data and leak-detection logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->